### PR TITLE
feat(labeling): LocalLLMLabelBackend -- offline oracular labeling

### DIFF
--- a/merken/_shadow.py
+++ b/merken/_shadow.py
@@ -47,11 +47,21 @@ import os
 _ENABLED_VALUES = {"nanogpt", "llm"}
 _SHADOW_KIND = os.environ.get("MERKEN_SHADOW", "").strip().lower()
 _PRIMARY_KIND = os.environ.get("MERKEN_PRIMARY", "").strip().lower()
+# Local-oracle labeling also needs torch loaded first (Mistake #10):
+# ``merken audit --label-with local`` constructs an LLMWriteDecider
+# which imports transformers + torch. If vstash has already loaded
+# fastembed, the process segfaults on first model forward.
+_LABEL_LLM_MODEL = os.environ.get("MERKEN_LABEL_LLM_MODEL", "").strip()
 
-# Eagerly import torch if either role is enabled. This must happen
-# before any other merken module that transitively imports vstash
-# (fastembed/ONNX). See notes/nanogpt-training-log.md Mistake #10.
-if _SHADOW_KIND in _ENABLED_VALUES or _PRIMARY_KIND in _ENABLED_VALUES:
+# Eagerly import torch if any role that needs torch is enabled. This
+# must happen before any other merken module that transitively imports
+# vstash (fastembed/ONNX). See notes/nanogpt-training-log.md
+# Mistake #10.
+if (
+    _SHADOW_KIND in _ENABLED_VALUES
+    or _PRIMARY_KIND in _ENABLED_VALUES
+    or _LABEL_LLM_MODEL
+):
     import torch  # noqa: F401
 
 

