### PR TITLE
feat: ChainedWriteDecider (graduation) + v6 markdown-NOISE synthesis

### DIFF
--- a/experiments/consolidation/generate_markdown_noise.py
+++ b/experiments/consolidation/generate_markdown_noise.py
@@ -1,0 +1,189 @@
+"""Generate synthetic markdown-NOISE training samples via Gemini.
+
+The 2026-04-17 `markdown_tables_held_out` scenario showed that both
+char v2 and BPE v4 classify EVERY table-formatted event as DECISION
+(100% FPR on 6 noise tables). Root cause: the NOISE side of training
+data is 100% single-paragraph flat text ("Sprint planning:
+..."), so the model has no reference for table-formatted NOISE.
+
+This script asks Gemini to generate routine-status markdown tables
+across six categories (schedule / status_snapshot / toc / pricing /
+log / roster) so v6 training has balanced structured NOISE. The
+content deliberately uses domains absent from the 6 held-out
+examples (those domains: aviation, game dev, biolab, satellite,
+firmware, retail waves) -- we synthesize in adjacent-but-distinct
+domains so the held-out scenario remains an honest generalization
+test.
+
+Usage:
+
+    export GEMINI_API_KEY=...
+    PYTHONPATH=. python -m experiments.consolidation.generate_markdown_noise \\
+        --out data/markdown_noise_v6.json --per-category 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import time
+from pathlib import Path
+
+CATEGORIES: dict[str, str] = {
+    "schedule": (
+        "A routine meeting/oncall/event schedule formatted as a markdown "
+        "table. No decisions, just upcoming slots or attendance. "
+        "Examples of the TYPE (do NOT reuse): daily standup agenda, "
+        "oncall rotation week, retro attendance, design review roster."
+    ),
+    "status_snapshot": (
+        "A routine status snapshot formatted as a markdown table. "
+        "Numeric metrics or pass/fail columns, nothing decided. "
+        "Examples of the TYPE: sprint burndown, service health, "
+        "ticket triage summary, capacity report."
+    ),
+    "toc": (
+        "A table of contents or index as a markdown table, with no "
+        "substantive content besides section names and page numbers."
+    ),
+    "pricing": (
+        "A declarative pricing / tier / configuration reference as a "
+        "markdown table. Just values, no commitment to act."
+    ),
+    "log": (
+        "A structured log digest as a markdown table (one row per event, "
+        "columns for severity / source / message). Summary-of-noise, "
+        "not an incident postmortem."
+    ),
+    "roster": (
+        "A team/committee roster as a markdown table: name, role, "
+        "contact. No decisions, just a directory."
+    ),
+}
+
+# Mini-universes so Gemini doesn't keep producing 'engineering team'
+# examples. We sample a fresh universe per prompt to spread coverage.
+UNIVERSES = [
+    "maritime logistics company",
+    "public library system",
+    "urban planning office",
+    "renewable energy co-op",
+    "university research lab",
+    "veterinary clinic chain",
+    "music festival production crew",
+    "municipal water utility",
+    "arts foundation grants office",
+    "neighbourhood clinic network",
+    "regional airline cargo ops",
+    "archival digitization project",
+]
+
+
+_PROMPT_TEMPLATE = (
+    "Generate ONE markdown document that is an example of routine NOISE "
+    "(not a decision worth keeping in long-term memory). It MUST satisfy "
+    "all of:\n"
+    "\n"
+    "- Category: {category_desc}\n"
+    "- Setting: {universe}.\n"
+    "- Contains at least one GitHub-flavored markdown table with 3-5 "
+    "columns and 3-6 rows. A short header line is fine.\n"
+    "- 400-1200 characters total.\n"
+    "- Feels routine or declarative, never a decision being made. No "
+    "language like 'we decided', 'migrated', 'adopted', 'chose'.\n"
+    "- Do NOT repeat any of the excluded tech stacks below:\n"
+    "{excluded}\n"
+    "\n"
+    "Return ONLY the markdown body. No code fences, no preamble."
+)
+
+# Domains used by the held-out scenario -- we MUST avoid generating
+# similar content or the val set leaks into train.
+EXCLUDED_STACKS = [
+    "flight planner event bus (Kafka / NATS)",
+    "game engine selection (Godot / Bevy)",
+    "cytometry panel cutoffs",
+    "retail store inventory-V2 rollout waves",
+    "satellite ground station slot allocation (AsterSat, Svalbard, Kiruna)",
+    "firmware 4.8 feature freeze",
+]
+
+EXCLUDED_TEXT = "\n".join(f"  - {s}" for s in EXCLUDED_STACKS)
+
+
+def _generate_one(client, model: str, category: str, universe: str) -> str | None:
+    prompt = _PROMPT_TEMPLATE.format(
+        category_desc=CATEGORIES[category],
+        universe=universe,
+        excluded=EXCLUDED_TEXT,
+    )
+    try:
+        resp = client.models.generate_content(model=model, contents=prompt)
+        text = (resp.text or "").strip()
+    except Exception as exc:
+        print(f"  ! {category}/{universe}: {exc.__class__.__name__}: {exc}")
+        return None
+
+    # Strip accidental code fences.
+    text = re.sub(r"^```(?:markdown)?\n", "", text)
+    text = re.sub(r"\n```\s*$", "", text)
+
+    if len(text) < 200 or len(text) > 2000:
+        print(f"  ! {category}/{universe}: length out of bounds ({len(text)} chars)")
+        return None
+    if "|" not in text or text.count("|") < 6:
+        print(f"  ! {category}/{universe}: does not look like a table")
+        return None
+    return text.strip()
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="JSON output path (a list of {id, text, topic, category} rows)",
+    )
+    p.add_argument("--per-category", type=int, default=5)
+    p.add_argument("--model", default="gemini-2.0-flash")
+    p.add_argument("--seed", type=int, default=17)
+    args = p.parse_args()
+
+    from google import genai
+
+    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not key:
+        raise SystemExit("set GEMINI_API_KEY or GOOGLE_API_KEY")
+    client = genai.Client(api_key=key)
+
+    random.seed(args.seed)
+    rows = []
+    for category in CATEGORIES:
+        chosen = random.sample(UNIVERSES, args.per_category)
+        for universe in chosen:
+            print(f"- generating {category}/{universe} ...", flush=True)
+            text = _generate_one(client, args.model, category, universe)
+            if text is None:
+                continue
+            rows.append({
+                "id": f"md_noise_{category}_{len(rows):02d}",
+                "topic": "noise",
+                "category": category,
+                "universe": universe,
+                "text": text,
+            })
+            time.sleep(0.2)  # gentle rate-limit guard
+
+    args.out.write_text(json.dumps(rows, indent=2, ensure_ascii=False))
+    print(
+        f"\nSaved {len(rows)} samples to {args.out} "
+        f"(categories: {sorted({r['category'] for r in rows})})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/data/markdown_noise_v6.json
+++ b/experiments/data/markdown_noise_v6.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": "md_noise_schedule_00",
+    "topic": "noise",
+    "category": "schedule",
+    "universe": "arts foundation grants office",
+    "text": "# Grant Application Review Schedule - Fall 2024\n\nThis is the rotating schedule for initial application review. Reviewers are responsible for reading assigned applications and providing a brief summary and rating (High, Medium, Low) based on alignment with the foundation's artistic goals and criteria.\n\n| Week      | Reviewer 1         | Reviewer 2      | Reviewer 3     |\n| ----------- | ----------- | ----------- | ----------- |\n| Oct 21-25   | Amelia Chen      | David Rossi   | Elena Silva   |\n| Oct 28-Nov 1 | Ben Carter      | Amelia Chen    | David Rossi |\n| Nov 4-8    | Felicity Ito    | Ben Carter    | Amelia Chen  |\n| Nov 11-15 | David Rossi | Felicity Ito | Ben Carter |\n| Nov 18-22 | Elena Silva  | David Rossi | Felicity Ito |\n| Nov 25-29   | Amelia Chen      | Elena Silva   | David Rossi   |"
+  },
+  {
+    "id": "md_noise_schedule_01",
+    "topic": "noise",
+    "category": "schedule",
+    "universe": "music festival production crew",
+    "text": "# Stagehand Schedule: Weekend 2\n\nHere's the upcoming stagehand crew schedule for Weekend 2 of the festival.\n\n| Time          | Stage     | Task               | Crew Lead  |\n|---------------|-----------|--------------------|------------|\n| Fri 14:00-18:00 | Main      | Set Dressing       | Maya       |\n| Fri 18:00-22:00 | Indie Tent| Lights Check       | Kenji      |\n| Sat 08:00-12:00 | Main      | Band Load-in       | Liam       |\n| Sat 12:00-16:00 | Side Stage| Monitor Setup      | Anya       |\n| Sun 10:00-14:00 | Main      | Instrument Tuning  | Liam       |\n| Sun 14:00-18:00 | Indie Tent| Stage Breakdown    | Kenji      |"
+  },
+  {
+    "id": "md_noise_schedule_02",
+    "topic": "noise",
+    "category": "schedule",
+    "universe": "university research lab",
+    "text": "# BioSim Lab - Microscope Booking (Week of Oct 23, 2024)\n\nUpcoming microscope slots for the week. Please ensure samples are prepared beforehand. Contact [lab manager email] with questions.\n\n| Date      | Time          | Microscope       | User          |\n|-----------|---------------|-------------------|---------------|\n| Oct 23    | 9:00 - 12:00   | Confocal Zeiss 880 | Alice B.    |\n| Oct 23    | 14:00 - 17:00  | Widefield Olympus  | Bob C.      |\n| Oct 24    | 10:00 - 13:00  | Confocal Zeiss 880 | Carol D.    |\n| Oct 24    | 14:00 - 17:00  | Inverted Nikon Ti | David E.    |\n| Oct 25    | 9:00 - 12:00   | Widefield Olympus  | Alice B.    |\n| Oct 25    | 13:00 - 16:00  | Confocal Zeiss 880 | Frank G.    |\n\nPlease remember to clean the objective lenses after use. Log sheets are beside each microscope."
+  },
+  {
+    "id": "md_noise_schedule_03",
+    "topic": "noise",
+    "category": "schedule",
+    "universe": "veterinary clinic chain",
+    "text": "# MedVet Clinic - Weekend Vaccination Roster\n\nUpcoming weekend vaccination clinic staffing. Please ensure coverage during your assigned slot. Contact Scheduling if you need to swap.\n\n| Date       | Time Slot     | Vet On Duty   | Tech Support    |\n|------------|---------------|----------------|-----------------|\n| 2024-07-20 | 9:00 - 13:00  | Dr. Emily Carter | Sarah Miller    |\n| 2024-07-20 | 13:00 - 17:00 | Dr. Ben Nguyen  | David Lee       |\n| 2024-07-21 | 9:00 - 13:00  | Dr. Anna Patel   | Maria Rodriguez |\n| 2024-07-21 | 13:00 - 17:00 | Dr. Emily Carter | John Smith      |"
+  },
+  {
+    "id": "md_noise_schedule_04",
+    "topic": "noise",
+    "category": "schedule",
+    "universe": "neighbourhood clinic network",
+    "text": "# Clinic Network On-Call Schedule: Week of October 26, 2024\n\n| Day       | Primary Doctor      | Backup Doctor      | Nurse Coordinator    |\n|-----------|-----------------------|----------------------|-----------------------|\n| Monday    | Dr. Ramirez          | Dr. Chen           | Sarah Miller, RN      |\n| Tuesday   | Dr. Chen             | Dr. Jones          | David Lee, RN         |\n| Wednesday | Dr. Jones            | Dr. Ramirez          | Sarah Miller, RN      |\n| Thursday  | Dr. Ramirez          | Dr. Chen           | David Lee, RN         |\n| Friday    | Dr. Chen             | Dr. Jones          | Sarah Miller, RN      |\n\nNotes: Please ensure pagers are charged and accessible. Contact numbers are available on the shared drive. Any shift swaps must be communicated to all listed parties and the clinic administrator."
+  },
+  {
+    "id": "md_noise_status_snapshot_05",
+    "topic": "noise",
+    "category": "status_snapshot",
+    "universe": "urban planning office",
+    "text": "# Daily Land Use Report - October 26, 2023\n\nHere's a summary of zoning application progress and inspection completion rates:\n\n| Application Type | Received Today | Approved Today | Pending Review |\n|-------------------|-----------------|------------------|---------------|\n| Residential       | 12              | 8                | 35            |\n| Commercial        | 5               | 2                | 18            |\n| Industrial        | 2               | 1                | 7             |\n\nCurrent Inspection Completion: 87% of inspections scheduled today are complete, with the remaining scheduled for completion by end of day. Rescheduling is rare.\n\nBelow is the list of the scheduled inspections for tomorrow:\n\n| Address                | Type        | Priority | Status         |\n| ---------------------- | ----------- | -------- | -------------- |\n| 123 Main St            | Residential | High     | Scheduled      |\n| 456 Oak Ave            | Commercial  | Medium   | Scheduled      |\n| 789 Pine Ln            | Industrial  | High     | Scheduled      |\n| 101 Elm St             | Residential | Low      | Scheduled      |"
+  },
+  {
+    "id": "md_noise_status_snapshot_06",
+    "topic": "noise",
+    "category": "status_snapshot",
+    "universe": "arts foundation grants office",
+    "text": "Arts Foundation Grant Pipeline - Week 34\n\n| Grant Type | Applications Received | Applications Assigned | Applications Under Review |\n|---|---|---|---|\n| Visual Arts | 17 | 17 | 8 |\n| Performing Arts | 22 | 22 | 15 |\n| Literary Arts | 11 | 11 | 6 |\n| Community Arts | 8 | 8 | 4 |\n\n**Reviewer Load**\n\nReviewers have 3-5 applications each. No reviewers exceed the maximum allocation limit of 5 applications currently. All applications assigned before the end of Week 33 now have reviewer assignments. Automated assignment continues.\n\n**System Status**\n\nThe grant portal is operating normally. No outages reported. The automated assignment script ran successfully each night."
+  },
+  {
+    "id": "md_noise_status_snapshot_07",
+    "topic": "noise",
+    "category": "status_snapshot",
+    "universe": "university research lab",
+    "text": "## Lab Server Status - 2024-10-27\n\n| Server Name | CPU Load (%) | Memory Usage (%) | Disk Usage (%) | Status |\n|---|---|---|---|---|\n| NeuronSim-01 | 12 | 65 | 32 | Online |\n| SpikeAnalysis-02 | 85 | 92 | 88 | Warning |\n| GenomeAlign-03 | 4 | 15 | 7 | Online |\n| ProteinFold-04 | 67 | 70 | 55 | Online |\n| DataArchive-01 | 2 | 5 | 95 | Critical |\n\nSpikeAnalysis-02 CPU and memory usage are high; check running processes. DataArchive-01 disk usage is critical, free up space. All other servers within nominal operating parameters. Log files are being rotated regularly."
+  },
+  {
+    "id": "md_noise_status_snapshot_08",
+    "topic": "noise",
+    "category": "status_snapshot",
+    "universe": "public library system",
+    "text": "# Branch Status: 2024-02-29\n\n| Branch | Open Hours | Patron Count | WiFi Uptime (%) | PC Availability (%) |\n|---|---|---|---|---|\n| Central | 10 | 357 | 99.8 | 95 |\n| Westside | 10 | 289 | 99.5 | 88 |\n| Downtown | 8 | 195 | 100 | 72 |\n| North End | 6 | 112 | 98.9 | 99 |\n| Eastgate | 10 | 312 | 99.9 | 91 |\n\nAutomated hourly updates show branch traffic and key systems performance. No action required unless metrics consistently fall below thresholds specified in policy LIB-POL-007. WiFi and PC availability are monitored by networked monitoring software (Zabbix). Patron counts are estimated via entry turnstile data."
+  },
+  {
+    "id": "md_noise_status_snapshot_09",
+    "topic": "noise",
+    "category": "status_snapshot",
+    "universe": "maritime logistics company",
+    "text": "# Container Yard Utilization - Weekly Snapshot\n\nHere's a quick snapshot of container yard utilization across our key port locations as of 2024-10-27. Numbers represent current container counts and percentages of maximum capacity.\n\n| Port      | Inbound Containers | Outbound Containers | Total Utilization |\n| --------- | ------------------ | ------------------- | ----------------- |\n| Rotterdam | 4520               | 3980                | 85%               |\n| Shanghai  | 6110               | 5890                | 92%               |\n| Long Beach| 3250               | 2800                | 75%               |\n| Singapore | 5280               | 4720                | 88%               |\n\nAll locations are operating within acceptable limits. No immediate capacity concerns."
+  },
+  {
+    "id": "md_noise_toc_10",
+    "topic": "noise",
+    "category": "toc",
+    "universe": "renewable energy co-op",
+    "text": "## Renewable Energy Co-op Documentation\n\n| Section               | Page |\n|-----------------------|------|\n| 1. Intro               | 1    |\n| 2. Meeting Schedule     | 2    |\n| 3. Vendor Contact Info | 3    |\n| 4. Project Updates     | 4    |\n\n### Vendor Contract Details\n\n| Vendor Name         | Contact Person | Phone         | Email                     | Notes          |\n|----------------------|----------------|---------------|---------------------------|----------------|\n| Solar Solutions Inc. | Jane Doe       | 555-123-4567  | jane.doe@solar.com        | Panel supplier |\n| Wind Power Gen   | John Smith      | 555-987-6543  | john.smith@wind.com       | Turbine maint  |\n| Grid Connect Ltd.  | Alice Brown      | 555-246-8013  | alice.brown@grid.com      | Grid services  |\n| Hydro Dynamics      | Bob White       | 555-369-1215  | bob.white@hydro.com       | Micro hydro   |\n\nMonthly meetings are held on the first Tuesday of the month at 7 PM. Agendas are distributed one week prior. All members are expected to review the agenda beforehand. Project update summaries are posted to the internal wiki on the last day of each month. New vendor onboarding follows the standard checklist. IT help desk is available for password resets."
+  },
+  {
+    "id": "md_noise_toc_11",
+    "topic": "noise",
+    "category": "toc",
+    "universe": "music festival production crew",
+    "text": "# Stagehand Runbook\n\n| Section                                   | Page |\n| ----------------------------------------- | ---- |\n| Daily Schedule Overview                    | 1    |\n| Sound Check Procedures                    | 2    |\n| Band Hospitality Rider Checklist          | 3    |\n| Emergency Contact Information              | 4    |\n\n## Page 1: Daily Schedule Overview\n\n## Page 2: Sound Check Procedures\n\n## Page 3: Band Hospitality Rider Checklist\n\nRider Item Checklist\n\n| Item                  | Quantity | Status    | Notes                                 |\n|-----------------------|----------|-----------|---------------------------------------|\n| Bottled Water        | 24       | Delivered | Dasani, per rider                    |\n| Craft Service Platter | 1        | Delivered | Vegan options confirmed              |\n| Towels                | 4        | Delivered | Black, hand towels                    |\n| Local Beer (IPA)       | 12       | Delivered | \"Hop Riot\" specified, got it locally |\n| Fruit Bowl            | 1        | Delivered | Assorted, seasonal                     |\n\n## Page 4: Emergency Contact Information"
+  },
+  {
+    "id": "md_noise_toc_12",
+    "topic": "noise",
+    "category": "toc",
+    "universe": "regional airline cargo ops",
+    "text": "# Table of Contents\n\n| Section           | Page |\n|-------------------|------|\n| Daily Flight Schedule | 1    |\n| Cargo Manifest Updates | 2    |\n| Maintenance Log    | 3    |\n\n## Page 1: Daily Flight Schedule\n\n| Flight # | Origin | Destination | Departure | Arrival |\n|----------|--------|-------------|-----------|---------|\n| AX101    | SEA    | PDX         | 06:00 PST | 07:00 PST|\n| AX102    | PDX    | SFO         | 07:30 PST | 09:00 PST|\n| AX103    | SFO    | LAX         | 09:30 PST | 11:00 PST|\n\n## Page 2: Cargo Manifest Updates\n\nManifest data for flights AX101 - AX103 updated at 05:30 PST. Load weights within acceptable limits. No hazardous materials reported.\n\n## Page 3: Maintenance Log\n\nRoutine pre-flight checks completed on all aircraft assigned to today's schedule. Tire pressures nominal. Avionics self-tests passed. Ground crew refueled all aircraft. Aircraft cleaning in progress."
+  },
+  {
+    "id": "md_noise_toc_13",
+    "topic": "noise",
+    "category": "toc",
+    "universe": "university research lab",
+    "text": "# Lab Notebook: Index\n\n| Section                       | Page |\n| ----------------------------- | ---- |\n| Protocol Updates              | 1    |\n| Equipment Calibration Logs    | 2    |\n| Reagent Inventory             | 3    |\n| Meeting Reminders             | 4    |\n\n## Page 3: Reagent Inventory\n\nCurrent Stock Levels:\n\n| Reagent      | Lot Number | Expiration Date | Location | Quantity (mL) |\n|--------------|------------|-----------------|----------|---------------|\n| Antibody A   | L1234      | 2024-12-31      | Freezer 1| 5             |\n| Buffer X     | B5678      | 2025-03-15      | Shelf 2  | 100           |\n| Inhibitor Z  | I9012      | 2024-11-01      | Freezer 2| 2             |\n| Compound Y   | C3456      | 2025-06-30      | Shelf 3  | 25            |\n| Media Supplement | M7890 | 2026-01-15      | Fridge | 50 |"
+  },
+  {
+    "id": "md_noise_toc_14",
+    "topic": "noise",
+    "category": "toc",
+    "universe": "veterinary clinic chain",
+    "text": "## Table of Contents\n\n| Section                      | Page |\n|-------------------------------|------|\n| New Client Onboarding Process | 1    |\n| Weekly Staff Schedule         | 2    |\n| Supply Re-Order Levels        | 3    |\n\n### New Client Onboarding Process\nFill out forms, confirm reminders, give tour.\n\n### Weekly Staff Schedule\n\nThis week's schedule assignments:\n\n| Employee | Monday    | Tuesday   | Wednesday | Thursday  | Friday    |\n|----------|-----------|-----------|-----------|-----------|-----------|\n| Dr. Lee  | Surgery   | Exams     | Surgery   | Exams     | Surgery   |\n| Ash     | Reception | Reception | Reception | Reception | Reception |\n| Ben      | Tech      | Tech      | Tech      | Tech      | Tech      |\n\n### Supply Re-Order Levels\n\nReordering needs for the next stock are determined by usage analysis and a set minimum inventory level.\nA request is generated if any items fall below set thresholds, and automatically approved by a supervisor.\nThe following are common minimums:\n\n| Item              | Minimum Level | Units  |\n|-------------------|---------------|--------|\n| Exam Gloves       | 500           | Pair   |\n| Syringes (3cc)    | 200           | Each   |\n| Antibiotic Pills | 1000          | Tablet |\n| Bandages          | 300           | Roll   |"
+  },
+  {
+    "id": "md_noise_pricing_15",
+    "topic": "noise",
+    "category": "pricing",
+    "universe": "regional airline cargo ops",
+    "text": "## Cargo Rates - Preliminary\n\nThese are preliminary cargo rate estimates for different zones and priority levels, in USD per kg. These are subject to change.\n\n| Zone  | Priority | Rate/kg | Surcharge (Hazmat) | Est. Transit (hrs) |\n|-------|----------|---------|--------------------|----------------------|\n| Zone A| Standard | $0.75   | $0.20              | 48-72                |\n| Zone A| Express  | $1.25   | $0.20              | 24-36                |\n| Zone B| Standard | $1.00   | $0.30              | 72-96                |\n| Zone B| Express  | $1.75   | $0.30              | 36-48                |\n| Zone C| Standard | $1.50   | $0.40              | 96-120               |\n| Zone C| Express  | $2.50   | $0.40              | 48-60                |"
+  },
+  {
+    "id": "md_noise_pricing_16",
+    "topic": "noise",
+    "category": "pricing",
+    "universe": "archival digitization project",
+    "text": "# Archival Digitization Project - Pricing Estimates\n\nThese are potential vendors and their associated pricing tiers for scanning services. All prices are estimates and subject to change. This is purely informational.\n\n## Scanning Vendor Pricing (USD)\n\n| Vendor | Basic Scan (per page) | Enhanced Scan (per page) | OCR/Indexing (per page) |\n|---|---|---|---|\n| DigitizePro | $0.10 | $0.25 | $0.05 |\n| Archival Solutions | $0.12 | $0.30 | $0.07 |\n| ScanMasters | $0.09 | $0.22 | $0.04 |\n| FutureArchive | $0.15 | $0.35 | $0.10 |\n\n## Notes\n\n*   Basic Scan includes standard resolution scanning.\n*   Enhanced Scan includes higher resolution scanning, color correction, and minor damage repair.\n*   OCR/Indexing includes optical character recognition and creation of searchable PDFs. These prices are based on publicly available price sheets."
+  },
+  {
+    "id": "md_noise_pricing_17",
+    "topic": "noise",
+    "category": "pricing",
+    "universe": "music festival production crew",
+    "text": "## Stagehand Rates\n\nCurrent hourly rates for the various stagehand positions. These are ballpark figures; actual rates can vary slightly based on experience and union agreements.\n\n| Position        | Base Rate | Overtime (After 8 hrs) | Weekend Rate |\n|-----------------|-----------|-------------------------|--------------|\n| Stagehand       | $25/hr    | $37.50/hr              | $50/hr      |\n| Lighting Tech   | $30/hr    | $45/hr                 | $60/hr      |\n| Audio Engineer  | $35/hr    | $52.50/hr              | $70/hr      |\n| Rigger          | $40/hr    | $60/hr                 | $80/hr      |\n| Carpenter       | $30/hr    | $45/hr                 | $60/hr      |\n\nEquipment rental cost ranges, per day.\n\n| Equipment       | Low End   | High End  |\n|-----------------|-----------|-----------|\n| PA System       | $500      | $2000     |\n| Lighting Rig    | $300      | $1500     |\n| Stage Decking   | $100      | $500      |"
+  },
+  {
+    "id": "md_noise_pricing_18",
+    "topic": "noise",
+    "category": "pricing",
+    "universe": "urban planning office",
+    "text": "## Zoning Permit Fees - Proposed\n\nHere's the draft schedule.\n\n| Zone   | Type          | Area (sq ft) | Cost  | Review Time (days) |\n| :------ | :------------ | :------------ | :---- | :----------------- |\n| R-1    | Single Family | <2000         | $50   | 5                   |\n| R-1    | Single Family | 2000-4000     | $100  | 7                   |\n| C-1    | Commercial    | <5000         | $200  | 10                  |\n| C-1    | Commercial    | 5000+         | $500  | 15                  |\n| M-1    | Industrial    | Any           | $1000 | 20                  |\n| AG-1   | Agricultural  | Any           | $25   | 3                   |\n\nThese are projected costs for the next fiscal year, subject to council approval. We'll update this sheet with any changes. Just a draft for now."
+  },
+  {
+    "id": "md_noise_pricing_19",
+    "topic": "noise",
+    "category": "pricing",
+    "universe": "maritime logistics company",
+    "text": "# Maritime Logistics Pricing Tiers\n\nHere's a snapshot of potential pricing for various cargo types and destinations. These are example rates only and subject to change.\n\n| Cargo Type | Destination | Price per TEU | Transit Time (Days) |\n|---|---|---|---|\n| Dry Goods | Antwerp | $2500 | 21 |\n| Refrigerated | Rotterdam | $3800 | 18 |\n| Hazardous Materials | Singapore | $4200 | 28 |\n| Automotive Parts | Bremerhaven | $3100 | 24 |\n| Bulk Grain | Constanta | $1900 | 35 |\n\nStandard demurrage charges apply after 7 days at the destination port ($150/day). Fuel surcharges may fluctuate based on current market conditions. Special handling for oversized cargo is priced separately upon request. All prices in USD. Insurance options are available. We utilize an internal container tracking system based on PostgreSQL and Django."
+  },
+  {
+    "id": "md_noise_log_20",
+    "topic": "noise",
+    "category": "log",
+    "universe": "urban planning office",
+    "text": "## Daily Log Digest - Urban Planning Office\n\n| Severity | Source         | Message                                                              |\n| :------- | :------------- | :--------------------------------------------------------------------- |\n| INFO     | BuildingPermit | Permit #2023-UP-4789 submitted for review.                           |\n| WARN     | TrafficModel   | Peak hour congestion exceeds threshold on Elm Street between 8-9 AM. |\n| INFO     | Zoning         | Application for variance received at 14:22.                          |\n| INFO     | PublicComment  | New comment added to the proposed park design.                      |\n| WARN     | GIS Server     | Disk space nearing capacity (85%).                                  |\n\nParking Spot Usage:\n\n| Location       | Total Spots | Spots Used | Spots Available |\n|----------------|-------------|------------|-----------------|\n| City Hall      | 100         | 78         | 22              |\n| Community Center| 50          | 35         | 15              |\n| Library        | 30          | 28         | 2               |"
+  },
+  {
+    "id": "md_noise_log_21",
+    "topic": "noise",
+    "category": "log",
+    "universe": "renewable energy co-op",
+    "text": "## Daily System Status - Green Solutions Co-op - 2024-10-27\n\n| Severity | Source | Message |\n|---|---|---|\n| INFO | WindTurbine-07 | Power output: 1.2 MW |\n| WARN | SolarArray-AZ-1 | Panel temperature exceeds threshold. Derating initiated. |\n| INFO | BatteryBank-02 | Charge level: 98% |\n| INFO | WeatherService | Predicted sunshine hours: 7 |\n| DEBUG | Inverter-GridTie-A | Voltage slightly high - within tolerance. |\n| INFO | DemandResponse | Peak demand exceeded forecast, initiating tiered shedding. |"
+  },
+  {
+    "id": "md_noise_log_22",
+    "topic": "noise",
+    "category": "log",
+    "universe": "archival digitization project",
+    "text": "## Archival Digitization - Daily Log\n\n| Severity | Source       | Message                                                              |\n| :------- | :----------- | :-------------------------------------------------------------------- |\n| INFO     | OCR Processor | Document ID A123 processed successfully.                            |\n| WARN     | Image Server | Low DPI detected for Document ID B456. Recommend re-scanning.       |\n| INFO     | File Storage   | File 'A123_scan.tif' uploaded to archive.                         |\n| DEBUG    | Workflow     | Triggered OCR for Document ID C789.                                 |\n| INFO     | Validation   | Metadata validation passed for Document ID A123.                    |\n\n### System Stats\n\n| Metric         | Value    |\n| :------------- | :------- |\n| CPU Utilization | 35%      |\n| Disk Space Used | 2.3 TB   |\n| Documents Proc | 65 today |\n| Error Rate     | 0.01%    |"
+  },
+  {
+    "id": "md_noise_log_23",
+    "topic": "noise",
+    "category": "log",
+    "universe": "arts foundation grants office",
+    "text": "Arts Foundation Grant System - Routine Log Digest\n\n| Severity | Source       | Message                                                              |\n| -------- | ------------- | --------------------------------------------------------------------- |\n| INFO     | UserAuth      | Successful login: user 'amelia.hernandez'                             |\n| WARN     | PaymentGateway | Transaction declined for Grant ID 2024-003. Insufficient funds.        |\n| INFO     | ApplicationSrv| Grant application 'Sculpting the Void' autosaved.                     |\n| DEBUG    | EmailService  | Email queued: Notification to user 'bjorn.olsen' re: grant deadline. |\n| INFO     | UserAuth      | Successful logout: user 'amelia.hernandez'                            |\n\nGrant Application Activity (Last 24 Hours)\n\n| Grant ID | Status      | Stage         |\n|----------|-------------|---------------|\n| 2024-007 | In Progress | Draft         |\n| 2024-003 | Submitted   | Review        |\n| 2024-012 | In Progress | Budget Upload |\n| 2024-009 | Submitted   | Awaiting Funds |"
+  },
+  {
+    "id": "md_noise_log_24",
+    "topic": "noise",
+    "category": "log",
+    "universe": "regional airline cargo ops",
+    "text": "## Cargo Route Daily Log - 2024-02-29\n\n| Severity | Source        | Message                                     |\n|----------|---------------|---------------------------------------------|\n| INFO     | Ramp Agent 3  | Container A12 secured on flight SR227.      |\n| WARN     | Weight System | Minor discrepancy: Actual weight 1kg > manifest. |\n| INFO     | Load Balancer  | Flight SR228: Optimal load distribution achieved.|\n| INFO     | RFID Scanner  | Pallet X452 scanned at loading dock 7.     |\n| WARN     | Fuel Sensor   | SR229: Increased fuel consumption detected during taxi.|\n| INFO     | Baggage System| Container B11 transferred to connecting flight LR301. |"
+  },
+  {
+    "id": "md_noise_roster_25",
+    "topic": "noise",
+    "category": "roster",
+    "universe": "veterinary clinic chain",
+    "text": "# Regional Veterinary Clinic Team Roster\n\nHere's the current contact list for our regional support team.\n\n| Name          | Role                         | Contact Email           |\n|---------------|------------------------------|--------------------------|\n| Dr. Anya Sharma  | Regional Medical Director   | a.sharma@vetcare.com     |\n| Ben Carter    | Clinic Operations Manager   | b.carter@vetcare.com    |\n| Carol Davies   | Client Services Coordinator| c.davies@vetcare.com    |\n| David Evans   | HR Generalist               | d.evans@vetcare.com     |\n| Emily Flores | Marketing Specialist        | e.flores@vetcare.com   |"
+  },
+  {
+    "id": "md_noise_roster_26",
+    "topic": "noise",
+    "category": "roster",
+    "universe": "arts foundation grants office",
+    "text": "## Grants Review Committee - Spring 2024\n\nHere's the current roster for the Spring 2024 grant review committee. Please reach out to individuals directly with any questions relevant to their role.\n\n| Name           | Role             | Contact                | Area of Expertise   |\n|----------------|-------------------|------------------------|----------------------|\n| Alice Chen     | Visual Arts Lead  | alice.chen@artfound.org| Painting, Sculpture|\n| Bob Davis      | Literary Arts      | bob.davis@artfound.org  | Poetry, Non-Fiction |\n| Carol Evans    | Performing Arts   | carol.evans@artfound.org| Dance, Theatre     |\n| David Flores   | New Media Arts    | david.flores@artfound.org| Digital Art, Film   |\n| Emily Garcia  | Community Arts Liaison  | emily.garcia@artfound.org| Public Art, Outreach |"
+  },
+  {
+    "id": "md_noise_roster_27",
+    "topic": "noise",
+    "category": "roster",
+    "universe": "public library system",
+    "text": "# West Branch Library - Volunteers Committee\n\nHere's the current roster of volunteers serving on the West Branch's Volunteers Committee.\n\n| Name          | Role               | Contact                | Background                                |\n|---------------|--------------------|------------------------|-------------------------------------------|\n| Alice Chen    | Committee Chair    | alice.chen@email.org   | Retired Teacher                            |\n| Bob Davis     | Secretary          | bob.davis@email.net    | Local Business Owner                      |\n| Carol Evans   | Recruitment Lead   | carol.evans@email.com  | Community Organizer                      |\n| David Foster  | Training Coordinator| david.foster@email.gov | Former Librarian (another branch)        |\n| Emily Garcia  | Event Support      | emily.garcia@email.edu | High School Student Volunteer            |"
+  },
+  {
+    "id": "md_noise_roster_28",
+    "topic": "noise",
+    "category": "roster",
+    "universe": "neighbourhood clinic network",
+    "text": "# Clinic Network Roster - Q3 2024\n\nHere's the current team roster for the Tri-County Community Clinic Network. Please reach out to the appropriate contact for any questions or assistance.\n\n| Name           | Role                      | Contact              | Notes                                     |\n|----------------|---------------------------|-----------------------|-------------------------------------------|\n| Anya Sharma    | Network Coordinator        | anya.sharma@tcc.org    | Main point of contact for general inquiries |\n| Ben Carter     | Data Analytics Specialist | ben.carter@tcc.org     | Reporting, dashboard maintenance          |\n| Chloe Davis    | Community Outreach Lead   | chloe.davis@tcc.org    | Event planning, volunteer management      |\n| David Evans   | IT Support               | david.evans@tcc.org    | Hardware, software, network issues         |\n\nAll personnel are available during standard business hours, Monday-Friday, 9 AM - 5 PM. After hours support requests should be directed to the general clinic line."
+  },
+  {
+    "id": "md_noise_roster_29",
+    "topic": "noise",
+    "category": "roster",
+    "universe": "university research lab",
+    "text": "# Neuroimaging Lab Team Roster\n\n## Contact Information\n\n| Name          | Role               | Contact Email          | Slack Handle |\n|---------------|--------------------|------------------------|--------------|\n| Dr. Anya Sharma| Principal Investigator| anya.sharma@uni.edu    | @dr_sharma    |\n| Ben Carter     | Research Assistant   | ben.carter@uni.edu     | @bcarter     |\n| Chloe Davis    | PhD Candidate      | chloe.davis@uni.edu    | @chlo_davis   |\n| David Lee      | Lab Technician     | david.lee@uni.edu      | @dlee        |\n| Emily Flores   | Postdoctoral Fellow| emily.flores@uni.edu   | @eflores     |"
+  }
+]

--- a/merken/__init__.py
+++ b/merken/__init__.py
@@ -13,6 +13,7 @@ from merken.consolidation import ConsolidationResult, Fact
 from merken.memory import ForgetResult, Memory, RememberResult
 from merken.policies import (
     AlwaysWrite,
+    ChainedWriteDecider,
     ConsolidateContext,
     ConsolidateDecider,
     ConsolidationDecision,
@@ -43,6 +44,7 @@ from merken.policies import (
 __version__ = "0.1.0"
 __all__ = [
     "AlwaysWrite",
+    "ChainedWriteDecider",
     "ContentTypePriorDecider",
     "ConsolidateContext",
     "ConsolidateDecider",

--- a/merken/_shadow.py
+++ b/merken/_shadow.py
@@ -1,27 +1,43 @@
-"""Env-var shadow-mode wiring.
+"""Env-var activation for shadow mode and graduation.
 
-If ``MERKEN_SHADOW`` is set, ``Memory`` auto-wraps its default decider
-in a ``ShadowWriteDecider`` whose secondary is constructed from the
-other ``MERKEN_SHADOW_*`` vars. This lets CLI, MCP, and SDK consumers
-opt into shadow mode with zero code changes.
+Two roles for a classifier (nanoGPT / LLM) via env:
+
+- ``MERKEN_SHADOW=nanogpt|llm`` -- auditing-only. The default
+  ``HeuristicWriteDecider`` stays primary and controls writes; the
+  classifier only annotates the audit reason with its prediction and
+  an agree/disagree tag. Bootstrap mode.
+
+- ``MERKEN_PRIMARY=nanogpt|llm`` -- graduation. The classifier becomes
+  authoritative, chained *after* ``HeuristicWriteDecider`` so that the
+  hygiene gates (empty, too-short, too-long, exact-dup) still fire
+  before the classifier sees the event. Only use this once the shadow
+  logs + oracular labels have shown the classifier beats the gate-only
+  baseline on held-out content.
+
+Only one of ``MERKEN_SHADOW`` / ``MERKEN_PRIMARY`` should be set at a
+time. If both are set the primary role wins (ignores SHADOW) -- a
+deliberately conservative tie-breaker: whoever typed ``PRIMARY`` meant
+it.
 
 Torch is imported **at module evaluation** (not inside a function) when
-shadow is enabled, so that ``from merken import ...`` causes torch to
-load BEFORE vstash/fastembed. That's the Mistake #10 order requirement
-(notes/nanogpt-training-log.md): the first native library to load wins
-the macOS process; later ones can segfault. Keep this module as the
-first import in ``merken/__init__.py``.
+either role is enabled, so that ``from merken import ...`` causes torch
+to load BEFORE vstash/fastembed. That's the Mistake #10 order
+requirement (notes/nanogpt-training-log.md): the first native library
+to load wins the macOS process; later ones can segfault. Keep this
+module as the first import in ``merken/__init__.py``.
 
-Supported env vars:
+Supported backends (shared between SHADOW and PRIMARY):
 
-- ``MERKEN_SHADOW=nanogpt``
-    + ``MERKEN_SHADOW_NANOGPT_CKPT=/path/to/ckpt.pt``
-    + ``MERKEN_SHADOW_NANOGPT_META=/path/to/meta.pkl``
-- ``MERKEN_SHADOW=llm``
-    + ``MERKEN_SHADOW_LLM_MODEL=google/gemma-3-270m-it`` (HF id or local path)
-    + ``MERKEN_SHADOW_LLM_DEVICE=cpu`` (optional, default ``cpu``)
+- ``nanogpt``
+    + ``MERKEN_<role>_NANOGPT_CKPT=/path/to/ckpt.pt``
+    + ``MERKEN_<role>_NANOGPT_META=/path/to/meta.pkl``
+- ``llm``
+    + ``MERKEN_<role>_LLM_MODEL=google/gemma-3-270m-it``
+    + ``MERKEN_<role>_LLM_DEVICE=cpu`` (optional, default ``cpu``)
 
-Anything else (empty / unset / unknown) -> shadow disabled.
+where ``<role>`` is ``SHADOW`` or ``PRIMARY``.
+
+Anything else (empty / unset / unknown) -> no classifier wired.
 """
 
 from __future__ import annotations
