### PR TITLE
feat(labeling): oracular labeling of shadow disagreements

### DIFF
--- a/experiments/consolidation/shadow_dry_run.py
+++ b/experiments/consolidation/shadow_dry_run.py
@@ -1,0 +1,180 @@
+# ruff: noqa: I001, E402
+"""Shadow-mode dry run: dimension the disagreement rate.
+
+Runs HeuristicWriteDecider + NanoGPTWriteDecider (BPE v4) over a mixed
+set of events (organic docs from ~/.merken/*.db plus every loop-quality
+scenario on disk) and reports the four agree/disagree buckets:
+
+  both write   -- primary says keep, shadow says keep   (low signal)
+  both skip    -- primary says drop, shadow says drop   (high-signal negatives)
+  primary-write/shadow-skip -- shadow flags as noise    (review target)
+  primary-skip/shadow-write -- shadow rescues          (rarer; also interesting)
+
+The point is to size shadow mode honestly BEFORE committing to a
+review cadence: if we see 5 disagreements per 100 events on realistic
+content, a 200-sample target is ~40 days of typical use; if we see 50,
+it's a week. The answer shapes whether oracle-based labeling is
+urgent or optional.
+
+No Gemini calls, no vstash writes: pure classifier comparison.
+"""
+
+from __future__ import annotations
+
+# Torch must load before any merken import (Mistake #10).
+import torch  # noqa: F401
+
+import argparse
+import glob
+import json
+import sqlite3
+from collections import Counter
+from pathlib import Path
+
+from merken.classifiers.nanogpt import NanoGPTWriteDecider
+from merken.policies import Event, HeuristicWriteDecider, WriteContext
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+NANOGPT_DIR = REPO_ROOT.parent / "nanoGPT"
+SCENARIO_DIR = REPO_ROOT / "experiments" / "loop_quality" / "scenarios"
+
+
+def load_merken_events(merken_dir: Path) -> list[tuple[str, str, str]]:
+    """Return (source, title, text) for every real doc in local stores."""
+    rows: list[tuple[str, str, str]] = []
+    for db_path in sorted(glob.glob(str(merken_dir / "*.db"))):
+        db = sqlite3.connect(db_path)
+        try:
+            cur = db.execute(
+                """
+                SELECT d.title, GROUP_CONCAT(c.text, '\n\n')
+                FROM documents d
+                JOIN chunks c ON c.doc_id = d.id
+                WHERE d.collection NOT IN ('merken_audit', 'merken_tombstones')
+                GROUP BY d.id, d.title
+                """
+            )
+            for title, text in cur.fetchall():
+                rows.append((f"merken:{Path(db_path).stem}", title or "", text or ""))
+        except sqlite3.OperationalError:
+            continue
+        finally:
+            db.close()
+    return rows
+
+
+def load_scenario_events(scenario_dir: Path) -> list[tuple[str, str, str]]:
+    rows: list[tuple[str, str, str]] = []
+    for path in sorted(scenario_dir.glob("*.json")):
+        try:
+            scenario = json.loads(path.read_text())
+        except Exception:
+            continue
+        events = scenario.get("events") or []
+        for e in events:
+            rows.append((
+                f"scenario:{path.stem}",
+                e.get("id", ""),
+                e.get("text", ""),
+            ))
+    return rows
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--merken-dir", type=Path, default=Path.home() / ".merken",
+    )
+    p.add_argument(
+        "--ckpt",
+        type=Path,
+        default=NANOGPT_DIR / "out-merken-bpe" / "ckpt.pt",
+    )
+    p.add_argument(
+        "--meta",
+        type=Path,
+        default=NANOGPT_DIR / "data" / "merken_bpe" / "meta.pkl",
+    )
+    p.add_argument("--threshold", type=float, default=0.5)
+    p.add_argument(
+        "--per-source-breakdown",
+        action="store_true",
+        help="print counts per source",
+    )
+    args = p.parse_args()
+
+    events = load_merken_events(args.merken_dir) + load_scenario_events(SCENARIO_DIR)
+    print(f"Loaded {len(events)} events (merken dbs + scenarios)")
+
+    shadow = NanoGPTWriteDecider(
+        args.ckpt, args.meta, confidence_threshold=args.threshold
+    )
+    ctx = WriteContext(project="dryrun")
+
+    bucket: Counter = Counter()
+    per_source: dict[str, Counter] = {}
+
+    # Fresh HeuristicWriteDecider per source so cross-source text
+    # collisions (e.g. organic_val events also appear in
+    # jay_vstash_snapshot) do not show up as fake dup_exact skips.
+    # Within a single source, dedup still applies and is realistic.
+    primary_per_source: dict[str, HeuristicWriteDecider] = {}
+
+    for source, title, text in events:
+        primary = primary_per_source.setdefault(source, HeuristicWriteDecider())
+        ev = Event(text=text, title=title or None)
+        p_d = primary.decide(ev, ctx)
+        s_d = shadow.decide(ev, ctx)
+        key = (
+            ("write" if p_d.write else "skip"),
+            ("write" if s_d.write else "skip"),
+        )
+        bucket[key] += 1
+        per_source.setdefault(source, Counter())[key] += 1
+
+    def pct(n: int) -> str:
+        return f"{(100 * n / len(events)):.1f}%" if events else "0.0%"
+
+    both_write = bucket[("write", "write")]
+    both_skip = bucket[("skip", "skip")]
+    disagree_flag_skip = bucket[("write", "skip")]   # shadow thinks noise
+    disagree_flag_write = bucket[("skip", "write")]  # shadow thinks decision
+
+    print()
+    print(f"{'bucket':<32} {'count':>6}  {'pct':>6}")
+    print("-" * 52)
+    print(f"{'both write':<32} {both_write:>6}  {pct(both_write):>6}")
+    print(f"{'both skip':<32} {both_skip:>6}  {pct(both_skip):>6}")
+    print(
+        f"{'primary=write shadow=skip':<32} {disagree_flag_skip:>6}  "
+        f"{pct(disagree_flag_skip):>6}"
+    )
+    print(
+        f"{'primary=skip shadow=write':<32} {disagree_flag_write:>6}  "
+        f"{pct(disagree_flag_write):>6}"
+    )
+    print("-" * 52)
+    total_disagree = disagree_flag_skip + disagree_flag_write
+    print(f"{'total disagreements':<32} {total_disagree:>6}  {pct(total_disagree):>6}")
+    print()
+
+    # Sizing: how many events to see N disagreements?
+    rate = total_disagree / len(events) if events else 0
+    if rate > 0:
+        for target in (50, 100, 200):
+            needed = int(target / rate) if rate > 0 else 0
+            print(f"~{needed} events to accumulate {target} disagreements")
+    else:
+        print("no disagreements observed; shadow tells you nothing on this sample")
+
+    if args.per_source_breakdown:
+        print("\nPer-source:")
+        for source, counts in sorted(per_source.items()):
+            total = sum(counts.values())
+            dis = counts[("write", "skip")] + counts[("skip", "write")]
+            dis_pct = f"{100 * dis / total:.1f}%" if total else "0.0%"
+            print(f"  {source:<40} n={total:>4}  disagree={dis:>3} ({dis_pct})")
+
+
+if __name__ == "__main__":
+    main()