--- a/merken/cli.py
+++ b/merken/cli.py
@@ -303,10 +303,25 @@ _SHADOW_FLAG_TO_MARKER = {
 
 
 def _build_label_backend(name: str):
-    """Construct a ``LabelBackend`` from a CLI string identifier."""
+    """Construct a ``LabelBackend`` from a CLI string identifier.
+
+    Backends:
+
+    - ``gemini`` -- Gemini 2.0 Flash via the google-genai SDK. Online,
+      fast, rich rationales.
+    - ``local`` -- a local HuggingFace causal LM scored via
+      ``LLMWriteDecider``. Offline; model defaults to
+      ``google/gemma-3-1b-it`` but is overridable via
+      ``MERKEN_LABEL_LLM_MODEL`` (and ``MERKEN_LABEL_LLM_DEVICE``).
+    """
     if name == "gemini":
         from merken.labeling import GeminiLabelBackend
         return GeminiLabelBackend()
+    if name == "local":
+        from merken.labeling import LocalLLMLabelBackend
+        model = os.environ.get("MERKEN_LABEL_LLM_MODEL", "google/gemma-3-1b-it")
+        device = os.environ.get("MERKEN_LABEL_LLM_DEVICE", "cpu")
+        return LocalLLMLabelBackend(model_name=model, device=device)
     raise SystemExit(f"unknown --label-with backend: {name!r}")
 
 
@@ -729,12 +744,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     aud.add_argument(
         "--label-with",
-        choices=("gemini",),
+        choices=("gemini", "local"),
         default=None,
         help=(
-            "run oracular labeling on unlabeled shadow_disagree rows with the "
-            "chosen backend. Labels are stored in the merken_labels "
-            "collection; re-running is safe."
+            "run oracular labeling on unlabeled shadow_disagree rows with "
+            "the chosen backend (gemini: online Flash; local: offline "
+            "HuggingFace model, see MERKEN_LABEL_LLM_MODEL). Labels are "
+            "stored in the merken_labels collection; re-running is safe."
         ),
     )
     aud.add_argument(

--- a/merken/labeling.py
+++ b/merken/labeling.py
@@ -144,6 +144,62 @@ class GeminiLabelBackend:
         return _parse_backend_response(resp.text or "", self.name)
 
 
+class LocalLLMLabelBackend:
+    """Offline label oracle via ``LLMWriteDecider`` under the hood.
+
+    Good when: labeling a batch privately (no API call), or when the
+    caller wants to measure how much of Gemini's signal a local model
+    captures on the same disagreement set. Uses the same chat-template
+    + single-turn few-shot scoring that
+    :class:`merken.classifiers.llm.LLMWriteDecider` uses, so the
+    classifier's production behavior and the oracular comparison stay
+    aligned.
+
+    Rationale is synthesized mechanically from the logit scores --
+    small local LMs are not reliable at producing useful natural-
+    language justifications in a single forward pass, so we trade
+    prose for honesty about what the oracle actually did.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        device: str = "cpu",
+        confidence_threshold: float = 0.5,
+    ) -> None:
+        # Import here so importing merken.labeling does not force
+        # torch + transformers on every CLI invocation.
+        from merken.classifiers.llm import LLMWriteDecider
+
+        self._decider = LLMWriteDecider(
+            model_name=model_name,
+            device=device,
+            confidence_threshold=confidence_threshold,
+        )
+        self.name = f"local-llm:{model_name}"
+
+    def label(self, text: str) -> Label:
+        from merken.policies import Event, WriteContext
+
+        decision = self._decider.decide(
+            Event(text=text), WriteContext(project="labeling")
+        )
+        # Map WriteDecider output onto the oracle schema. Local LLMs
+        # via two-token scoring never emit UNCERTAIN -- the caller can
+        # inspect confidence if they want an uncertainty proxy.
+        kind = "DECISION" if decision.write else "NOISE"
+        return Label(
+            decision=kind,
+            confidence=float(decision.confidence),
+            rationale=(
+                f"local-llm scored {decision.reason}; "
+                f"policy={decision.policy}"
+            ),
+            backend=self.name,
+        )
+
+
 def _shadow_marker(reason: str) -> str | None:
     """Return the shadow marker in a reason string, or None."""
     if "|shadow_" not in reason:

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from merken import AlwaysWrite, Memory, ShadowWriteDecider
 from merken.labeling import (
     Label,
+    LocalLLMLabelBackend,
     _parse_backend_response,
     label_disagreements,
 )
@@ -158,6 +159,50 @@ def test_label_disagreements_error_is_caught(tmp_path: Path) -> None:
         errored = [r for r in results if r[0] == "error"]
         assert len(errored) >= 1
         assert all("RuntimeError" in r[3] for r in errored)
+
+
+def test_local_label_backend_maps_decision(monkeypatch) -> None:
+    """LocalLLMLabelBackend converts WriteDecider output into a Label.
+
+    The backend wraps ``LLMWriteDecider`` and maps its write/skip call
+    onto the DECISION/NOISE oracle schema. We stub the decider so
+    tests stay offline.
+    """
+    from merken.policies import Decision
+
+    calls: list[str] = []
+
+    class _StubDeciderFactory:
+        def __init__(self, *, write: bool, policy: str = "stub-llm") -> None:
+            self._write = write
+            self._policy = policy
+
+        def decide(self, event: Event, ctx: WriteContext) -> Decision:  # noqa: ARG002
+            calls.append(event.text)
+            return Decision(
+                write=self._write,
+                reason="P(D)=0.900 P(N)=0.100 raw_mass=0.950",
+                confidence=0.9,
+                policy=self._policy,
+            )
+
+    # Avoid loading transformers + torch in CI.
+    def _fake_init(self, *, model_name, device="cpu", confidence_threshold=0.5):
+        self._decider = _StubDeciderFactory(write=True)
+        self.name = f"local-llm:{model_name}"
+
+    monkeypatch.setattr(
+        LocalLLMLabelBackend, "__init__", _fake_init
+    )
+
+    backend = LocalLLMLabelBackend(model_name="stub-model")
+    out = backend.label("some event text")
+
+    assert out.decision == "DECISION"
+    assert out.backend == "local-llm:stub-model"
+    assert 0.0 <= out.confidence <= 1.0
+    assert "P(D)=" in out.rationale
+    assert calls == ["some event text"]
 
 
 def test_memory_label_roundtrip(tmp_path: Path) -> None:


### PR DESCRIPTION
Second backend for `merken audit --label-with`: local HuggingFace model (default Gemma 3 1B-IT) via LLMWriteDecider. Privacy, offline, or measuring local-vs-API agreement on the same disagreement set.

Verified end-to-end on live Gemma + shadow_smoke.db. 206 tests pass. See training log for the iteration trail.