@@ -29,41 +45,66 @@ from __future__ import annotations
 import os
 
 _ENABLED_VALUES = {"nanogpt", "llm"}
-_KIND = os.environ.get("MERKEN_SHADOW", "").strip().lower()
+_SHADOW_KIND = os.environ.get("MERKEN_SHADOW", "").strip().lower()
+_PRIMARY_KIND = os.environ.get("MERKEN_PRIMARY", "").strip().lower()
 
-# Eagerly import torch if shadow is enabled. This must happen before any
-# other merken module that transitively imports vstash (fastembed/ONNX)
-# -- see notes/nanogpt-training-log.md Mistake #10.
-if _KIND in _ENABLED_VALUES:
+# Eagerly import torch if either role is enabled. This must happen
+# before any other merken module that transitively imports vstash
+# (fastembed/ONNX). See notes/nanogpt-training-log.md Mistake #10.
+if _SHADOW_KIND in _ENABLED_VALUES or _PRIMARY_KIND in _ENABLED_VALUES:
     import torch  # noqa: F401
 
 
-def load_shadow_from_env():
-    """Return a shadow ``WriteDecider`` constructed from env, or ``None``."""
-    if _KIND not in _ENABLED_VALUES:
-        return None
-
-    if _KIND == "nanogpt":
+def _build_classifier(kind: str, role: str):
+    """Construct the classifier for ``role`` (``SHADOW`` / ``PRIMARY``)."""
+    if kind == "nanogpt":
         from merken.classifiers.nanogpt import NanoGPTWriteDecider
 