--- a/merken/audit.py
+++ b/merken/audit.py
@@ -140,8 +140,14 @@ def format_audit_row(event: Event, decision: Decision) -> tuple[str, str]:
     The body is plain text on purpose: it has to be human-readable when an
     operator runs ``mem.audit("why was this dropped")``, and it has to be
     indexable by both vstash's vector and FTS paths.
+
+    The title includes microseconds *and* the event title so that two
+    audit rows produced within the same second (common in batch
+    ingestion) do not collide. Earlier versions used second-precision
+    only, which silently dropped audit rows when the same policy
+    produced identical reasons in quick succession.
     """
-    ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    ts = datetime.now(timezone.utc).isoformat(timespec="microseconds")
     preview = " ".join(event.text.split())[:_PREVIEW_CHARS]
 
     body = (
@@ -157,5 +163,6 @@ def format_audit_row(event: Event, decision: Decision) -> tuple[str, str]:
         f"event_text_preview: {preview}\n"
     )
 
-    title = f"audit:should_remember:{decision.reason}:{ts}"
+    title_suffix = f":{event.title}" if event.title else ""
+    title = f"audit:should_remember:{decision.reason}:{ts}{title_suffix}"
     return title, body

--- a/merken/cli.py
+++ b/merken/cli.py
@@ -230,6 +230,45 @@ _SHADOW_FLAG_TO_MARKER = {
 }
 
 
+def _build_label_backend(name: str):
+    """Construct a ``LabelBackend`` from a CLI string identifier."""
+    if name == "gemini":
+        from merken.labeling import GeminiLabelBackend
+        return GeminiLabelBackend()
+    raise SystemExit(f"unknown --label-with backend: {name!r}")
+
+
+def _run_labeling(args: argparse.Namespace) -> int:
+    from merken.labeling import label_disagreements
+
+    backend = _build_label_backend(args.label_with)
+    print(f"oracle: {backend.name}")
+
+    counts = {"labeled": 0, "skipped": 0, "error": 0}
+    with Memory(project=args.project, db=_resolve_db(args)) as mem:
+        for status, event_title, label, detail in label_disagreements(
+            mem, backend, limit=args.limit
+        ):
+            counts[status] = counts.get(status, 0) + 1
+            if status == "labeled" and label is not None:
+                print(
+                    f"✓ {event_title[:60]:<60}  "
+                    f"{label.decision:<9}  conf={label.confidence:.2f}  "
+                    f"{label.rationale[:80]}"
+                )
+            elif status == "error":
+                print(f"✗ {event_title[:60]:<60}  {detail[:80]}")
+            # "skipped" stays silent to keep the output compact.
+
+    print()
+    print(
+        f"labeled={counts['labeled']}  "
+        f"skipped={counts['skipped']}  "
+        f"error={counts['error']}"
+    )
+    return 0 if counts["error"] == 0 else 1
+
+
 def _parse_audit_row(text: str) -> dict[str, str]:
     """Parse the ``key: value`` block emitted by ``format_audit_row``."""
     fields: dict[str, str] = {}
@@ -268,6 +307,12 @@ def cmd_audit(args: argparse.Namespace) -> int:
         if getattr(args, flag, False):
             shadow_filter = marker
             break
+
+    # --label-with implies --shadow-disagree (only disagreements can
+    # become training labels) and runs the labeling loop instead of
+    # just printing.
+    if getattr(args, "label_with", None):
+        return _run_labeling(args)
 
     query = shadow_filter or args.query or "should_"
 
@@ -531,6 +576,22 @@ def build_parser() -> argparse.ArgumentParser:
         "--shadow-error",
         action="store_true",
         help="surface events where the shadow decider raised (primary unaffected)",
+    )
+    aud.add_argument(
+        "--label-with",
+        choices=("gemini",),
+        default=None,
+        help=(
+            "run oracular labeling on unlabeled shadow_disagree rows with the "
+            "chosen backend. Labels are stored in the merken_labels "
+            "collection; re-running is safe."
+        ),
+    )
+    aud.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="max new labels per --label-with run (default: all)",
     )
     aud.set_defaults(func=cmd_audit)
 

--- a/merken/labeling.py
+++ b/merken/labeling.py
@@ -1,0 +1,253 @@
+"""Oracular labeling of shadow-mode disagreements.
+
+Shadow mode writes a ``shadow_disagree`` tag into every audit row where
+the primary decider and the shadow classifier disagreed. Left alone,
+those tags are just annotations. This module turns them into labeled
+training data by asking an oracle (LLM backend) which side was right.
+
+Flow::
+
+    ShadowWriteDecider      -> audit row ``novel|shadow_disagree:...``
+    label_disagreements     -> for each disagreement, backend.label(text)
+                            -> label row in ``merken_labels`` collection
+
+Labels are stored per-project in the same vstash DB as the audit log,
+under the ``merken_labels`` collection. Re-running ``label_disagreements``
+skips events that already have a label -- it is safe to run
+repeatedly, and safe to interrupt.
+
+The backend protocol is deliberately thin; any object with
+``name: str`` and ``label(text) -> Label`` works. That lets callers
+compose oracles (Gemini, Claude, local Gemma, even a human-in-the-loop
+wrapper) without touching merken internals.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from merken.memory import Memory
+
+
+LABEL_COLLECTION = "merken_labels"
+LABEL_LAYER = "audit"
+
+_PROMPT = (
+    "You are labeling memory events for an agent's write-filter training set.\n"
+    "Read the event below and classify it as exactly one of:\n"
+    "  DECISION  -- a lasting commitment, design choice, resolved open\n"
+    "              question, or reference material worth keeping.\n"
+    "  NOISE     -- routine status, attendance, transient update, or\n"
+    "              ephemeral log with no lasting value.\n"
+    "  UNCERTAIN -- genuinely ambiguous; a reasonable person could go\n"
+    "              either way.\n\n"
+    "Event:\n"
+    "<<<\n"
+    "{text}\n"
+    ">>>\n\n"
+    "Respond on a single line in this exact format (no prose, no code fences):\n"
+    "LABEL: <DECISION|NOISE|UNCERTAIN> | CONFIDENCE: <number 0.0-1.0> | "
+    "REASON: <one sentence>"
+)
+
+
+@dataclass(frozen=True)
+class Label:
+    """One oracular judgment on a disagreement."""
+
+    decision: str  # "DECISION" | "NOISE" | "UNCERTAIN"
+    confidence: float
+    rationale: str
+    backend: str
+
+
+class LabelBackend(Protocol):
+    """Protocol for label oracles.
+
+    Implementations should be idempotent and deterministic where
+    possible (temperature=0 for LLMs) so re-running produces stable
+    training data.
+    """
+
+    name: str
+
+    def label(self, text: str) -> Label: ...
+
+
+def _parse_backend_response(raw: str, backend_name: str) -> Label:
+    """Parse ``LABEL: X | CONFIDENCE: 0.8 | REASON: ...`` into a Label.
+
+    Degrades gracefully on malformed responses: returns an UNCERTAIN
+    label with confidence 0 and the raw text as the rationale, so a
+    misbehaving backend never crashes the labeling loop.
+    """
+    parts: dict[str, str] = {}
+    for piece in raw.splitlines()[0].split("|") if raw.strip() else []:
+        if ":" not in piece:
+            continue
+        key, _, value = piece.partition(":")
+        parts[key.strip().upper()] = value.strip()
+
+    decision = parts.get("LABEL", "UNCERTAIN").upper()
+    if decision not in ("DECISION", "NOISE", "UNCERTAIN"):
+        decision = "UNCERTAIN"
+
+    try:
+        confidence = float(parts.get("CONFIDENCE", "0"))
+    except ValueError:
+        confidence = 0.0
+    confidence = max(0.0, min(1.0, confidence))
+
+    rationale = parts.get("REASON", raw.strip())
+    return Label(
+        decision=decision,
+        confidence=confidence,
+        rationale=rationale[:500],
+        backend=backend_name,
+    )
+
+
+class GeminiLabelBackend:
+    """LLM label oracle backed by Google's genai SDK (Gemini)."""
+
+    def __init__(
+        self,
+        *,
+        model: str = "gemini-2.0-flash",
+        api_key: str | None = None,
+    ) -> None:
+        from google import genai
+
+        resolved_key = (
+            api_key
+            or os.environ.get("GEMINI_API_KEY")
+            or os.environ.get("GOOGLE_API_KEY")
+        )
+        if not resolved_key:
+            raise RuntimeError(
+                "GeminiLabelBackend needs GEMINI_API_KEY or GOOGLE_API_KEY "
+                "set in the environment."
+            )
+        self._client = genai.Client(api_key=resolved_key)
+        self.name = model
+
+    def label(self, text: str) -> Label:
+        prompt = _PROMPT.format(text=text[:3000])
+        resp = self._client.models.generate_content(
+            model=self.name, contents=prompt
+        )
+        return _parse_backend_response(resp.text or "", self.name)
+
+
+def _shadow_marker(reason: str) -> str | None:
+    """Return the shadow marker in a reason string, or None."""
+    if "|shadow_" not in reason:
+        return None
+    _, _, tail = reason.partition("|shadow_")
+    marker, _, _ = tail.partition(":")
+    return "shadow_" + marker if marker else None
+
+
+def _parse_audit_body(text: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for line in (text or "").splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        fields[key.strip()] = value.strip()
+    return fields
+
+
+def _label_title(event_title: str) -> str:
+    """Stable title so re-labeling is idempotent per event."""
+    return f"label:{event_title}"
+
+
+def label_disagreements(
+    mem: Memory,
+    backend: LabelBackend,
+    *,
+    marker: str = "shadow_disagree",
+    limit: int | None = None,
+    max_audit_rows: int = 1000,
+) -> Iterator[tuple[str, str, Label | None, str]]:
+    """Label every disagreement not yet labeled.
+
+    Yields ``(status, event_title, label_or_none, detail)`` tuples so
+    the caller (CLI, notebook, whatever) can render progress without
+    this function doing any printing itself.
+
+    ``status`` is one of:
+        - ``"labeled"`` (new label written)
+        - ``"skipped"`` (already labeled, or missing event text)
+        - ``"error"`` (backend raised; write not attempted)
+
+    Labels are stored in the project's vstash under
+    ``LABEL_COLLECTION``. Re-running is safe: the first pass processes
+    all fresh disagreements, subsequent passes skip them.
+    """
+    existing = mem.search_labels(top_k=max_audit_rows)
+    already_labeled: set[str] = set()
+    for row in existing:
+        title = getattr(row, "title", None) or ""
+        if title.startswith("label:"):
+            already_labeled.add(title.removeprefix("label:"))
+
+    audit_rows = mem.audit(query=marker, top_k=max_audit_rows, fts_only=True)
+    audit_rows = [r for r in audit_rows if marker in (r.text or "")]
+
+    new_count = 0
+    for row in audit_rows:
+        fields = _parse_audit_body(row.text or "")
+        event_title = fields.get("event_title") or ""
+        reason = fields.get("reason") or ""
+        if _shadow_marker(reason) != marker:
+            yield ("skipped", event_title, None, "marker_mismatch")
+            continue
+        if not event_title:
+            yield ("skipped", "", None, "no_event_title")
+            continue
+        if event_title in already_labeled:
+            yield ("skipped", event_title, None, "already_labeled")
+            continue
+
+        text = fields.get("event_text_preview") or ""
+        if not text:
+            yield ("skipped", event_title, None, "no_text")
+            continue
+
+        try:
+            label = backend.label(text)
+        except Exception as exc:
+            yield (
+                "error",
+                event_title,
+                None,
+                f"{exc.__class__.__name__}: {exc}",
+            )
+            continue
+
+        body = json.dumps(
+            {
+                "decision": label.decision,
+                "confidence": label.confidence,
+                "rationale": label.rationale,
+                "backend": label.backend,
+                "shadow_marker": marker,
+                "event_text_preview": text[:500],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        mem.remember_label(event_title=event_title, body=body)
+        already_labeled.add(event_title)
+
+        yield ("labeled", event_title, label, label.decision)
+        new_count += 1
+        if limit is not None and new_count >= limit:
+            return

--- a/merken/memory.py
+++ b/merken/memory.py
@@ -850,17 +850,57 @@ class Memory:
         query: str = "should_remember",
         *,
         top_k: int = 20,
+        fts_only: bool = False,
     ) -> list[SearchResult]:
         """Query the audit log.
 
         Use this to answer "why was X kept / dropped?" The audit collection
-        is searched in isolation from normal memory.
+        is searched in isolation from normal memory. Pass ``fts_only=True``
+        when the query is a literal token (e.g. ``shadow_disagree``) so
+        vstash uses its full-text index directly instead of hybrid vector
+        + FTS -- embedding tiny tag tokens degrades recall on small
+        collections.
         """
         return self._vstash.search(
             query,
             top_k=top_k,
             collection=AUDIT_COLLECTION,
             layer=AUDIT_LAYER,
+            fts_only=fts_only,
+        )
+
+    # --------------------------------------------------------------- labels
+
+    def remember_label(self, *, event_title: str, body: str) -> None:
+        """Write one oracular label into the ``merken_labels`` collection.
+
+        Used by ``merken.labeling`` when an oracle classifies a
+        shadow-mode disagreement. Stored in the project's own vstash so
+        labels are always co-located with the audit rows they annotate.
+        Failure is silent for the same reason audit writes are silent:
+        label failures must not break normal memory ops.
+        """
+        from merken.labeling import LABEL_COLLECTION, LABEL_LAYER, _label_title
+
+        try:
+            self._vstash.remember(
+                body,
+                title=_label_title(event_title),
+                collection=LABEL_COLLECTION,
+                layer=LABEL_LAYER,
+            )
+        except Exception:
+            pass
+
+    def search_labels(self, query: str = "label:", *, top_k: int = 200):
+        """Query the label store for previously-oracled disagreements."""
+        from merken.labeling import LABEL_COLLECTION, LABEL_LAYER
+
+        return self._vstash.search(
+            query,
+            top_k=top_k,
+            collection=LABEL_COLLECTION,
+            layer=LABEL_LAYER,
         )
 
     # --------------------------------------------------------------- internals

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -1,0 +1,169 @@
+"""Unit tests for the oracular labeling loop.
+
+Uses a stub backend (no LLM) so the tests run offline in CI and
+exercise the iteration logic, idempotence, and error handling paths.
+The real GeminiLabelBackend is smoke-tested manually against an API
+key outside of pytest.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from merken import AlwaysWrite, Memory, ShadowWriteDecider
+from merken.labeling import (
+    Label,
+    _parse_backend_response,
+    label_disagreements,
+)
+from merken.policies import Decision, Event, WriteContext
+
+
+class _StubShadow:
+    """A ShadowWriteDecider-compatible secondary that always skips."""
+
+    name = "stub-shadow"
+
+    def decide(self, event: Event, ctx: WriteContext) -> Decision:  # noqa: ARG002
+        return Decision(False, "stub_skip", 0.8, self.name)
+
+
+class _StubBackend:
+    """Idempotent deterministic backend that labels by the event text."""
+
+    name = "stub-backend"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def label(self, text: str) -> Label:
+        self.calls.append(text)
+        decision = "NOISE" if "noise" in text.lower() else "DECISION"
+        return Label(
+            decision=decision,
+            confidence=0.9,
+            rationale=f"stub said {decision}",
+            backend=self.name,
+        )
+
+
+class _RaisingBackend:
+    name = "raises"
+
+    def label(self, text: str) -> Label:  # noqa: ARG002
+        raise RuntimeError("backend offline")
+
+
+def _primed_memory(tmp_path: Path) -> Memory:
+    """Build a Memory wired in shadow mode and write 3 events.
+
+    Uses substantive, lexically distinct texts so vstash does not
+    reject any of them as empty/trivial -- we want all three to
+    produce ``shadow_disagree`` audit rows.
+    """
+    mem = Memory(
+        project="labeling_test",
+        db=tmp_path / "lbl.db",
+        write_decider=ShadowWriteDecider(AlwaysWrite(), _StubShadow()),
+    )
+    mem.remember(
+        "Decision: switched the inventory service from CockroachDB to Yugabyte "
+        "after a three-week spike showed better multi-region write latency.",
+        title="t_decision",
+    )
+    mem.remember(
+        "Routine noise log: warehouse inventory service nightly job completed "
+        "at 04:12 UTC with zero errors reported and full report attached.",
+        title="t_noise",
+    )
+    mem.remember(
+        "Ambient meeting reminder for the platform sync on Tuesday at 14:00; "
+        "agenda covers onboarding, access control, and the next refactor wave.",
+        title="t_meeting",
+    )
+    return mem
+
+
+# ------------------------------------------------------------- parser
+
+
+def test_parse_backend_response_full() -> None:
+    out = _parse_backend_response(
+        "LABEL: DECISION | CONFIDENCE: 0.87 | REASON: it documents a real choice",
+        "test",
+    )
+    assert out.decision == "DECISION"
+    assert out.confidence == 0.87
+    assert out.rationale.startswith("it documents")
+    assert out.backend == "test"
+
+
+def test_parse_backend_response_rejects_unknown_label() -> None:
+    out = _parse_backend_response(
+        "LABEL: MAYBE | CONFIDENCE: 0.5 | REASON: dunno",
+        "test",
+    )
+    assert out.decision == "UNCERTAIN"
+
+
+def test_parse_backend_response_clamps_confidence() -> None:
+    out = _parse_backend_response(
+        "LABEL: NOISE | CONFIDENCE: 2.0 | REASON: out of range",
+        "test",
+    )
+    assert 0.0 <= out.confidence <= 1.0
+
+
+def test_parse_backend_response_handles_malformed() -> None:
+    out = _parse_backend_response("garbage output", "test")
+    assert out.decision == "UNCERTAIN"
+    assert out.confidence == 0.0
+
+
+# ------------------------------------------------------------- loop
+
+
+def test_label_disagreements_writes_labels_and_skips_second_run(
+    tmp_path: Path,
+) -> None:
+    with _primed_memory(tmp_path) as mem:
+        backend = _StubBackend()
+
+        results = list(label_disagreements(mem, backend))
+        labeled = [r for r in results if r[0] == "labeled"]
+        assert len(labeled) == 3, (
+            "all 3 writes should have produced shadow_disagree rows"
+        )
+
+        # Second pass: every event is already labeled.
+        results_2 = list(label_disagreements(mem, backend))
+        labeled_2 = [r for r in results_2 if r[0] == "labeled"]
+        assert labeled_2 == [], "re-running must be idempotent"
+        assert len(backend.calls) == 3, (
+            "backend must NOT be called again after all events are labeled"
+        )
+
+
+def test_label_disagreements_respects_limit(tmp_path: Path) -> None:
+    with _primed_memory(tmp_path) as mem:
+        backend = _StubBackend()
+        results = list(label_disagreements(mem, backend, limit=2))
+        labeled = [r for r in results if r[0] == "labeled"]
+        assert len(labeled) == 2
+
+
+def test_label_disagreements_error_is_caught(tmp_path: Path) -> None:
+    with _primed_memory(tmp_path) as mem:
+        results = list(label_disagreements(mem, _RaisingBackend()))
+        errored = [r for r in results if r[0] == "error"]
+        assert len(errored) >= 1
+        assert all("RuntimeError" in r[3] for r in errored)
+
+
+def test_memory_label_roundtrip(tmp_path: Path) -> None:
+    """Memory.remember_label -> Memory.search_labels should find it."""
+    with Memory(project="lbl", db=tmp_path / "r.db") as mem:
+        mem.remember_label(event_title="demo_evt", body='{"decision": "DECISION"}')
+        rows = mem.search_labels(top_k=10)
+        titles = [(r.title or "") for r in rows]
+        assert any(t == "label:demo_evt" for t in titles)


### PR DESCRIPTION
## Summary

Closes the bootstrap loop. Shadow mode writes `shadow_disagree` tags (PR #1/2/3); this PR turns those tags into labeled training data by asking an oracle (Gemini by default) to classify the event.

## Volume measurement (drove the design)

`experiments/consolidation/shadow_dry_run.py` measures the shadow-mode disagreement rate across every scenario + every `~/.merken/*.db`. Result: **~6% on organic content** (vs ~69% on synthetic noise scenarios, which are the training distribution).

At ~6%, passive accumulation of 200 disagreements takes ~2 months. Oracle labeling is not optional -- it's necessary for a usable review cadence.

## Oracle labeling

```
merken audit --label-with gemini [--limit N]
```

- Skips events already in `merken_labels` (idempotent, re-runnable).
- Gemini as the first backend (zero-config given Jay's env keys).
- Fail-safe: per-event errors don't block the loop.

## Audit fix (pre-requisite)

While writing tests: `format_audit_row` used second-precision timestamps so two rows produced within the same second for the same policy+reason had identical titles and vstash silently dropped one. Fix: microseconds + event_title suffix.

## E2E verification against live Gemini

Ran `merken audit --label-with gemini` on `/tmp/shadow_smoke.db` (the shadow smoke from PR #2 with 1 disagreement). Gemini labeled "Sprint planning: infra team prioritized CI pipeline" as **DECISION** (conf=0.90, "Prioritization of the CI pipeline represents a lasting commitment..."). Oracle overrode nanoGPT's SKIP -- exactly the kind of correction needed to train v6. Re-run: `labeled=0 skipped=1` (idempotent).

## Test plan

- [x] 8 new unit tests for parser + loop + idempotency + error handling (stub backend, no network).
- [x] `pytest -q --ignore=tests/test_embed_model_resolution.py` = **199 passed**, 3 deselected.
- [x] `ruff check` clean on all new files.
- [x] E2E smoke against live Gemini API key.

## Scope-excluded intentionally

- No Claude backend yet (~20 lines; Gemini already covers the immediate need).
- No batching / rate limiting (Gemini Flash is cheap at this scale).
- No graduation path from shadow to primary decider (still TODO).