### PR TITLE
feat(shadow): env-var activation + generic LLMWriteDecider

### DIFF
--- a/merken/__init__.py
+++ b/merken/__init__.py
@@ -4,6 +4,11 @@ See ``CONSTITUTION.md`` for what merken is, what it isn't, and the principles
 that should outlive any specific implementation.
 """
 
+# Must import _shadow FIRST: when MERKEN_SHADOW is set, this eagerly
+# loads torch before vstash/fastembed gets imported transitively via
+# .memory / .consolidation -- see notes/nanogpt-training-log.md
+# Mistake #10 for why the load order matters.
+from merken import _shadow as _shadow  # noqa: F401
 from merken.consolidation import ConsolidationResult, Fact
 from merken.memory import ForgetResult, Memory, RememberResult
 from merken.policies import (

--- a/merken/_shadow.py
+++ b/merken/_shadow.py
@@ -1,0 +1,69 @@
+"""Env-var shadow-mode wiring.
+
+If ``MERKEN_SHADOW`` is set, ``Memory`` auto-wraps its default decider
+in a ``ShadowWriteDecider`` whose secondary is constructed from the
+other ``MERKEN_SHADOW_*`` vars. This lets CLI, MCP, and SDK consumers
+opt into shadow mode with zero code changes.
+
+Torch is imported **at module evaluation** (not inside a function) when
+shadow is enabled, so that ``from merken import ...`` causes torch to
+load BEFORE vstash/fastembed. That's the Mistake #10 order requirement
+(notes/nanogpt-training-log.md): the first native library to load wins
+the macOS process; later ones can segfault. Keep this module as the
+first import in ``merken/__init__.py``.
+
+Supported env vars:
+
+- ``MERKEN_SHADOW=nanogpt``
+    + ``MERKEN_SHADOW_NANOGPT_CKPT=/path/to/ckpt.pt``
+    + ``MERKEN_SHADOW_NANOGPT_META=/path/to/meta.pkl``
+- ``MERKEN_SHADOW=llm``
+    + ``MERKEN_SHADOW_LLM_MODEL=google/gemma-3-270m-it`` (HF id or local path)
+    + ``MERKEN_SHADOW_LLM_DEVICE=cpu`` (optional, default ``cpu``)
+
+Anything else (empty / unset / unknown) -> shadow disabled.
+"""
+
+from __future__ import annotations
+
+import os
+
+_ENABLED_VALUES = {"nanogpt", "llm"}
+_KIND = os.environ.get("MERKEN_SHADOW", "").strip().lower()
+
+# Eagerly import torch if shadow is enabled. This must happen before any
+# other merken module that transitively imports vstash (fastembed/ONNX)
+# -- see notes/nanogpt-training-log.md Mistake #10.
+if _KIND in _ENABLED_VALUES:
+    import torch  # noqa: F401
+
+
+def load_shadow_from_env():
+    """Return a shadow ``WriteDecider`` constructed from env, or ``None``."""
+    if _KIND not in _ENABLED_VALUES:
+        return None
+
+    if _KIND == "nanogpt":
+        from merken.classifiers.nanogpt import NanoGPTWriteDecider
+
+        ckpt = os.environ.get("MERKEN_SHADOW_NANOGPT_CKPT")
+        meta = os.environ.get("MERKEN_SHADOW_NANOGPT_META")
+        if not (ckpt and meta):
+            raise RuntimeError(
+                "MERKEN_SHADOW=nanogpt requires MERKEN_SHADOW_NANOGPT_CKPT "
+                "and MERKEN_SHADOW_NANOGPT_META env vars."
+            )
+        return NanoGPTWriteDecider(ckpt, meta)
+
+    if _KIND == "llm":
+        from merken.classifiers.llm import LLMWriteDecider
+
+        model = os.environ.get("MERKEN_SHADOW_LLM_MODEL")
+        if not model:
+            raise RuntimeError(
+                "MERKEN_SHADOW=llm requires MERKEN_SHADOW_LLM_MODEL env var."
+            )
+        device = os.environ.get("MERKEN_SHADOW_LLM_DEVICE", "cpu")
+        return LLMWriteDecider(model_name=model, device=device)
+
+    return None

--- a/merken/classifiers/llm.py
+++ b/merken/classifiers/llm.py
@@ -1,0 +1,115 @@
+"""Generic LLM-backed write decider.
+
+Uses any HuggingFace causal LM as a zero-shot DECISION/NOISE classifier
+by scoring two single-token continuations ("DECISION" vs "NOISE") after
+a short prompt. One forward pass per event.
+
+Designed for small local models (Gemma 3 270M-instruct, Qwen 0.5B,
+SmolLM 360M) where CPU inference is a few hundred ms per event. Bigger
+models work too but the write-path latency adds up.
+
+Why this instead of ``NanoGPTWriteDecider``: a pretrained LM has seen
+markdown tables, code blocks, prose, transcripts in its training
+corpus. It gets the format-sensitivity for free, without the
+3-session-iteration-on-synthetic-data treadmill that the custom
+800K-param classifier went through. The trade-off is size and latency.
+"""
+
+from __future__ import annotations
+
+from merken.policies.types import Decision, Event, WriteContext
+
+_PROMPT_TEMPLATE = (
+    "You classify memory events as DECISION or NOISE.\n"
+    "- DECISION: a lasting choice, design commitment, resolved open question, "
+    "or reference material worth keeping.\n"
+    "- NOISE: routine status, attendance, transient update, or ephemeral log "
+    "with no lasting value.\n\n"
+    "Event:\n{text}\n\n"
+    "Label:"
+)
+
+
+class LLMWriteDecider:
+    """Score two single-token continuations after a classification prompt.
+
+    The model runs once per event; we compare the logit of the first
+    token of " DECISION" vs " NOISE" at the label position. This is
+    cheaper and more stable than generating an answer and parsing it.
+    """
+
+    name = "llm-classifier"
+
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        device: str = "cpu",
+        confidence_threshold: float = 0.5,
+        max_input_chars: int = 3000,
+    ) -> None:
+        import torch
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        self._torch = torch
+        self._device = device
+        self._threshold = confidence_threshold
+        self._max_input_chars = max_input_chars
+        self._model_name = model_name
+
+        self._tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self._model = AutoModelForCausalLM.from_pretrained(model_name)
+        self._model.eval()
+        self._model.to(device)
+
+        # Find the token ids for the first subword of " DECISION" and
+        # " NOISE". Leading space matters -- after "Label:" the natural
+        # continuation starts with a space token in most SentencePiece
+        # and BPE tokenizers.
+        self._d_id = self._first_token(" DECISION")
+        self._n_id = self._first_token(" NOISE")
+
+    def _first_token(self, text: str) -> int:
+        ids = self._tokenizer.encode(text, add_special_tokens=False)
+        if not ids:
+            raise RuntimeError(
+                f"tokenizer produced no ids for {text!r} "
+                f"(model={self._model_name!r})"
+            )
+        return int(ids[0])
+
+    def decide(self, event: Event, ctx: WriteContext) -> Decision:  # noqa: ARG002
+        text = event.text[: self._max_input_chars]
+        prompt = _PROMPT_TEMPLATE.format(text=text)
+        inputs = self._tokenizer(prompt, return_tensors="pt").to(self._device)
+
+        with self._torch.no_grad():
+            outputs = self._model(**inputs)
+
+        last_logits = outputs.logits[0, -1, :]
+        probs = self._torch.nn.functional.softmax(last_logits, dim=-1)
+
+        p_d = float(probs[self._d_id])
+        p_n = float(probs[self._n_id])
+
+        # Normalize over the two-choice subspace so the confidence
+        # number is interpretable even when the LM distributes mass
+        # across other continuations.
+        total = p_d + p_n
+        if total > 0:
+            rel_p_d = p_d / total
+            rel_p_n = p_n / total
+        else:
+            rel_p_d = rel_p_n = 0.5
+
+        is_signal = rel_p_d > rel_p_n and rel_p_d >= self._threshold
+
+        return Decision(
+            write=is_signal,
+            reason=(
+                f"P(D)={rel_p_d:.3f} P(N)={rel_p_n:.3f} "
+                f"raw_mass={total:.3f}"
+            ),
+            confidence=max(rel_p_d, rel_p_n),
+            policy=self.name,
+        )

--- a/merken/memory.py
+++ b/merken/memory.py
@@ -40,7 +40,6 @@ from merken.consolidation import (
     cluster_by_jaccard,
     cluster_by_recall,
     fact_fingerprint,
-    generate_briefs,
     materialize_fact,
 )
 from merken.policies.should_consolidate import (
@@ -61,7 +60,10 @@ from merken.policies.should_recall import (
     RecallDecider,
     RecallPlan,
 )
-from merken.policies.should_remember import HeuristicWriteDecider
+from merken.policies.should_remember import (
+    HeuristicWriteDecider,
+    ShadowWriteDecider,
+)
 from merken.policies.types import Decision, Event, WriteContext, WriteDecider
 
 if TYPE_CHECKING:
@@ -69,6 +71,32 @@ if TYPE_CHECKING:
 
 DEFAULT_LAYER = "episodic"
 DEFAULT_COLLECTION = "default"
+
+
+def _default_write_decider() -> WriteDecider:
+    """Build the write decider, auto-wrapping in shadow mode if env set.
+
+    Env vars are read via ``merken._shadow.load_shadow_from_env``. If no
+    ``MERKEN_SHADOW`` is configured, returns a plain
+    ``HeuristicWriteDecider``. Otherwise wraps it in a
+    ``ShadowWriteDecider`` whose secondary is the env-configured
+    classifier (nanoGPT or LLM). Shadow failures do not block writes;
+    the ShadowWriteDecider catches them per-event.
+
+    If shadow construction itself fails (e.g. missing checkpoint),
+    degrade to the plain default -- the user's writes must not break
+    because an opt-in shadow is misconfigured.
+    """
+    from merken._shadow import load_shadow_from_env
+
+    primary = HeuristicWriteDecider()
+    try:
+        shadow = load_shadow_from_env()
+    except Exception:
+        return primary
+    if shadow is None:
+        return primary
+    return ShadowWriteDecider(primary, shadow)
 
 
 def _resolve_vstash_embed_model(vstash_memory: vstash.Memory) -> str:
@@ -195,7 +223,7 @@ class Memory:
             db=db,
             collection=collection,
         )
-        self._write_decider: WriteDecider = write_decider or HeuristicWriteDecider()
+        self._write_decider: WriteDecider = write_decider or _default_write_decider()
         self._consolidate_decider: ConsolidateDecider = (
             consolidate_decider or PeriodicConsolidator()
         )

--- a/tests/test_shadow_env.py
+++ b/tests/test_shadow_env.py
@@ -1,0 +1,89 @@
+"""Env-var wiring for shadow mode.
+
+Verifies that ``Memory`` auto-wraps its default decider with a
+``ShadowWriteDecider`` when ``MERKEN_SHADOW`` is set, and that an
+invalid or missing shadow config degrades gracefully to the plain
+default -- never to a write-blocking failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from merken import HeuristicWriteDecider, Memory, ShadowWriteDecider
+
+
+def test_no_env_uses_plain_default(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("MERKEN_SHADOW", raising=False)
+
+    with Memory(project="t", db=tmp_path / "a.db") as mem:
+        assert isinstance(mem._write_decider, HeuristicWriteDecider)
+
+
+def test_unknown_kind_is_ignored(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("MERKEN_SHADOW", "banana")
+
+    # Need to reload _shadow module to re-read the env var.
+    import importlib
+
+    import merken._shadow
+    importlib.reload(merken._shadow)
+
+    with Memory(project="t", db=tmp_path / "b.db") as mem:
+        assert isinstance(mem._write_decider, HeuristicWriteDecider)
+
+
+def test_nanogpt_env_missing_paths_falls_back_cleanly(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """If MERKEN_SHADOW=nanogpt but the required ckpt/meta vars are
+    unset, ``Memory`` must degrade to the plain default rather than
+    raise -- writes must not break because an opt-in shadow is broken.
+    """
+    monkeypatch.setenv("MERKEN_SHADOW", "nanogpt")
+    monkeypatch.delenv("MERKEN_SHADOW_NANOGPT_CKPT", raising=False)
+    monkeypatch.delenv("MERKEN_SHADOW_NANOGPT_META", raising=False)
+
+    import importlib
+
+    import merken._shadow
+    importlib.reload(merken._shadow)
+
+    with Memory(project="t", db=tmp_path / "c.db") as mem:
+        assert isinstance(mem._write_decider, HeuristicWriteDecider), (
+            "broken shadow config must not propagate; "
+            "plain default must still work"
+        )
+
+
+def test_explicit_shadow_decider_overrides_env(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A caller-provided write_decider must not be replaced by the
+    env-wired default -- explicit config always wins.
+    """
+    monkeypatch.setenv("MERKEN_SHADOW", "nanogpt")
+    monkeypatch.setenv("MERKEN_SHADOW_NANOGPT_CKPT", "/nope/not/real.pt")
+    monkeypatch.setenv("MERKEN_SHADOW_NANOGPT_META", "/nope/not/real.pkl")
+
+    custom = HeuristicWriteDecider()
+    with Memory(project="t", db=tmp_path / "d.db", write_decider=custom) as mem:
+        assert mem._write_decider is custom
+        assert not isinstance(mem._write_decider, ShadowWriteDecider)
+
+
+def test_default_returns_plain_when_shadow_import_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Exceptions during shadow construction are caught; fall back."""
+    monkeypatch.setenv("MERKEN_SHADOW", "llm")
+    monkeypatch.setenv("MERKEN_SHADOW_LLM_MODEL", "definitely/not-a-real-model-xyz")
+
+    import importlib
+
+    import merken._shadow
+    importlib.reload(merken._shadow)
+
+    # Memory construction must not raise even if shadow fails to load.
+    with Memory(project="t", db=tmp_path / "e.db") as mem:
+        assert isinstance(mem._write_decider, HeuristicWriteDecider)


### PR DESCRIPTION
## Summary

- Memory auto-wraps its default decider with ShadowWriteDecider when `MERKEN_SHADOW` env var is set, so CLI/MCP/SDK opt in without code changes.
- New `LLMWriteDecider` wraps any HuggingFace causal LM (e.g. `google/gemma-3-270m-it`) as a zero-shot DECISION/NOISE classifier via two-token logit scoring.
- Torch is eagerly imported in `merken/_shadow.py` at module-eval time when shadow is enabled, satisfying the torch-before-fastembed load order (Mistake #10).
- Fail-safe: if shadow construction errors, Memory degrades to plain `HeuristicWriteDecider`. An opt-in shadow never blocks writes.

## Env vars

| Var                            | Purpose                                        |
|--------------------------------|------------------------------------------------|
| `MERKEN_SHADOW`                | `nanogpt`, `llm`, or unset                     |
| `MERKEN_SHADOW_NANOGPT_CKPT`   | ckpt path (when kind=nanogpt)                  |
| `MERKEN_SHADOW_NANOGPT_META`   | meta.pkl path (when kind=nanogpt)              |
| `MERKEN_SHADOW_LLM_MODEL`      | HF id or local path (when kind=llm)            |
| `MERKEN_SHADOW_LLM_DEVICE`     | `cpu` (default) or `mps` / `cuda` (when kind=llm) |

## Smoke test (manual)

```
$ MERKEN_SHADOW=nanogpt \
  MERKEN_SHADOW_NANOGPT_CKPT=.../out-merken-bpe/ckpt.pt \
  MERKEN_SHADOW_NANOGPT_META=.../data/merken_bpe/meta.pkl \
  merken --db /tmp/smoke.db --project smoke remember "Replaced PostgreSQL with CockroachDB." --title t1
reason=novel|shadow_agree:nanogpt-classifier=write:1.000
policy=Shadow(HeuristicWriteDecider|nanogpt-classifier)

$ merken ... remember "Sprint planning: infra team prioritized CI pipeline." --title t2
reason=novel|shadow_disagree:nanogpt-classifier=skip:1.000
policy=Shadow(HeuristicWriteDecider|nanogpt-classifier)
```

Primary (HeuristicWriteDecider) writes both; shadow flags the second as noise. Disagreements accumulate in the audit for later review.

## Test plan

- [x] 5 new unit tests for env wiring (no-env, unknown, missing-paths, explicit-override, llm-fallback).
- [x] `pytest -q --ignore=tests/test_embed_model_resolution.py` (185 passed, 3 deselected).
- [x] `ruff check` clean on all new files.
- [x] End-to-end CLI smoke reproducing shadow_agree / shadow_disagree.

## Hook change (separate, outside this PR)

`~/.claude/hooks/merken-save.sh` now exports the three `MERKEN_SHADOW_*` vars so live Claude Code sessions run in shadow mode automatically. That is a local settings change (not checked in).