-        ckpt = os.environ.get("MERKEN_SHADOW_NANOGPT_CKPT")
-        meta = os.environ.get("MERKEN_SHADOW_NANOGPT_META")
+        ckpt = os.environ.get(f"MERKEN_{role}_NANOGPT_CKPT")
+        meta = os.environ.get(f"MERKEN_{role}_NANOGPT_META")
         if not (ckpt and meta):
             raise RuntimeError(
-                "MERKEN_SHADOW=nanogpt requires MERKEN_SHADOW_NANOGPT_CKPT "
-                "and MERKEN_SHADOW_NANOGPT_META env vars."
+                f"MERKEN_{role}=nanogpt requires MERKEN_{role}_NANOGPT_CKPT "
+                f"and MERKEN_{role}_NANOGPT_META env vars."
             )
         return NanoGPTWriteDecider(ckpt, meta)
 
-    if _KIND == "llm":
+    if kind == "llm":
         from merken.classifiers.llm import LLMWriteDecider
 
-        model = os.environ.get("MERKEN_SHADOW_LLM_MODEL")
+        model = os.environ.get(f"MERKEN_{role}_LLM_MODEL")
         if not model:
             raise RuntimeError(
-                "MERKEN_SHADOW=llm requires MERKEN_SHADOW_LLM_MODEL env var."
+                f"MERKEN_{role}=llm requires MERKEN_{role}_LLM_MODEL env var."
             )
-        device = os.environ.get("MERKEN_SHADOW_LLM_DEVICE", "cpu")
+        device = os.environ.get(f"MERKEN_{role}_LLM_DEVICE", "cpu")
         return LLMWriteDecider(model_name=model, device=device)
 
-    return None
+    raise RuntimeError(f"unknown MERKEN_{role} backend: {kind!r}")
+
+
+def load_shadow_from_env():
+    """Return a shadow ``WriteDecider`` constructed from env, or ``None``.
+
+    Only returns a classifier when ``MERKEN_SHADOW`` is set AND
+    ``MERKEN_PRIMARY`` is NOT set. When PRIMARY wins, there is no
+    "shadow" decider -- graduation mode is strictly about putting the
+    classifier on the write path.
+    """
+    if _PRIMARY_KIND in _ENABLED_VALUES:
+        return None
+    if _SHADOW_KIND not in _ENABLED_VALUES:
+        return None
+    return _build_classifier(_SHADOW_KIND, "SHADOW")
+
+
+def load_primary_from_env():
+    """Return the graduated classifier constructed from env, or ``None``.
+
+    When this returns a non-None value, ``Memory`` will chain it AFTER
+    a ``HeuristicWriteDecider`` gate so hygiene rules still fire, and
+    will NOT wrap it in shadow mode.
+    """
+    if _PRIMARY_KIND not in _ENABLED_VALUES:
+        return None
+    return _build_classifier(_PRIMARY_KIND, "PRIMARY")

--- a/merken/memory.py
+++ b/merken/memory.py
@@ -61,6 +61,7 @@ from merken.policies.should_recall import (
     RecallPlan,
 )
 from merken.policies.should_remember import (
+    ChainedWriteDecider,
     HeuristicWriteDecider,
     ShadowWriteDecider,
 )
@@ -74,29 +75,39 @@ DEFAULT_COLLECTION = "default"
 
 
 def _default_write_decider() -> WriteDecider:
-    """Build the write decider, auto-wrapping in shadow mode if env set.
+    """Build the write decider with env-based shadow / primary wiring.
 
-    Env vars are read via ``merken._shadow.load_shadow_from_env``. If no
-    ``MERKEN_SHADOW`` is configured, returns a plain
-    ``HeuristicWriteDecider``. Otherwise wraps it in a
-    ``ShadowWriteDecider`` whose secondary is the env-configured
-    classifier (nanoGPT or LLM). Shadow failures do not block writes;
-    the ShadowWriteDecider catches them per-event.
+    Precedence (MERKEN_PRIMARY wins if both are set -- typing PRIMARY
+    is the more deliberate act):
 
-    If shadow construction itself fails (e.g. missing checkpoint),
-    degrade to the plain default -- the user's writes must not break
-    because an opt-in shadow is misconfigured.
+    1. ``MERKEN_PRIMARY`` set -> ``ChainedWriteDecider(Heuristic, classifier)``.
+       Heuristic keeps hygiene gates; classifier decides write/skip for
+       anything that passes the gates.
+    2. ``MERKEN_SHADOW`` set -> ``ShadowWriteDecider(Heuristic, classifier)``.
+       Heuristic stays authoritative; classifier only annotates the
+       audit reason.
+    3. Neither set (or classifier construction fails) -> plain
+       ``HeuristicWriteDecider()``. An opt-in classifier never blocks
+       writes, even when misconfigured.
     """
-    from merken._shadow import load_shadow_from_env
+    from merken._shadow import load_primary_from_env, load_shadow_from_env
 
-    primary = HeuristicWriteDecider()
+    heuristic = HeuristicWriteDecider()
+
+    try:
+        primary_classifier = load_primary_from_env()
+    except Exception:
+        primary_classifier = None
+    if primary_classifier is not None:
+        return ChainedWriteDecider(heuristic, primary_classifier)
+
     try:
         shadow = load_shadow_from_env()
     except Exception:
-        return primary
+        return heuristic
     if shadow is None:
-        return primary
-    return ShadowWriteDecider(primary, shadow)
+        return heuristic
+    return ShadowWriteDecider(heuristic, shadow)
 
 
 def _resolve_vstash_embed_model(vstash_memory: vstash.Memory) -> str:

--- a/merken/policies/__init__.py
+++ b/merken/policies/__init__.py
@@ -32,6 +32,7 @@ from merken.policies.should_recall import (
 )
 from merken.policies.should_remember import (
     AlwaysWrite,
+    ChainedWriteDecider,
     ContentTypePriorDecider,
     HeuristicWriteDecider,
     ShadowWriteDecider,
@@ -40,6 +41,7 @@ from merken.policies.types import Decision, Event, WriteContext, WriteDecider
 
 __all__ = [
     "AlwaysWrite",
+    "ChainedWriteDecider",
     "ContentTypePriorDecider",
     "ConsolidateContext",
     "ConsolidateDecider",

--- a/merken/policies/should_remember.py
+++ b/merken/policies/should_remember.py
@@ -153,6 +153,70 @@ class HeuristicWriteDecider:
         return Decision(True, "novel", 0.8, self.name)
 
 
+class ChainedWriteDecider:
+    """Run a gate then a classifier. Gate skips short-circuit the chain.
+
+    The graduation path from shadow mode to "classifier-as-primary":
+    we do NOT want to swap the shadow and primary wholesale, because
+    a model-based decider has no dedup state, no empty/too-short
+    checks, and no length guard. Those gates belong to
+    ``HeuristicWriteDecider``.
+
+    Composition:
+
+    - ``gate.decide(event, ctx)`` runs first. If it returns ``write=False``,
+      that decision is returned unchanged -- the classifier never sees
+      an empty/duplicate/too-long event.
+    - If the gate says write, ``classifier.decide`` is called and its
+      result becomes the chain's result. The chain's reason prefixes
+      the classifier's reason with ``gate_ok|`` so audits remain
+      self-describing.
+
+    Hydration: the gate typically needs a hydrate_fn (dedup).
+    ``set_hydrate_fn`` forwards to the gate only.
+
+    When to graduate: use this only AFTER shadow mode + oracular
+    labels have shown the classifier beats the gate-only baseline on
+    held-out organic content AND does not regress on
+    ``markdown_tables_held_out``. See notes/nanogpt-training-log.md
+    for the criteria.
+    """
+
+    def __init__(self, gate, classifier) -> None:
+        self._gate = gate
+        self._classifier = classifier
+        gate_name = getattr(gate, "name", type(gate).__name__)
+        clf_name = getattr(classifier, "name", type(classifier).__name__)
+        self.name = f"Chain({gate_name}->{clf_name})"
+
+    def set_hydrate_fn(
+        self,
+        fn: Callable[[], Iterable[str]],
+    ) -> None:
+        if hasattr(self._gate, "set_hydrate_fn"):
+            self._gate.set_hydrate_fn(fn)
+
+    def decide(self, event: Event, ctx: WriteContext) -> Decision:
+        gate = self._gate.decide(event, ctx)
+        if not gate.write:
+            # Gate rejected. Preserve reason verbatim so audit reads
+            # like "dup_exact" / "too_short:<8" / etc.
+            return Decision(
+                write=False,
+                reason=gate.reason,
+                confidence=gate.confidence,
+                policy=self.name,
+            )
+
+        clf = self._classifier.decide(event, ctx)
+        return Decision(
+            write=clf.write,
+            reason=f"gate_ok|{clf.reason}",
+            confidence=clf.confidence,
+            policy=self.name,
+        )
+
+
 class ShadowWriteDecider:
     """Run two deciders side by side; the primary is authoritative.
 

--- a/tests/test_chained_write_decider.py
+++ b/tests/test_chained_write_decider.py
@@ -1,0 +1,136 @@
+"""Tests for ChainedWriteDecider -- the graduation-mode write path.
+
+Graduation replaces shadow mode's ``Shadow(Heuristic|classifier)`` with
+``Chain(Heuristic -> classifier)``. The chain short-circuits on
+gate-skip so the classifier never has to learn dedup / length rules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from merken import Memory
+from merken.policies import (
+    ChainedWriteDecider,
+    Decision,
+    Event,
+    HeuristicWriteDecider,
+    WriteContext,
+)
+
+
+class _FixedClassifier:
+    """Minimal classifier double. Always returns the preset decision."""
+
+    def __init__(self, *, write: bool, reason: str, confidence: float = 0.9) -> None:
+        self.name = f"FixedClassifier({reason})"
+        self._write = write
+        self._reason = reason
+        self._confidence = confidence
+
+    def decide(self, event: Event, ctx: WriteContext) -> Decision:  # noqa: ARG002
+        return Decision(self._write, self._reason, self._confidence, self.name)
+
+
+@pytest.fixture
+def ctx() -> WriteContext:
+    return WriteContext(project="test")
+
+
+def test_gate_skip_short_circuits(ctx: WriteContext) -> None:
+    """When Heuristic skips (empty text), the classifier MUST NOT run."""
+    calls: list[str] = []
+
+    class _TracingClassifier:
+        name = "tracing"
+
+        def decide(self, event: Event, ctx: WriteContext) -> Decision:  # noqa: ARG002
+            calls.append(event.text)
+            return Decision(True, "clf_write", 1.0, "tracing")
+
+    chain = ChainedWriteDecider(HeuristicWriteDecider(), _TracingClassifier())
+    d = chain.decide(Event(text=""), ctx)
+
+    assert d.write is False
+    assert d.reason == "empty", "gate reason must be preserved verbatim"
+    assert calls == [], "classifier must not run when the gate skips"
+
+
+def test_gate_ok_delegates_write(ctx: WriteContext) -> None:
+    chain = ChainedWriteDecider(
+        HeuristicWriteDecider(),
+        _FixedClassifier(write=True, reason="clf_novel", confidence=0.77),
+    )
+    d = chain.decide(
+        Event(text="A reasonably long event that passes the gate."), ctx
+    )
+    assert d.write is True
+    assert d.reason.startswith("gate_ok|")
+    assert "clf_novel" in d.reason
+    assert d.confidence == pytest.approx(0.77)
+
+
+def test_gate_ok_honours_classifier_skip(ctx: WriteContext) -> None:
+    """Classifier can still veto a write after the gate lets it through."""
+    chain = ChainedWriteDecider(
+        HeuristicWriteDecider(),
+        _FixedClassifier(write=False, reason="clf_looks_like_noise"),
+    )
+    d = chain.decide(
+        Event(text="A reasonably long event that passes the gate."), ctx
+    )
+    assert d.write is False
+    assert "gate_ok|" in d.reason
+    assert "clf_looks_like_noise" in d.reason
+
+
+def test_hydration_forwards_to_gate(tmp_path: Path) -> None:
+    """The gate's dedup state must still be populated cross-invocation."""
+    gate = HeuristicWriteDecider()
+    chain = ChainedWriteDecider(
+        gate, _FixedClassifier(write=True, reason="clf_novel")
+    )
+    with Memory(
+        project="chain", db=tmp_path / "c.db", write_decider=chain
+    ) as mem:
+        first = mem.remember(
+            "An event that should be written once and then deduped.",
+            title="chain1",
+        )
+        second = mem.remember(
+            "An event that should be written once and then deduped.",
+            title="chain1_dup",
+        )
+
+    assert first.written is True
+    # Dedup should fire in the gate on the second call, short-circuiting
+    # the classifier.
+    assert second.written is False
+    assert second.decision.reason == "dup_exact"
+
+
+def test_env_primary_overrides_shadow(monkeypatch, tmp_path: Path) -> None:
+    """If MERKEN_PRIMARY wins, no ShadowWriteDecider is built.
+
+    We do not have a real nanoGPT ckpt in CI, so we point PRIMARY at a
+    missing path and assert that Memory degrades to plain
+    HeuristicWriteDecider (no chain, no shadow). The behaviour that
+    matters: misconfig must never take writes offline.
+    """
+    monkeypatch.setenv("MERKEN_SHADOW", "nanogpt")  # would otherwise wire
+    monkeypatch.setenv("MERKEN_PRIMARY", "nanogpt")
+    # Omit ckpt paths -> _build_classifier raises -> memory degrades.
+    monkeypatch.delenv("MERKEN_PRIMARY_NANOGPT_CKPT", raising=False)
+    monkeypatch.delenv("MERKEN_PRIMARY_NANOGPT_META", raising=False)
+    monkeypatch.delenv("MERKEN_SHADOW_NANOGPT_CKPT", raising=False)
+    monkeypatch.delenv("MERKEN_SHADOW_NANOGPT_META", raising=False)
+
+    import importlib
+
+    import merken._shadow
+    importlib.reload(merken._shadow)
+
+    with Memory(project="t", db=tmp_path / "e.db") as mem:
+        assert isinstance(mem._write_decider, HeuristicWriteDecider)


### PR DESCRIPTION
## Summary

Two features in one PR because they're the two concrete answers to the "what next" question after the bootstrap loop closed in PRs #1-#4:

1. **Graduation path**: `ChainedWriteDecider(Heuristic, classifier)` and `MERKEN_PRIMARY` env activation. Lets a classifier (nanoGPT / LLM) be put on the write path without losing the hygiene gates (empty / too-short / exact-dup) that the Heuristic provides.

2. **v6 NOISE synthesis**: 30 Gemini-generated markdown-table NOISE samples to fill the distribution hole v5 exposed. Training data committed at `experiments/data/markdown_noise_v6.json`; training config + prepare script live in the nanoGPT sister repo.

## Graduation path details

```
MERKEN_PRIMARY=nanogpt  # classifier on the write path
  + MERKEN_PRIMARY_NANOGPT_CKPT=/path/to/ckpt.pt
  + MERKEN_PRIMARY_NANOGPT_META=/path/to/meta.pkl

MERKEN_PRIMARY=llm      # generic HF LM on the write path
  + MERKEN_PRIMARY_LLM_MODEL=google/gemma-3-270m-it
  + MERKEN_PRIMARY_LLM_DEVICE=cpu
```

Chain semantics:
- Heuristic runs first. Gate-skip reasons (`empty`, `too_short:<8`, `too_long:>N`, `dup_exact`) are returned verbatim and the classifier never runs.
- If Heuristic says write, the classifier decides. Reason prefixes with `gate_ok|` so audits are self-describing.

Precedence: `MERKEN_PRIMARY` wins over `MERKEN_SHADOW` (typing PRIMARY is the more deliberate act). Misconfig still degrades to plain `HeuristicWriteDecider` -- a broken opt-in never takes writes offline.

## v6 NOISE details

`experiments/consolidation/generate_markdown_noise.py` hits Gemini with per-category prompts (schedule / status_snapshot / toc / pricing / log / roster), 5 samples each in 6 domains absent from `markdown_tables_held_out` (maritime logistics, public library, vet clinics, urban planning, archival, music festival, etc.) so the held-out scenario stays an honest generalization test.

Sample count: 30 samples, 200-2000 chars each. All contain at least one markdown table.

Training (in progress in the background, not in this PR): `data/merken_bpe_v6/prepare.py` merges v5 sources + the new 30 samples. Eval results vs v4/v5 on four scenarios (including `markdown_tables_held_out`) will land as a follow-up commit.

## Test plan

- [x] `pytest -q --ignore=tests/test_embed_model_resolution.py` -> 204 passed, 3 deselected (+5 new chain tests).
- [x] `ruff check` clean on all new files.
- [x] 30 Gemini-generated markdown-NOISE samples saved + spot-checked (distribution looks right).