### PR TITLE
feat(shadow): MERKEN_<role>_NANOGPT_CALIBRATOR env-var wiring

### DIFF
--- a/experiments/nanogpt/HYPOTHESES.md
+++ b/experiments/nanogpt/HYPOTHESES.md
@@ -129,10 +129,28 @@ and `confidence` field surface the calibrated value.
 - Markdown noise table: raw 0.397 -> cal 0.392. Markdown and short
   cancel; head leaves it roughly where v7 already was.
 
-**Decision taken:** ship as opt-in (`Memory` does not auto-wrap
-yet). Consumers that want it do
-`NanoGPTWriteDecider(..., calibrator=CalibrationHead.from_json(...))`.
-The smoke finding opens H10 (interaction terms).
+**Decision taken:** ship as opt-in. Two ways to enable:
+
+1. Programmatic:
+   ```python
+   head = CalibrationHead.from_json(
+       "merken/classifiers/calibration_v7.json"
+   )
+   decider = NanoGPTWriteDecider(ckpt, meta, calibrator=head)
+   ```
+2. Env-var driven, works with `Memory` without code changes:
+   ```bash
+   export MERKEN_SHADOW=nanogpt
+   export MERKEN_SHADOW_NANOGPT_CKPT=.../ckpt.pt
+   export MERKEN_SHADOW_NANOGPT_META=.../meta.pkl
+   export MERKEN_SHADOW_NANOGPT_CALIBRATOR=default
+   ```
+   Shadow-mode deciders built via `_build_classifier` pick up the
+   calibrator automatically. `default` -> shipped v7 head; any other
+   value -> filesystem path. Unset -> no calibration.
+
+The smoke finding on short-concrete DECs pushed down by the head
+opened H10 (interaction terms), shipped in the same PR.
 
 ---
 

--- a/experiments/nanogpt/HYPOTHESES.md
+++ b/experiments/nanogpt/HYPOTHESES.md
@@ -131,11 +131,13 @@ and `confidence` field surface the calibrated value.
 
 **Decision taken:** ship as opt-in. Two ways to enable:
 
-1. Programmatic:
+1. Programmatic (resolve the path from the installed package so
+   the example works regardless of current working directory):
    ```python
-   head = CalibrationHead.from_json(
-       "merken/classifiers/calibration_v7.json"
-   )
+   from pathlib import Path
+   import merken.classifiers
+   head_path = Path(merken.classifiers.__file__).parent / "calibration_v7.json"
+   head = CalibrationHead.from_json(head_path)
    decider = NanoGPTWriteDecider(ckpt, meta, calibrator=head)
    ```
 2. Env-var driven, works with `Memory` without code changes:

--- a/experiments/nanogpt/PAPER_DRAFT.md
+++ b/experiments/nanogpt/PAPER_DRAFT.md
@@ -1,186 +1,232 @@
 # Latent Calibration in an 800K-Parameter Memory Filter
 
-**Working title.** Draft consolidating the v7 write-filter work into a
-paper-shaped narrative. Numbers are load-bearing; everything cites a
-script in `experiments/` or an artifact in `experiments/nanogpt/`.
+**Working title.** N=1 engineering memo. **Not a workshop submission**
+as-is; see "What this is / is not" below. Numbers are load-bearing;
+everything cites a script in `experiments/` or an artifact in
+`experiments/nanogpt/`.
+
+## What this is / is not
+
+This is an **engineering memo from a single developer** (Jay)
+documenting the design + honest measurement of a small
+specialized classifier for one memory system, on one user's
+transcript distribution, oracled by Gemini 2.0 Flash in a
+specific prompt.
+
+Core methodological limits, stated up front so no reviewer has to
+dig for them:
+
+- **N=1 user.** All real-content measurement is on transcripts from
+  one author.
+- **Gemini-in-this-prompt is the "oracle".** There is no human
+  ground truth at scale. A 20-sample manual audit agreed with
+  Gemini on 15/20 DECISIONs (75%) -- the oracle itself has a
+  non-trivial error rate. Every "accuracy" number below is
+  accuracy-against-Gemini-in-this-prompt, not accuracy-vs-truth.
+- **One held-out scenario contaminated.** The
+  `jay_vstash_2026_04_09_snapshot` scenario that v7 hits 100% on
+  has 13/20 events present in the v7 organic training set
+  (`/tmp/organic_train.json`). See section 3.3.
+- **H10 feature set was motivated by one smoke case.** Interaction
+  terms were added after observing one short-concrete-DEC being
+  mis-calibrated. Honest label: post-hoc feature engineering. See
+  section 4.4.
+
+With those caveats the rest of the document is what we measured.
+This framing targets a **blog post / tech report**, not a venue
+submission. To get to a workshop we would need N >= 3 users, a
+larger human-labeled subset as a second oracle, retrieval E2E
+evaluation, and a clean held-out that drove no design decisions.
 
 ## Abstract
 
-We trained an 800,000-parameter BPE transformer to decide whether
-assistant responses in an agent conversation should be kept in
-long-term memory. Against a LoCoMo-style synthetic benchmark the
-filter achieves 86% store reduction and 100% recall on held-out
-decisions. On real Claude Code transcripts produced by the same
-author the numbers collapse: real store reduction is **7.7%**, real
-population-weighted accuracy is **80.9%** (vs 84.7% first reported on
-an incomplete slice), and the filter is uniformly over-confident on
-short prose and uniformly under-confident on out-of-distribution
-public instruction-tuning data. We document this Production-Benchmark
-Gap, show that uncertainty detection emerges from real-label training
-(a v6 baseline lacks it entirely), and demonstrate that a nine- to
-fourteen-parameter post-hoc head restores in-distribution calibration
-to ECE 0.035 without retraining. We close by showing that the same
-post-hoc head does NOT close cross-distribution drift, because the
-direction of miscalibration flips across domains -- a result that a
-scalar Platt / temperature fit cannot represent.
+On held-out synthetic benchmarks a 4-layer 800K-parameter BPE
+transformer achieves 86% store reduction and 100% recall. On real
+Claude Code transcripts from the same author the numbers move:
+real store reduction is **7.7%**, real population-weighted
+accuracy-vs-Gemini is **80.9%**, and the filter is uniformly
+over-confident on short prose and uniformly under-confident on
+out-of-distribution public instruction-tuning data. We document
+this Production-Benchmark Gap and show that **scalar post-hoc
+calibration cannot represent opposite-direction bias across
+domains** -- a structural limit, not a fundamental one; a per-
+distribution head would. An ablation with v6 + our H10 head shows
+that calibration is largely a post-hoc fit that works on either
+base model (v6+head ECE 0.047, v7+head ECE 0.035); real-label
+training redistributes raw output mass (bimodal 93% -> 59%) but
+does NOT confer calibration the head can't recover.
 
 ## 1. Setup
 
 `merken` is a memory layer for LLM agents. Each assistant turn is a
 candidate event; the ``should_remember`` policy decides write vs
-skip. The production policy is ``HeuristicWriteDecider``: novelty
-check + dedup + length gates. ``NanoGPTWriteDecider`` is a
-specialized classifier that auditors ("shadow mode") alongside the
-heuristic. After labeling disagreements with an oracle, the
-classifier is eligible for graduation to primary.
+skip. Production default is ``HeuristicWriteDecider``: novelty +
+dedup + length gates. ``NanoGPTWriteDecider`` is a specialized
+classifier that runs in "shadow mode" alongside the heuristic;
+after labeling disagreements it can be graduated to primary.
 
-All model training runs on ``nanoGPT`` (Karpathy) fork with the same
-architecture across versions:
+Architecture across v4-v8:
 
-- n_layer = 4
-- n_head = 4
-- n_embd = 128
-- vocab_size = 512 (BPE)
-- ~800K trainable parameters
+- n_layer = 4, n_head = 4, n_embd = 128
+- vocab_size = 512 (BPE), ~800K params
+- v4-v6: block_size = 128. v7+: block_size = 256 (see 3.1).
 
-Versions v4 to v6 had block_size = 128. v7 raised it to 256 after a
-measurement (section 3.1) showed 45.9% of real DECISIONs exceed the
-v6 context window.
+## 2. Dataset bootstrap
 
-## 2. Dataset bootstrap (the engineering prerequisite)
+No labeled benchmark for "keep-this-in-long-term-memory" exists for
+agent transcripts. We built one.
 
-Prior work on calibration of small classifiers tends to assume a
-labeled benchmark is available. For this problem none existed.
+The live Claude Code PreCompact hook had been silently broken:
+``json.load`` on JSONL transcripts, error swallowed by
+``2> /dev/null``, zero writes since the transcript format change.
+All per-project ``~/.merken/*.db`` had ``shadow_agree =
+shadow_disagree = 0``.
 
-The live Claude Code PreCompact hook was silently broken: it ran
-``json.load`` on a JSONL transcript, swallowed the exception via
-``2> /dev/null``, and produced zero writes since the transcript
-format change. Every per-project ``~/.merken/*.db`` had
-`shadow_agree = shadow_disagree = 0`. Discovering this while reading
-audit tables (not intended output) was the single highest-leverage
-moment in this project.
+After the hook fix, three scripts:
 
-Once the hook was fixed, three bootstrap scripts replayed history:
-
-1. `experiments/bootstrap_retro_labels.py`: replay v6 over the
-   already-written ``should_remember`` audit rows. Small (58 rows, 2
-   disagreements) -- a sanity loop, not a training signal.
-
-2. `experiments/bootstrap_from_transcripts.py`: replay primary +
+1. `experiments/bootstrap_from_transcripts.py` replays primary +
    shadow over every `~/.claude/projects/*.jsonl` transcript (415
-   files). 18,220 candidate events; 1,040 primary/shadow
-   disagreements; 0 errors.
+   files, 18,220 candidate events). Labels the 1,040 disagreements
+   with Gemini 2.0 Flash using a strict prompt (see
+   `experiments/oracle_model_bench.py`). A manual audit flagged
+   the first pass as too permissive; a re-label with an explicit
+   filler-pattern definition flipped 588 of 739 (80%) DECs to
+   NOISE. Final ratio: 157 DEC / 869 NOI.
 
-3. `experiments/relabel_decision_pile.py`: the first oracle pass
-   used Gemini 2.0 Flash with a permissive prompt. Manual audit of
-   20 labeled DECs flagged 15/20 as filler. The strict prompt (see
-   `experiments/oracle_model_bench.py`) explicitly defines "transition
-   sentences like 'Let me X', 'Now let me Y' ... regardless of what
-   X/Y refer to" as NOISE. Re-running on the DECISION pile flipped
-   588 of 739 labels (80%) to NOISE. Final ratio: 157 DEC / 869 NOI.
+2. `experiments/oracle_agree_write_sample.py` reservoir-samples
+   500 events from the 12,492 agree_write population to complete
+   the confusion matrix. 494 labeled (6 rate-limit skips).
 
-An independent probe (`experiments/oracle_agree_write_sample.py`)
-reservoir-sampled 500 events from the 12,492 agree_write population
-and oracled them with the same strict prompt, giving the other column
-of the confusion matrix (398 DEC, 96 NOI).
+3. `experiments/oracle_public_dataset.py` adds 288 LDJnr/Capybara
+   and 200 Open-Orca/SlimOrca chunks for cross-distribution
+   probes.
 
-All oracular work uses ``gemini-2.0-flash``. The 9-model bench in
-`experiments/oracle_model_bench.py` showed that pro-tier models
-(``gemini-2.5-pro``, ``gemini-3.1-pro-preview``) scored **lower** on
-a 20-item hand-curated test (90% agreement vs 2.0-flash's 95%) --
-they were more "creative" at finding DEC in filler text. For this
-narrow-classification task, prompt quality dominates model capability.
+Total Gemini-labeled pool: 1520 (Jay transcripts) + 488 (public).
+A 20-sample manual audit on DECs showed 15/20 (75%) agreement with
+the Gemini label; the other 5 the human would have flipped to
+NOISE. This bounds the useful strength of our oracle: ~80% reliable
+on the DEC class. All "agreement" numbers below should be read with
+that ceiling in mind.
 
-## 3. v7 graduation
+## 3. v7 measurement
 
 `experiments/eval_v7_vs_v6.py` compares v4-v8 on held-out scenarios.
-See `RESULTS.md` for the per-version table; the v7 row is the
-published contribution.
 
-### 3.1 The block_size measurement
+### 3.1 Block_size measurement
 
-Before training v7 we measured the token length of real DECs vs NOI
-on the strict-labeled pool:
-
-| class | median | p90 | max | % over 128 BPE tokens |
-|-------|-------:|----:|----:|----------------------:|
+| class | median tokens | p90 | max | % > block_size=128 |
+|-------|--------------:|----:|----:|-------------------:|
 | DECISION | 116 | 305 | 557 | **45.9%** |
 | NOISE | 38 | 60 | 357 | 0.7% |
 
-At block_size=128 the model literally could not see the payload of
-nearly half the real DECs (p95 exceeded the window). The prior v6
-shows this as a 66.7% FPR on markdown_tables_held_out -- not a model
-defect, a window-size defect. v7 doubled block_size to 256.
+At block_size=128 the model could not see the payload of half the
+real DECs. v6's 66.7% FPR on markdown_tables_held_out was
+partially a window-size defect, not purely a training defect.
+v7 doubled block_size to 256.
 
 ### 3.2 Scenario scores (v6 vs v7)
 
-| scenario | v6 agreement | v7 agreement | delta |
-|----------|-------------:|-------------:|------:|
-| markdown_tables_held_out | 66.7% | **100%** | +33.3pp |
-| organic_val_held_out | 100% | 100% | +0.0 |
-| jay_vstash_snapshot | 100% | 100% | +0.0 |
-| knowledge_update_50t | 99.9% | 97.4% | -2.5 |
+| scenario | v6 agreement | v7 agreement | note |
+|----------|-------------:|-------------:|------|
+| markdown_tables_held_out | 66.7% | 100% | held-out by construction |
+| organic_val_held_out | 100% | 100% | |
+| jay_vstash_snapshot | 100% | 100% | **CONTAMINATED (see 3.3)** |
+| knowledge_update_50t | 99.9% | 97.4% | synthetic; v7 dilutes stereotype |
 
-v7 is the first version to clear criterion #5 (markdown FPR <= 50%)
-with a 50pp margin. The regression on knowledge_update_50t is on a
-synthetic scenario that rewards memorizing stereotyped DEC phrasing
-("Replaced X with Y"). v7 dilutes that signal with 1026 heterogeneous
-real transcripts. The trade is a cosmetic loss on synthetic for a
-meaningful win on real.
+### 3.3 Contamination disclosure
 
-### 3.3 Full population-weighted confusion matrix (`experiments/confusion_matrix_v7.py`)
+Of the 20 events in `jay_vstash_2026_04_09_snapshot.json`,
+**13 also appear in `/tmp/organic_train.json`**, which is loaded
+into v7's training set as ``DECISION:organic:v1`` (see
+`nanoGPT/data/merken_bpe_v7/prepare.py`). So 65% of the "held-out"
+events are actually training data. The 100% agreement is largely
+memorization.
+
+This is the same kind of bug that invalidated H1's first result
+(copilot caught it on PR #15). Our graduation criterion #2
+("jay_vstash recall >= 95%") is a contaminated metric in its
+current form. Fix: remove the organic events from the held-out
+scenario OR retrain v8+ without the organic DECs. We did neither,
+so this number should be read as evidence of memorization, not
+generalization.
+
+### 3.4 Full population-weighted confusion matrix
+
+`experiments/confusion_matrix_v7.py`:
 
 ```
                oracle=DEC   oracle=NOI
-v7 WRITE         398 (TP)     96 (FP)     n=494   (agree_write sample)
-v7 SKIP          157 (FN)    869 (TN)     n=1026  (disagreement pool)
+v7 WRITE         398 (TP)     96 (FP)     n=494
+v7 SKIP          157 (FN)    869 (TN)     n=1026
 ```
 
-Projected onto the full 13,539-event population (12,492 agree_write
-+ 1,047 disagree_skip observed during the bootstrap scan):
+Projected onto the observed ~13,539-event population:
 
-| metric | value | remarks |
-|--------|------:|---------|
-| accuracy (pop-weighted) | **80.9%** | NOT the 84.7% we first reported |
-| DEC recall | 98.4% | rarely drops a real decision |
-| NOI recall (specificity) | **26.8%** | catches only 1 of 4 noise events |
-| store reduction | **7.7%** | NOT the 86% synthetic benchmark suggests |
+| metric | value |
+|--------|------:|
+| accuracy-vs-Gemini (pop-weighted) | **80.9%** |
+| DEC recall | 98.4% |
+| NOI recall (specificity) | **26.8%** |
+| real store reduction | **7.7%** |
 
-The 84.7% was skip-set only; adding the WRITE column moved it to
-80.9%. The 86% store reduction was measured against a scenario with
-~86% NOI events. Real class distribution is ~76% DEC / ~25% NOI.
-The filter is operating at 80.9% accuracy, 7.7% store reduction --
-a CONSERVATIVE filter that almost never costs you a decision but
-only modestly prunes noise.
+The 84.7% we first reported was skip-set only. Adding the WRITE
+column drops accuracy to 80.9%. The 86% store reduction was
+measured on a scenario with 86% NOI events. Real distribution is
+~76% DEC / ~24% NOI. v7 is a CONSERVATIVE filter: rarely costs a
+real decision (98.4% DEC recall), rarely prunes noise (26.8% NOI
+recall).
+
+Given the oracle ceiling (~80% from manual audit), the 80.9%
+accuracy number sits at the noise floor of Gemini's own reliability.
+We cannot claim v7 is more accurate than Gemini agrees with itself.
 
 ## 4. Calibration
 
-### 4.1 v6 vs v7 (cross-version)
+### 4.1 Raw-output distributions
 
-`experiments/cross_version_calibration.py`:
+From `experiments/v6_with_h10_head_ablation.py` on the 979-event
+clean pool:
 
-| model | n | ECE | signed bias | profile |
-|-------|--:|----:|------------:|---------|
-| v6 | 1520 | 0.159 | +0.135 | bimodal: 524 in [0.9,1.0), 372 in [0.0,0.1), nothing in middle |
-| v7 (full) | 1520 | 0.120 | +0.090 | more distributed; 410 events in [0.3, 0.6) |
+| model | raw ECE | bimodal frac (<0.1 or >=0.9) | middle frac (0.3-0.7) |
+|-------|--------:|------------------------------:|----------------------:|
+| v6 | 0.166 | 92.9% | 1.5% |
+| v7 | 0.056 | 59.4% | 7.6% |
 
-Training on real labels reduced aggregate miscalibration by ~25%
-and redistributed probability mass out of the extremes. v6 is a
-confident 2-class voter; v7 starts to look like an uncertainty
-estimator. **This is the emergent-uncertainty-detection claim and
-it depends on real training data. It does not emerge from the
-architecture alone.**
+v6 is a confident 2-class voter: 93% of events at the extremes,
+1.5% in the middle range. v7 has more distribution mass in the
+ambiguous zone: 59% at extremes, 7.6% middle. **Real-label training
+redistributes raw output mass; it does not obviously confer
+calibration.**
 
-### 4.2 Structure-dependent calibration
+### 4.2 Post-hoc head (H10) on both
 
-`experiments/content_type_calibration.py` tags each event by content
-structure (code fence, inline code, markdown table, numbers, file
-paths, short, long, plain prose) and measures v7 ECE per tag on the
-1520 labels:
+Same H10 head architecture (14 features: v7 logit + 7 structure
+tags + 1 OOD flag + 5 interactions), fit separately on v6 outputs
+and on v7 outputs, both at C=1:
+
+| base model | raw ECE | +H10 head ECE | delta |
+|------------|--------:|---------------:|------:|
+| v6 | 0.166 | 0.047 | -0.119 |
+| v7 | 0.056 | 0.035 | -0.020 |
+
+**The head recovers calibration for EITHER base model.** Delta
+between v6+head and v7+head is 0.012, below the "meaningful
+difference" threshold we pre-registered (>0.02). This **falsifies**
+the stronger version of our earlier claim ("uncertainty emerges
+from training, not architecture"). Honest rewrite: real-label
+training **redistributes raw output mass**, but a small post-hoc
+head recovers ECE regardless. What training buys you is
+**interpretable probabilities without a calibration wrapper**, not
+calibration per se.
+
+### 4.3 Structure-dependent calibration
+
+`experiments/content_type_calibration.py` tags each of the 1520
+Jay events by structure and measures v7 ECE per tag:
 
 | tag | n | ECE | signed |
 |-----|--:|----:|-------:|
-| long (>= 1000c) | 78 | **0.045** | -0.045 |
+| long (>= 1000c) | 78 | 0.045 | -0.045 |
 | has_file_paths | 191 | 0.084 | +0.026 |
 | has_numbers | 385 | 0.104 | -0.062 |
 | has_inline_code | 502 | 0.103 | -0.051 |
@@ -188,169 +234,163 @@ paths, short, long, plain prose) and measures v7 ECE per tag on the
 | short (< 300c) | 1254 | 0.168 | +0.148 |
 | has_markdown_table | 79 | 0.184 | **-0.184** |
 | plain_prose | 786 | 0.191 | **+0.191** |
-| all | 1520 | 0.120 | +0.090 |
 
-Aggregate ECE 0.120 is dominated by plain_prose (786 of 1520 events,
-ECE 0.191) and short text (1254 events, ECE 0.168). Structured
-content (file paths, inline code, numbers, long-form) is well
-calibrated on its own. Markdown tables go the opposite way:
-under-confident by -0.184.
+Aggregate ECE 0.120 is dominated by plain_prose (n=786, ECE 0.191).
+Structured content is well-calibrated. This decomposition motivated
+the conditional head (section 4.5).
 
-### 4.3 Transferability probe, H5 (REJECTED)
+### 4.4 Transferability probe (H5, REJECTED)
 
-If structure-dependent ECE is a universal property of the filter, it
-should rank-transfer to other datasets. We compared with Spearman
-over categories present with n >= 5 in both datasets
-(`experiments/h5_content_type_transferability.py`):
+`experiments/h5_content_type_transferability.py` computed Spearman
+over the categories present with n >= 5 in both datasets:
 
-- jay_1520 vs capybara_288: rho = **-0.40** (4 shared bins)
-- jay_1520 vs slimorca_200: rho = **+0.50** (3 shared bins)
+- jay_1520 vs capybara_288: rho = -0.40 (4 shared bins)
+- jay_1520 vs slimorca_200: rho = +0.50 (3 shared bins)
 
-Neither crosses the pre-registered 0.7 acceptance bar. Per-structure
-ordering is dataset-specific.
+Both below the pre-registered 0.7 acceptance bar. Per-structure
+ordering is dataset-specific. What DOES transfer: every
+structure tag on the public IT datasets shows negative signed
+bias, i.e. v7 is uniformly under-confident OOD regardless of
+structure.
 
-What DOES transfer is the sign: every structure tag on the public IT
-datasets shows negative signed bias -- v7 is uniformly under-confident
-OOD, independent of structure.
+### 4.5 Post-hoc head: three fits
 
-### 4.4 Post-hoc calibration (H1, H11, H10)
+Honest history of feature selection:
 
-Three attempts, each an honest iteration.
+- **H1** (flawed): full 2005-label pool, found ECE 0.038 vs 0.070
+  raw. Review caught that the pool included `merken_labels_v7.jsonl`
+  -- v7 training data. Rerun on 982 clean events: ECE 0.049,
+  delta vs Platt only -0.004. Aggregate verdict: REJECTED.
+- **H11**: same features, C-sweep for L2 regularization. C=10
+  yields ECE 0.043, max |w| = 2.23 (unregularized fit had |w|=8.33
+  on n=13 slices).
+- **H10 (shipped)**: added 5 interaction features after smoke
+  testing H11 on "Fix: replaced pgbouncer..." (short + numbers +
+  file_paths, raw 0.857 -> H11 head 0.371 -> desired recovery).
+  C=1, ECE 0.035.
 
-**H1 (rejected on clean data).** Logistic regression with 9 features
-(v7 logit + 7 structure tags + is_ood) on the full 2005-label pool.
-First run reported ECE 0.038 (-46% vs raw). Review caught that the
-pool included `merken_labels_v7.jsonl`, which was part of v7's
-training data. After excluding (n=982) the result is ECE 0.049 vs
-Platt's 0.053: delta -0.004, not a meaningful win.
+**Feature-engineering disclosure:** the 5 interaction terms were
+added AFTER observing the specific smoke case. ECE 0.035 is on a
+clean 80/20 split of the 982-label pool, but the FEATURE DESIGN
+was motivated by one training example. A reviewer would rightly
+want either (a) a held-out-from-design test set, or (b) an ablation
+showing ECE with only 0-5 of the 5 interactions retained.
+Neither was run; documented as H10 caveat, not as part of this
+section's main claim.
 
-**H11 (regularization).** Unregularized fit produced two weights
-above 7.0 from n<20 slices. L2 C-sweep on clean pool identified C=10
-(ECE 0.043, max |w|=2.23) as the stable configuration.
+### 4.6 Cross-distribution bias is opposite-direction
 
-**H10 (interactions).** Smoke testing H11 on "Fix: replaced
-pgbouncer session mode with transaction mode in db/pool.py line 42.
-Latency p95 180ms -> 40ms." (short + numbers + file_paths, raw P(D)
-0.857) showed the additive head pushed it to P_cal=0.371 -- couldn't
-distinguish "short with payload" from "short filler". Adding 5
-interaction terms and refitting at C=1 yields ECE **0.035** and
-P_cal=0.629 on the same smoke input.
+Combining Jay HIGH-regime labels with Capybara LOW-regime events
+(`experiments/calibrate_v7_platt.py`, n=592): the two subsets have
+opposite bias signs. A scalar Platt fit REGRESSES ECE from 0.145
+(raw) to 0.177. Temperature scaling also regresses.
 
-| method | features | ECE | smoke case |
-|--------|---------:|----:|-----------:|
-| raw v7 | -- | 0.056 | 0.857 |
-| Platt | 1 | 0.053 | 0.580 |
-| H1 head | 9 (overfit) | 0.049 | 0.371 |
-| H11 head | 9 (L2) | 0.043 | 0.371 |
-| **H10 head** | **14 (interactions)** | **0.035** | **0.629** |
-
-The shipped head (`merken/classifiers/calibration_v7.json`) is the
-H10 C=1 fit. Enable via code (`NanoGPTWriteDecider(calibrator=...)`)
-or env var (`MERKEN_SHADOW_NANOGPT_CALIBRATOR=default`).
-
-### 4.5 Cross-distribution drift is not recoverable post-hoc
-
-Combining HIGH-regime Jay labels with LOW-regime Capybara gives a
-pooled clean set (n=592) where scaling methods REGRESS: ECE goes
-**up** from 0.145 (raw) to 0.177 (Platt). Reason: the two domains
-have opposite-direction biases (HIGH over-confident +0.10, LOW
-under-confident -0.57). A scalar transform cannot correct two biases
-pointing in opposite directions. This is a Pareto limit of post-hoc
-calibration on small specialized models crossing distributions.
+**This is a limit of scalar post-hoc methods, not a Pareto limit
+of post-hoc methods overall.** A two-head calibrator (one per
+domain, selected by a lightweight OOD indicator) would resolve it
+trivially. We didn't fit one because we don't have enough
+per-domain labels to support it and because the clean use case for
+this classifier is Jay's transcripts (in-distribution), where a
+single head suffices. Stating this as a "fundamental" or "Pareto"
+limit would overclaim.
 
 ## 5. What this contributes
 
-Three claims with numeric evidence:
+Three things. We pulled the two we had listed as "contributions" in
+an earlier draft (shadow-mode methodology; honest iteration) --
+neither is novel; both are basic engineering practice.
 
-1. **Production-Benchmark Gap is measurable and large.** Same model,
-   same week: 86% store reduction on a synthetic class-imbalanced
-   scenario vs 7.7% on real transcripts. Class-distribution mismatch
-   fully explains the delta.
+1. **The Production-Benchmark Gap is quantified on one concrete
+   pipeline.** Same 800K-param model on the same week gives 86%
+   store reduction on a synthetic scenario with 86% NOI events, and
+   7.7% on real transcripts with 24% NOI events. Class-distribution
+   mismatch fully accounts for the gap. This is a well-known
+   phenomenon in ML more broadly, cited here as an instance + a
+   specific magnitude for calibrated-filter work.
 
-2. **Uncertainty detection is training-driven, not architectural.**
-   v6 (synthetic-only) is bimodal with ECE 0.159. v7 (+1026 real
-   labels, same architecture) distributes probability into the
-   ambiguous bucket and drops ECE to 0.120. A 9+-parameter head on
-   clean data brings it to 0.035. Adding the 9-parameter head to v6
-   would not produce uncertainty detection -- v6 has nothing to
-   calibrate there.
+2. **Content-type-conditional calibration beats scalar scaling in
+   distribution, fails equally across distributions.** We fit
+   scalar Platt (2 params), regularized 9-param head, and
+   14-param head with interactions on the same 982-event pool.
+   Delta over Platt is -0.018 aggregate (0.053 -> 0.035), with
+   per-structure wins up to -0.184 on markdown_table. A per-
+   distribution head would plausibly cross-transfer too, but we
+   did not fit one. Feature design for the 14-param head was
+   post-hoc and is called out as a methodological limit.
 
-3. **Post-hoc calibration is directional.** Within a training
-   distribution, scalar scaling and small heads work well. Across
-   distributions with opposite bias directions, no scalar and no
-   tiny head suffices.
+3. **Real-label training redistributes raw output mass (bimodal
+   93% -> 59%) but does NOT confer calibration the head can't
+   recover.** v6+head reaches ECE 0.047, v7+head reaches 0.035,
+   delta 0.012. Our earlier claim that "uncertainty detection is
+   training-driven, not architectural" was too strong. The right
+   framing: real-label training gives you interpretable probabilities
+   without a calibration wrapper; for actual ECE either path works.
 
-And two methodological contributions that we think transfer:
+## 6. Limitations (expanded)
 
-4. **Shadow-mode + retroactive transcript replay + strict oracle**
-   is a bootstrap methodology that produces 1000+ labels without
-   labeling anyone's data up front. The pipeline is five Python
-   scripts and one prompt.
-
-5. **Honest iteration.** H1, H5, H11, H10 are all documented with
-   decision rules set up-front, results, and override notes when
-   the initial result was contaminated. See
-   `experiments/nanogpt/HYPOTHESES.md`.
-
-## 6. Limitations
-
-- **N=1 user.** All "real" data is one developer (Jay). Multi-user
-  evidence is a gap. The v7 -> v9 work is blocked on this.
-- **Gemini as oracle.** Labels are an LLM's interpretation of a
-  strict prompt. Circular: we're measuring how well v7 imitates
-  Gemini on this prompt. A human audit (20-sample manual check)
-  found 15/20 agreement on DECs but we lack a larger human ground
-  truth.
-- **No retrieval downstream eval.** We measure filter accuracy, not
-  the effect of the filter on eventual recall quality. LoCoMo-style
-  end-to-end eval is the gap between "filter is calibrated" and
-  "memory is useful".
-- **Benchmarks not standardized.** knowledge_update / markdown_
-  tables_held_out / organic_val_held_out are internal. MemBench and
-  LoCoMo were run on prior versions (`experiments/retrieval/locomo/
-  RESULTS.md`) but not on v7 with calibration.
+- **N=1 user** (same author as this memo).
+- **Gemini-in-this-prompt is the oracle.** Human audit showed 15/20
+  (75%) agreement on DECs; every accuracy number is bounded by
+  Gemini's own reliability.
+- **One held-out scenario contaminated** (jay_vstash_snapshot,
+  13/20 events in training).
+- **H10 feature design motivated by one smoke case.** Post-hoc
+  feature engineering. No ablation.
+- **No retrieval E2E.** Filter accuracy != memory usefulness. LoCoMo
+  was run on prior versions but not v7 + calibration.
+- **Benchmarks internal.** knowledge_update / organic_val_held_out
+  / markdown_tables_held_out live in this repo and drove design.
+  MemBench / LoCoMo evaluations are older and on prior versions.
+- **Synthetic-test contamination risk unchecked on other scenarios.**
+  Only verified jay_vstash_snapshot. Other 100% scores deserve an
+  audit we didn't do.
 
 ## 7. Reproducibility
 
-Every number in this document traces to a script + JSON artifact.
-Scripts run in <30 min each on a modern laptop. See
-`experiments/nanogpt/HYPOTHESES.md` for the per-hypothesis
-decision-rule log. Ckpt inventory in
-`experiments/nanogpt/MODELS.md`.
+Every numeric claim above traces to a script in `experiments/` and
+an artifact in `experiments/nanogpt/*.json`. One-shot regen:
 
-Data regeneration is one-shot:
-
-```
-# 1. Label bootstrap (Gemini-backed, ~1K API calls, ~$1)
+```bash
+# Label bootstrap (Gemini-backed, ~1-2K API calls, ~$1-2)
 PYTHONPATH=. python -m experiments.bootstrap_from_transcripts
 PYTHONPATH=. python -m experiments.relabel_decision_pile
 PYTHONPATH=. python -m experiments.oracle_agree_write_sample
+PYTHONPATH=. python -m experiments.oracle_public_dataset --dataset LDJnr/Capybara
+PYTHONPATH=. python -m experiments.oracle_public_dataset --dataset Open-Orca/SlimOrca
 
-# 2. Analysis + calibration fits
+# Analysis
 PYTHONPATH=. python -m experiments.confusion_matrix_v7
 PYTHONPATH=. python -m experiments.content_type_calibration
-PYTHONPATH=. python -m experiments.cross_version_calibration
-PYTHONPATH=. python -m experiments.h11_regularized_head
+PYTHONPATH=. python -m experiments.h5_content_type_transferability
 PYTHONPATH=. python -m experiments.h10_interaction_head
+PYTHONPATH=. python -m experiments.h11_regularized_head
+PYTHONPATH=. python -m experiments.v6_with_h10_head_ablation
+PYTHONPATH=. python -m experiments.cross_version_calibration
 ```
 
-## 8. Future work
+Decision-rule log for every hypothesis: `HYPOTHESES.md`.
+Checkpoint inventory: `MODELS.md`.
 
-- **Multi-user data.** N=3 developers would be meaningful; N=10 would
-  be publishable.
-- **Full retrieval E2E.** Does the calibrated filter change measured
-  retrieval quality on LoCoMo? Hook the calibrator into Memory and
-  run.
-- **Contrastive loss (H2).** Paired same-starter-different-class
-  events to force attention over the payload. Open.
-- **Architecture probe (H8).** If contrastive loss fails, bump
-  n_embd = 192 (~1.5M params) and see whether capacity was the
-  constraint.
+## 8. What would make this a submission
 
----
+To move from N=1 memo to workshop paper, the gap is:
 
-**Status of this draft:** honest first pass. Numbers are stable,
-framing has iterated through two review rounds. Not yet venue-
-targeted. If Jay wants to publish: either workshop (add N=3 users +
-1 retrieval E2E) or tech report / blog post (ship as-is with
-"N=1 user, further work needed" disclaimer).
+- N >= 3 users' transcripts (consent + labeling pipeline).
+- A ~200-sample human-labeled subset as a second oracle so the
+  accuracy numbers become accuracy-vs-human-adjudicated instead
+  of accuracy-vs-Gemini.
+- Retrieval E2E (LoCoMo or equivalent) with v7 +/- calibration.
+- A clean scenario set explicitly separated from training data;
+  re-audit every "100%" score.
+- v9 with contrastive loss (H2) OR v10 with more params (H8) --
+  to close the 157 FN remaining on real DECs without regressing
+  markdown FPR.
+
+Estimated: 4-6 weeks of focused work. Not planned.
+
+## 9. Recommended disposition
+
+Blog post / tech report to Jay's existing audience (r/LocalLLaMA,
+merken users, vstash users). The honest-memo framing is the pitch:
+specific numbers, acknowledged limits, negative results included.
+Publishable as a workshop paper only after section 8 is done.

--- a/experiments/nanogpt/PAPER_DRAFT.md
+++ b/experiments/nanogpt/PAPER_DRAFT.md
@@ -1,0 +1,356 @@
+# Latent Calibration in an 800K-Parameter Memory Filter
+
+**Working title.** Draft consolidating the v7 write-filter work into a
+paper-shaped narrative. Numbers are load-bearing; everything cites a
+script in `experiments/` or an artifact in `experiments/nanogpt/`.
+
+## Abstract
+
+We trained an 800,000-parameter BPE transformer to decide whether
+assistant responses in an agent conversation should be kept in
+long-term memory. Against a LoCoMo-style synthetic benchmark the
+filter achieves 86% store reduction and 100% recall on held-out
+decisions. On real Claude Code transcripts produced by the same
+author the numbers collapse: real store reduction is **7.7%**, real
+population-weighted accuracy is **80.9%** (vs 84.7% first reported on
+an incomplete slice), and the filter is uniformly over-confident on
+short prose and uniformly under-confident on out-of-distribution
+public instruction-tuning data. We document this Production-Benchmark
+Gap, show that uncertainty detection emerges from real-label training
+(a v6 baseline lacks it entirely), and demonstrate that a nine- to
+fourteen-parameter post-hoc head restores in-distribution calibration
+to ECE 0.035 without retraining. We close by showing that the same
+post-hoc head does NOT close cross-distribution drift, because the
+direction of miscalibration flips across domains -- a result that a
+scalar Platt / temperature fit cannot represent.
+
+## 1. Setup
+
+`merken` is a memory layer for LLM agents. Each assistant turn is a
+candidate event; the ``should_remember`` policy decides write vs
+skip. The production policy is ``HeuristicWriteDecider``: novelty
+check + dedup + length gates. ``NanoGPTWriteDecider`` is a
+specialized classifier that auditors ("shadow mode") alongside the
+heuristic. After labeling disagreements with an oracle, the
+classifier is eligible for graduation to primary.
+
+All model training runs on ``nanoGPT`` (Karpathy) fork with the same
+architecture across versions:
+
+- n_layer = 4
+- n_head = 4
+- n_embd = 128
+- vocab_size = 512 (BPE)
+- ~800K trainable parameters
+
+Versions v4 to v6 had block_size = 128. v7 raised it to 256 after a
+measurement (section 3.1) showed 45.9% of real DECISIONs exceed the
+v6 context window.
+
+## 2. Dataset bootstrap (the engineering prerequisite)
+
+Prior work on calibration of small classifiers tends to assume a
+labeled benchmark is available. For this problem none existed.
+
+The live Claude Code PreCompact hook was silently broken: it ran
+``json.load`` on a JSONL transcript, swallowed the exception via
+``2> /dev/null``, and produced zero writes since the transcript
+format change. Every per-project ``~/.merken/*.db`` had
+`shadow_agree = shadow_disagree = 0`. Discovering this while reading
+audit tables (not intended output) was the single highest-leverage
+moment in this project.
+
+Once the hook was fixed, three bootstrap scripts replayed history:
+
+1. `experiments/bootstrap_retro_labels.py`: replay v6 over the
+   already-written ``should_remember`` audit rows. Small (58 rows, 2
+   disagreements) -- a sanity loop, not a training signal.
+
+2. `experiments/bootstrap_from_transcripts.py`: replay primary +
+   shadow over every `~/.claude/projects/*.jsonl` transcript (415
+   files). 18,220 candidate events; 1,040 primary/shadow
+   disagreements; 0 errors.
+
+3. `experiments/relabel_decision_pile.py`: the first oracle pass
+   used Gemini 2.0 Flash with a permissive prompt. Manual audit of
+   20 labeled DECs flagged 15/20 as filler. The strict prompt (see
+   `experiments/oracle_model_bench.py`) explicitly defines "transition
+   sentences like 'Let me X', 'Now let me Y' ... regardless of what
+   X/Y refer to" as NOISE. Re-running on the DECISION pile flipped
+   588 of 739 labels (80%) to NOISE. Final ratio: 157 DEC / 869 NOI.
+
+An independent probe (`experiments/oracle_agree_write_sample.py`)
+reservoir-sampled 500 events from the 12,492 agree_write population
+and oracled them with the same strict prompt, giving the other column
+of the confusion matrix (398 DEC, 96 NOI).
+
+All oracular work uses ``gemini-2.0-flash``. The 9-model bench in
+`experiments/oracle_model_bench.py` showed that pro-tier models
+(``gemini-2.5-pro``, ``gemini-3.1-pro-preview``) scored **lower** on
+a 20-item hand-curated test (90% agreement vs 2.0-flash's 95%) --
+they were more "creative" at finding DEC in filler text. For this
+narrow-classification task, prompt quality dominates model capability.
+
+## 3. v7 graduation
+
+`experiments/eval_v7_vs_v6.py` compares v4-v8 on held-out scenarios.
+See `RESULTS.md` for the per-version table; the v7 row is the
+published contribution.
+
+### 3.1 The block_size measurement
+
+Before training v7 we measured the token length of real DECs vs NOI
+on the strict-labeled pool:
+
+| class | median | p90 | max | % over 128 BPE tokens |
+|-------|-------:|----:|----:|----------------------:|
+| DECISION | 116 | 305 | 557 | **45.9%** |
+| NOISE | 38 | 60 | 357 | 0.7% |
+
+At block_size=128 the model literally could not see the payload of
+nearly half the real DECs (p95 exceeded the window). The prior v6
+shows this as a 66.7% FPR on markdown_tables_held_out -- not a model
+defect, a window-size defect. v7 doubled block_size to 256.
+
+### 3.2 Scenario scores (v6 vs v7)
+
+| scenario | v6 agreement | v7 agreement | delta |
+|----------|-------------:|-------------:|------:|
+| markdown_tables_held_out | 66.7% | **100%** | +33.3pp |
+| organic_val_held_out | 100% | 100% | +0.0 |
+| jay_vstash_snapshot | 100% | 100% | +0.0 |
+| knowledge_update_50t | 99.9% | 97.4% | -2.5 |
+
+v7 is the first version to clear criterion #5 (markdown FPR <= 50%)
+with a 50pp margin. The regression on knowledge_update_50t is on a
+synthetic scenario that rewards memorizing stereotyped DEC phrasing
+("Replaced X with Y"). v7 dilutes that signal with 1026 heterogeneous
+real transcripts. The trade is a cosmetic loss on synthetic for a
+meaningful win on real.
+
+### 3.3 Full population-weighted confusion matrix (`experiments/confusion_matrix_v7.py`)
+
+```
+               oracle=DEC   oracle=NOI
+v7 WRITE         398 (TP)     96 (FP)     n=494   (agree_write sample)
+v7 SKIP          157 (FN)    869 (TN)     n=1026  (disagreement pool)
+```
+
+Projected onto the full 13,539-event population (12,492 agree_write
++ 1,047 disagree_skip observed during the bootstrap scan):
+
+| metric | value | remarks |
+|--------|------:|---------|
+| accuracy (pop-weighted) | **80.9%** | NOT the 84.7% we first reported |
+| DEC recall | 98.4% | rarely drops a real decision |
+| NOI recall (specificity) | **26.8%** | catches only 1 of 4 noise events |
+| store reduction | **7.7%** | NOT the 86% synthetic benchmark suggests |
+
+The 84.7% was skip-set only; adding the WRITE column moved it to
+80.9%. The 86% store reduction was measured against a scenario with
+~86% NOI events. Real class distribution is ~76% DEC / ~25% NOI.
+The filter is operating at 80.9% accuracy, 7.7% store reduction --
+a CONSERVATIVE filter that almost never costs you a decision but
+only modestly prunes noise.
+
+## 4. Calibration
+
+### 4.1 v6 vs v7 (cross-version)
+
+`experiments/cross_version_calibration.py`:
+
+| model | n | ECE | signed bias | profile |
+|-------|--:|----:|------------:|---------|
+| v6 | 1520 | 0.159 | +0.135 | bimodal: 524 in [0.9,1.0), 372 in [0.0,0.1), nothing in middle |
+| v7 (full) | 1520 | 0.120 | +0.090 | more distributed; 410 events in [0.3, 0.6) |
+
+Training on real labels reduced aggregate miscalibration by ~25%
+and redistributed probability mass out of the extremes. v6 is a
+confident 2-class voter; v7 starts to look like an uncertainty
+estimator. **This is the emergent-uncertainty-detection claim and
+it depends on real training data. It does not emerge from the
+architecture alone.**
+
+### 4.2 Structure-dependent calibration
+
+`experiments/content_type_calibration.py` tags each event by content
+structure (code fence, inline code, markdown table, numbers, file
+paths, short, long, plain prose) and measures v7 ECE per tag on the
+1520 labels:
+
+| tag | n | ECE | signed |
+|-----|--:|----:|-------:|
+| long (>= 1000c) | 78 | **0.045** | -0.045 |
+| has_file_paths | 191 | 0.084 | +0.026 |
+| has_numbers | 385 | 0.104 | -0.062 |
+| has_inline_code | 502 | 0.103 | -0.051 |
+| has_code_fence | 60 | 0.107 | -0.107 |
+| short (< 300c) | 1254 | 0.168 | +0.148 |
+| has_markdown_table | 79 | 0.184 | **-0.184** |
+| plain_prose | 786 | 0.191 | **+0.191** |
+| all | 1520 | 0.120 | +0.090 |
+
+Aggregate ECE 0.120 is dominated by plain_prose (786 of 1520 events,
+ECE 0.191) and short text (1254 events, ECE 0.168). Structured
+content (file paths, inline code, numbers, long-form) is well
+calibrated on its own. Markdown tables go the opposite way:
+under-confident by -0.184.
+
+### 4.3 Transferability probe, H5 (REJECTED)
+
+If structure-dependent ECE is a universal property of the filter, it
+should rank-transfer to other datasets. We compared with Spearman
+over categories present with n >= 5 in both datasets
+(`experiments/h5_content_type_transferability.py`):
+
+- jay_1520 vs capybara_288: rho = **-0.40** (4 shared bins)
+- jay_1520 vs slimorca_200: rho = **+0.50** (3 shared bins)
+
+Neither crosses the pre-registered 0.7 acceptance bar. Per-structure
+ordering is dataset-specific.
+
+What DOES transfer is the sign: every structure tag on the public IT
+datasets shows negative signed bias -- v7 is uniformly under-confident
+OOD, independent of structure.
+
+### 4.4 Post-hoc calibration (H1, H11, H10)
+
+Three attempts, each an honest iteration.
+
+**H1 (rejected on clean data).** Logistic regression with 9 features
+(v7 logit + 7 structure tags + is_ood) on the full 2005-label pool.
+First run reported ECE 0.038 (-46% vs raw). Review caught that the
+pool included `merken_labels_v7.jsonl`, which was part of v7's
+training data. After excluding (n=982) the result is ECE 0.049 vs
+Platt's 0.053: delta -0.004, not a meaningful win.
+
+**H11 (regularization).** Unregularized fit produced two weights
+above 7.0 from n<20 slices. L2 C-sweep on clean pool identified C=10
+(ECE 0.043, max |w|=2.23) as the stable configuration.
+
+**H10 (interactions).** Smoke testing H11 on "Fix: replaced
+pgbouncer session mode with transaction mode in db/pool.py line 42.
+Latency p95 180ms -> 40ms." (short + numbers + file_paths, raw P(D)
+0.857) showed the additive head pushed it to P_cal=0.371 -- couldn't
+distinguish "short with payload" from "short filler". Adding 5
+interaction terms and refitting at C=1 yields ECE **0.035** and
+P_cal=0.629 on the same smoke input.
+
+| method | features | ECE | smoke case |
+|--------|---------:|----:|-----------:|
+| raw v7 | -- | 0.056 | 0.857 |
+| Platt | 1 | 0.053 | 0.580 |
+| H1 head | 9 (overfit) | 0.049 | 0.371 |
+| H11 head | 9 (L2) | 0.043 | 0.371 |
+| **H10 head** | **14 (interactions)** | **0.035** | **0.629** |
+
+The shipped head (`merken/classifiers/calibration_v7.json`) is the
+H10 C=1 fit. Enable via code (`NanoGPTWriteDecider(calibrator=...)`)
+or env var (`MERKEN_SHADOW_NANOGPT_CALIBRATOR=default`).
+
+### 4.5 Cross-distribution drift is not recoverable post-hoc
+
+Combining HIGH-regime Jay labels with LOW-regime Capybara gives a
+pooled clean set (n=592) where scaling methods REGRESS: ECE goes
+**up** from 0.145 (raw) to 0.177 (Platt). Reason: the two domains
+have opposite-direction biases (HIGH over-confident +0.10, LOW
+under-confident -0.57). A scalar transform cannot correct two biases
+pointing in opposite directions. This is a Pareto limit of post-hoc
+calibration on small specialized models crossing distributions.
+
+## 5. What this contributes
+
+Three claims with numeric evidence:
+
+1. **Production-Benchmark Gap is measurable and large.** Same model,
+   same week: 86% store reduction on a synthetic class-imbalanced
+   scenario vs 7.7% on real transcripts. Class-distribution mismatch
+   fully explains the delta.
+
+2. **Uncertainty detection is training-driven, not architectural.**
+   v6 (synthetic-only) is bimodal with ECE 0.159. v7 (+1026 real
+   labels, same architecture) distributes probability into the
+   ambiguous bucket and drops ECE to 0.120. A 9+-parameter head on
+   clean data brings it to 0.035. Adding the 9-parameter head to v6
+   would not produce uncertainty detection -- v6 has nothing to
+   calibrate there.
+
+3. **Post-hoc calibration is directional.** Within a training
+   distribution, scalar scaling and small heads work well. Across
+   distributions with opposite bias directions, no scalar and no
+   tiny head suffices.
+
+And two methodological contributions that we think transfer:
+
+4. **Shadow-mode + retroactive transcript replay + strict oracle**
+   is a bootstrap methodology that produces 1000+ labels without
+   labeling anyone's data up front. The pipeline is five Python
+   scripts and one prompt.
+
+5. **Honest iteration.** H1, H5, H11, H10 are all documented with
+   decision rules set up-front, results, and override notes when
+   the initial result was contaminated. See
+   `experiments/nanogpt/HYPOTHESES.md`.
+
+## 6. Limitations
+
+- **N=1 user.** All "real" data is one developer (Jay). Multi-user
+  evidence is a gap. The v7 -> v9 work is blocked on this.
+- **Gemini as oracle.** Labels are an LLM's interpretation of a
+  strict prompt. Circular: we're measuring how well v7 imitates
+  Gemini on this prompt. A human audit (20-sample manual check)
+  found 15/20 agreement on DECs but we lack a larger human ground
+  truth.
+- **No retrieval downstream eval.** We measure filter accuracy, not
+  the effect of the filter on eventual recall quality. LoCoMo-style
+  end-to-end eval is the gap between "filter is calibrated" and
+  "memory is useful".
+- **Benchmarks not standardized.** knowledge_update / markdown_
+  tables_held_out / organic_val_held_out are internal. MemBench and
+  LoCoMo were run on prior versions (`experiments/retrieval/locomo/
+  RESULTS.md`) but not on v7 with calibration.
+
+## 7. Reproducibility
+
+Every number in this document traces to a script + JSON artifact.
+Scripts run in <30 min each on a modern laptop. See
+`experiments/nanogpt/HYPOTHESES.md` for the per-hypothesis
+decision-rule log. Ckpt inventory in
+`experiments/nanogpt/MODELS.md`.
+
+Data regeneration is one-shot:
+
+```
+# 1. Label bootstrap (Gemini-backed, ~1K API calls, ~$1)
+PYTHONPATH=. python -m experiments.bootstrap_from_transcripts
+PYTHONPATH=. python -m experiments.relabel_decision_pile
+PYTHONPATH=. python -m experiments.oracle_agree_write_sample
+
+# 2. Analysis + calibration fits
+PYTHONPATH=. python -m experiments.confusion_matrix_v7
+PYTHONPATH=. python -m experiments.content_type_calibration
+PYTHONPATH=. python -m experiments.cross_version_calibration
+PYTHONPATH=. python -m experiments.h11_regularized_head
+PYTHONPATH=. python -m experiments.h10_interaction_head
+```
+
+## 8. Future work
+
+- **Multi-user data.** N=3 developers would be meaningful; N=10 would
+  be publishable.
+- **Full retrieval E2E.** Does the calibrated filter change measured
+  retrieval quality on LoCoMo? Hook the calibrator into Memory and
+  run.
+- **Contrastive loss (H2).** Paired same-starter-different-class
+  events to force attention over the payload. Open.
+- **Architecture probe (H8).** If contrastive loss fails, bump
+  n_embd = 192 (~1.5M params) and see whether capacity was the
+  constraint.
+
+---
+
+**Status of this draft:** honest first pass. Numbers are stable,
+framing has iterated through two review rounds. Not yet venue-
+targeted. If Jay wants to publish: either workshop (add N=3 users +
+1 retrieval E2E) or tech report / blog post (ship as-is with
+"N=1 user, further work needed" disclaimer).

--- a/experiments/nanogpt/v6_with_h10_head_ablation.json
+++ b/experiments/nanogpt/v6_with_h10_head_ablation.json
@@ -1,0 +1,56 @@
+{
+  "v6": {
+    "n_train": 782,
+    "n_test": 197,
+    "raw_ece": 0.16632487309644675,
+    "head_ece": 0.04729692973702893,
+    "head_delta": -0.11902794335941783,
+    "bimodal_frac": 0.9289340101522843,
+    "middle_frac": 0.015228426395939087,
+    "intercept": 2.107894150460135,
+    "coefficients": {
+      "logit_P(D)": 0.02960663757528752,
+      "has_code_fence": 0.12957405252401724,
+      "has_inline_code": 0.9769096099443481,
+      "has_markdown_table": 0.5199894257768003,
+      "has_numbers": 0.9425603752957578,
+      "has_file_paths": 0.19457691214002557,
+      "is_short": -2.068496523994228,
+      "is_long": 0.4819918503403145,
+      "is_ood": 1.0921788166894224,
+      "short_X_numbers": -0.17972916436164207,
+      "short_X_file_paths": -0.3631470569715209,
+      "short_X_inline_code": -0.24311302778784935,
+      "short_X_markdown_table": 0.08785700969133031,
+      "ood_X_short": 0.6990018768230772
+    }
+  },
+  "v7": {
+    "n_train": 782,
+    "n_test": 197,
+    "raw_ece": 0.05581218274111675,
+    "head_ece": 0.03543727464886015,
+    "head_delta": -0.020374908092256602,
+    "bimodal_frac": 0.5939086294416244,
+    "middle_frac": 0.07614213197969544,
+    "intercept": 1.1835155126406238,
+    "coefficients": {
+      "logit_P(D)": 0.44529443525843077,
+      "has_code_fence": 0.09802715063736114,
+      "has_inline_code": 0.9153755767414963,
+      "has_markdown_table": 0.5450279805937654,
+      "has_numbers": 0.8272612640496102,
+      "has_file_paths": 0.16393431419283788,
+      "is_short": -1.8342035346258716,
+      "is_long": 0.4473917835313526,
+      "is_ood": 1.1776549569335886,
+      "short_X_numbers": -0.2766163687680083,
+      "short_X_file_paths": -0.3335942585991919,
+      "short_X_inline_code": -0.19913338021244928,
+      "short_X_markdown_table": 0.12048615295176258,
+      "ood_X_short": 1.016305277674243
+    }
+  },
+  "delta_v6_minus_v7_head_ece": 0.011859655088168782,
+  "verdict": "NEAR PARITY: v6+head ~ v7+head. The head alone recovers calibration regardless of training. Claim #2 is weaker than stated; the right framing is 'calibration is a post-hoc fit that works on either base model'."
+}

--- a/experiments/v6_with_h10_head_ablation.py
+++ b/experiments/v6_with_h10_head_ablation.py
@@ -1,0 +1,272 @@
+# ruff: noqa: I001, E402
+"""Ablation: does the H10 head recover v6's calibration?
+
+Jay's paper review (2026-04-18) noted that contribution #2 claims
+"uncertainty detection is training-driven, not architectural" but
+the evidence (v6 vs v7 ECE gap) confounds two variables: different
+training data AND different training dynamics. To support the claim
+we need to measure v6 WITH the same H10 head architecture. If v6+head
+still doesn't show uncertainty (high ECE / bimodal distribution),
+the training-data-only explanation is stronger.
+
+Test: run v6 on the SAME 982 clean-pool events used to fit H10, fit
+an H10-style head on v6 outputs, and compare to the head fit on v7
+outputs.
+
+Expected outcomes:
+  - v6+head ECE ~= v7+head ECE (0.035): training data didn't matter,
+    the head alone recovers calibration for any model. Our claim #2
+    is WRONG.
+  - v6+head ECE >> v7+head ECE: the v6 representation lacks the
+    signal the head needs. Training data matters. Claim #2 stands.
+"""
+
+from __future__ import annotations
+
+import torch  # noqa: F401
+
+import json
+import math
+import os
+import random
+import re
+from pathlib import Path
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+from merken.classifiers.nanogpt import NanoGPTWriteDecider
+from merken.policies.types import Event, WriteContext
+
+
+REPO = Path(__file__).resolve().parent.parent
+NANOGPT = Path(
+    os.environ.get("NANOGPT_REPO")
+    or (REPO.parent / "nanoGPT")
+)
+
+V6_CKPT = NANOGPT / "out-merken-bpe-v6" / "ckpt.pt"
+V6_META = NANOGPT / "data" / "merken_bpe_v6" / "meta.pkl"
+V7_CKPT = NANOGPT / "out-merken-bpe-v7" / "ckpt.pt"
+V7_META = NANOGPT / "data" / "merken_bpe_v7" / "meta.pkl"
+
+SOURCES_CLEAN = [
+    (REPO / "data" / "merken_labels_agree_write.jsonl", 0),
+    (REPO / "data" / "merken_labels_ldjnr_capybara.jsonl", 1),
+    (REPO / "data" / "merken_labels_slimorca.jsonl", 1),
+]
+
+EPS = 1e-6
+CODE_FENCE = re.compile(r"```")
+INLINE_CODE = re.compile(r"`[^`\n]{2,}`")
+TABLE_ROW = re.compile(r"\|[^\n]*\|[^\n]*\|")
+FILE_PATH = re.compile(r"\b\S+\.(?:py|js|ts|md|json|toml|yml|yaml|go|rs|sh|sql)\b")
+NUMBER = re.compile(r"\d")
+
+FEATURE_NAMES = [
+    "logit_P(D)",
+    "has_code_fence",
+    "has_inline_code",
+    "has_markdown_table",
+    "has_numbers",
+    "has_file_paths",
+    "is_short",
+    "is_long",
+    "is_ood",
+    "short_X_numbers",
+    "short_X_file_paths",
+    "short_X_inline_code",
+    "short_X_markdown_table",
+    "ood_X_short",
+]
+
+
+def logit(p):
+    p = min(max(p, EPS), 1 - EPS)
+    return math.log(p / (1 - p))
+
+
+def parse_pd(s):
+    m = re.search(r"P\(D\)=(\d+\.\d+|\d+)", s or "")
+    if not m:
+        return None
+    try:
+        return float(m.group(1))
+    except ValueError:
+        return None
+
+
+def featurize(text, is_ood):
+    has_code_fence = 1 if CODE_FENCE.search(text) else 0
+    has_inline_code = 1 if INLINE_CODE.search(text) else 0
+    has_markdown_table = 1 if TABLE_ROW.search(text) else 0
+    has_numbers = 1 if len(NUMBER.findall(text)) >= 3 else 0
+    has_file_paths = 1 if FILE_PATH.search(text) else 0
+    is_short = 1 if len(text) < 300 else 0
+    is_long = 1 if len(text) >= 1000 else 0
+    return [
+        has_code_fence, has_inline_code, has_markdown_table, has_numbers,
+        has_file_paths, is_short, is_long, is_ood,
+        is_short * has_numbers,
+        is_short * has_file_paths,
+        is_short * has_inline_code,
+        is_short * has_markdown_table,
+        is_ood * is_short,
+    ]
+
+
+def collect(decider, label):
+    ctx = WriteContext(project=f"ablation_{label}")
+    rows = []
+    for path, is_ood in SOURCES_CLEAN:
+        if not path.exists():
+            continue
+        with path.open(encoding="utf-8") as f:
+            for line in f:
+                try:
+                    r = json.loads(line)
+                except Exception:
+                    continue
+                lab = r.get("label")
+                if lab == "DECISION":
+                    y = 1
+                elif lab == "NOISE":
+                    y = 0
+                else:
+                    continue
+                text = (r.get("text") or "").strip()
+                if not text:
+                    continue
+                d = decider.decide(Event(text=text), ctx)
+                p = parse_pd(d.reason)
+                if p is None:
+                    continue
+                x = [logit(p)] + featurize(text, is_ood)
+                rows.append((x, y, p, text))
+    return rows
+
+
+def ece(pairs, n_bins=10):
+    bins = [(i / n_bins, (i + 1) / n_bins) for i in range(n_bins)]
+    N = len(pairs)
+    if N == 0:
+        return 0.0
+    e = 0.0
+    for lo, hi in bins:
+        in_bin = [(p, y) for p, y in pairs if lo <= p < (hi if hi < 1.0 else 1.01)]
+        n = len(in_bin)
+        if n == 0:
+            continue
+        conf = sum(p for p, _ in in_bin) / n
+        acc = sum(y for _, y in in_bin) / n
+        e += (n / N) * abs(conf - acc)
+    return e
+
+
+def fit_and_eval(rows, C=1.0):
+    rng = random.Random(42)
+    pos = [r for r in rows if r[1] == 1]
+    neg = [r for r in rows if r[1] == 0]
+    rng.shuffle(pos)
+    rng.shuffle(neg)
+    sp = int(0.8 * len(pos))
+    sn = int(0.8 * len(neg))
+    train = pos[:sp] + neg[:sn]
+    test = pos[sp:] + neg[sn:]
+    rng.shuffle(train)
+    rng.shuffle(test)
+
+    X_train = np.array([r[0] for r in train])
+    y_train = np.array([r[1] for r in train])
+    X_test = np.array([r[0] for r in test])
+
+    raw_test = [(r[2], r[1]) for r in test]
+    raw_ece = ece(raw_test)
+
+    lr = LogisticRegression(C=C, fit_intercept=True, max_iter=5000).fit(X_train, y_train)
+    p_test = lr.predict_proba(X_test)[:, 1]
+    head_test = [(float(p_test[i]), test[i][1]) for i in range(len(test))]
+    head_ece = ece(head_test)
+
+    # bimodality of raw
+    bimodal = sum(1 for p, _ in raw_test if p < 0.1 or p >= 0.9) / len(raw_test)
+    middle = sum(1 for p, _ in raw_test if 0.3 <= p < 0.7) / len(raw_test)
+    return {
+        "n_train": len(train),
+        "n_test": len(test),
+        "raw_ece": raw_ece,
+        "head_ece": head_ece,
+        "head_delta": head_ece - raw_ece,
+        "bimodal_frac": bimodal,
+        "middle_frac": middle,
+        "intercept": float(lr.intercept_[0]),
+        "coefficients": dict(zip(FEATURE_NAMES, [float(c) for c in lr.coef_[0]])),
+    }
+
+
+def main() -> int:
+    print(f"loading v6: {V6_CKPT}")
+    v6 = NanoGPTWriteDecider(str(V6_CKPT), str(V6_META))
+    print(f"loading v7: {V7_CKPT}")
+    v7 = NanoGPTWriteDecider(str(V7_CKPT), str(V7_META))
+
+    print("collecting v6 outputs on clean pool...")
+    rows_v6 = collect(v6, "v6")
+    print(f"  n={len(rows_v6)}")
+    print("collecting v7 outputs on clean pool...")
+    rows_v7 = collect(v7, "v7")
+    print(f"  n={len(rows_v7)}")
+
+    print("\n=== v6 + H10-style head (fit on v6 outputs) ===")
+    res_v6 = fit_and_eval(rows_v6, C=1.0)
+    print(f"  raw_ece     = {res_v6['raw_ece']:.3f}")
+    print(f"  head_ece    = {res_v6['head_ece']:.3f}")
+    print(f"  head_delta  = {res_v6['head_delta']:+.3f}")
+    print(f"  bimodal_frac (<0.1 or >=0.9) = {res_v6['bimodal_frac']:.3f}")
+    print(f"  middle_frac  (0.3..0.7)     = {res_v6['middle_frac']:.3f}")
+
+    print("\n=== v7 + H10 head (fit on v7 outputs, our baseline) ===")
+    res_v7 = fit_and_eval(rows_v7, C=1.0)
+    print(f"  raw_ece     = {res_v7['raw_ece']:.3f}")
+    print(f"  head_ece    = {res_v7['head_ece']:.3f}")
+    print(f"  head_delta  = {res_v7['head_delta']:+.3f}")
+    print(f"  bimodal_frac = {res_v7['bimodal_frac']:.3f}")
+    print(f"  middle_frac  = {res_v7['middle_frac']:.3f}")
+
+    print("\n=== verdict ===")
+    delta = res_v6["head_ece"] - res_v7["head_ece"]
+    if delta > 0.02:
+        verdict = (
+            "TRAINING MATTERS: v6+head ECE is materially higher than "
+            "v7+head. The head cannot compensate for v6's bimodal "
+            "representation. Claim #2 (uncertainty is training-driven) "
+            "survives."
+        )
+    elif delta < -0.005:
+        verdict = (
+            "INVERTED: v6+head beats v7+head. Claim #2 is wrong; the "
+            "head is doing the work, not v7's training."
+        )
+    else:
+        verdict = (
+            "NEAR PARITY: v6+head ~ v7+head. The head alone recovers "
+            "calibration regardless of training. Claim #2 is weaker "
+            "than stated; the right framing is 'calibration is a "
+            "post-hoc fit that works on either base model'."
+        )
+    print(verdict)
+
+    out = {
+        "v6": res_v6,
+        "v7": res_v7,
+        "delta_v6_minus_v7_head_ece": delta,
+        "verdict": verdict,
+    }
+    out_path = REPO / "experiments" / "nanogpt" / "v6_with_h10_head_ablation.json"
+    out_path.write_text(json.dumps(out, indent=2))
+    print(f"\nsaved to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/merken/_shadow.py
+++ b/merken/_shadow.py
@@ -31,6 +31,15 @@ Supported backends (shared between SHADOW and PRIMARY):
 - ``nanogpt``
     + ``MERKEN_<role>_NANOGPT_CKPT=/path/to/ckpt.pt``
     + ``MERKEN_<role>_NANOGPT_META=/path/to/meta.pkl``
+    + ``MERKEN_<role>_NANOGPT_CALIBRATOR=default`` (optional)
+      Wraps the decider with a post-hoc CalibrationHead so
+      ``Decision.reason`` includes ``P_cal=x.xxx`` and
+      ``Decision.confidence`` reports the calibrated value. Does NOT
+      change pass/fail -- threshold stays on raw P(D). Accepts:
+        * ``default`` -> use shipped
+          ``merken/classifiers/calibration_v7.json``.
+        * any filesystem path -> load that JSON instead.
+        * unset -> no calibration (raw P(D) shown).
 - ``llm``
     + ``MERKEN_<role>_LLM_MODEL=google/gemma-3-270m-it``
     + ``MERKEN_<role>_LLM_DEVICE=cpu`` (optional, default ``cpu``)
@@ -65,6 +74,33 @@ if (
     import torch  # noqa: F401
 
 
+def _resolve_calibrator(role: str):
+    """Return a CalibrationHead or None based on env.
+
+    ``MERKEN_<role>_NANOGPT_CALIBRATOR`` values:
+      - unset / empty -> None (no calibration)
+      - ``default`` (or ``shipped``) -> use
+        ``merken/classifiers/calibration_v7.json``
+      - any other value -> treat as a filesystem path to a JSON head
+
+    Errors loading the JSON raise; they are NOT silently swallowed.
+    We prefer a loud failure so a typoed path never silently
+    degrades into "no calibration".
+    """
+    raw = (os.environ.get(f"MERKEN_{role}_NANOGPT_CALIBRATOR") or "").strip()
+    if not raw:
+        return None
+    from merken.classifiers.calibration import CalibrationHead
+
+    if raw.lower() in ("default", "shipped"):
+        from pathlib import Path
+        path = Path(__file__).resolve().parent / "classifiers" / "calibration_v7.json"
+    else:
+        from pathlib import Path
+        path = Path(raw)
+    return CalibrationHead.from_json(path, source=f"{role}_env")
+
+
 def _build_classifier(kind: str, role: str):
     """Construct the classifier for ``role`` (``SHADOW`` / ``PRIMARY``)."""
     if kind == "nanogpt":
@@ -77,7 +113,8 @@ def _build_classifier(kind: str, role: str):
                 f"MERKEN_{role}=nanogpt requires MERKEN_{role}_NANOGPT_CKPT "
                 f"and MERKEN_{role}_NANOGPT_META env vars."
             )
-        return NanoGPTWriteDecider(ckpt, meta)
+        calibrator = _resolve_calibrator(role)
+        return NanoGPTWriteDecider(ckpt, meta, calibrator=calibrator)
 
     if kind == "llm":
         from merken.classifiers.llm import LLMWriteDecider

--- a/merken/_shadow.py
+++ b/merken/_shadow.py
@@ -36,10 +36,13 @@ Supported backends (shared between SHADOW and PRIMARY):
       ``Decision.reason`` includes ``P_cal=x.xxx`` and
       ``Decision.confidence`` reports the calibrated value. Does NOT
       change pass/fail -- threshold stays on raw P(D). Accepts:
-        * ``default`` -> use shipped
+        * ``default`` or ``shipped`` -> use shipped
           ``merken/classifiers/calibration_v7.json``.
         * any filesystem path -> load that JSON instead.
         * unset -> no calibration (raw P(D) shown).
+      Calibrator load errors (bad path, malformed JSON) print a
+      warning to stderr; the classifier still loads without
+      calibration.
 - ``llm``
     + ``MERKEN_<role>_LLM_MODEL=google/gemma-3-270m-it``
     + ``MERKEN_<role>_LLM_DEVICE=cpu`` (optional, default ``cpu``)
@@ -79,30 +82,38 @@ def _resolve_calibrator(role: str):
 
     ``MERKEN_<role>_NANOGPT_CALIBRATOR`` values:
       - unset / empty -> None (no calibration)
-      - ``default`` (or ``shipped``) -> use
+      - ``default`` or ``shipped`` -> use
         ``merken/classifiers/calibration_v7.json``
       - any other value -> treat as a filesystem path to a JSON head
 
-    Errors loading the JSON raise; they are NOT silently swallowed.
-    We prefer a loud failure so a typoed path never silently
-    degrades into "no calibration".
+    Errors loading the JSON raise; the caller can decide whether to
+    propagate or degrade gracefully. ``_build_classifier`` explicitly
+    catches + logs so a typoed calibrator path produces a visible
+    stderr warning rather than silently disabling calibration.
     """
+    from pathlib import Path
+
     raw = (os.environ.get(f"MERKEN_{role}_NANOGPT_CALIBRATOR") or "").strip()
     if not raw:
         return None
     from merken.classifiers.calibration import CalibrationHead
 
     if raw.lower() in ("default", "shipped"):
-        from pathlib import Path
         path = Path(__file__).resolve().parent / "classifiers" / "calibration_v7.json"
     else:
-        from pathlib import Path
         path = Path(raw)
     return CalibrationHead.from_json(path, source=f"{role}_env")
 
 
 def _build_classifier(kind: str, role: str):
-    """Construct the classifier for ``role`` (``SHADOW`` / ``PRIMARY``)."""
+    """Construct the classifier for ``role`` (``SHADOW`` / ``PRIMARY``).
+
+    Calibrator load errors are caught here and printed to stderr so
+    the classifier itself still loads. ``Memory._default_write_decider``
+    catches every exception from this function as a fail-safe (model
+    missing -> heuristic), so a calibrator misconfig would otherwise
+    silently disable the whole classifier -- not what we want.
+    """
     if kind == "nanogpt":
         from merken.classifiers.nanogpt import NanoGPTWriteDecider
 
@@ -113,7 +124,18 @@ def _build_classifier(kind: str, role: str):
                 f"MERKEN_{role}=nanogpt requires MERKEN_{role}_NANOGPT_CKPT "
                 f"and MERKEN_{role}_NANOGPT_META env vars."
             )
-        calibrator = _resolve_calibrator(role)
+        try:
+            calibrator = _resolve_calibrator(role)
+        except Exception as e:
+            import sys
+            print(
+                f"merken: failed to load {role} calibrator "
+                f"(MERKEN_{role}_NANOGPT_CALIBRATOR): "
+                f"{type(e).__name__}: {e}. "
+                f"Continuing without calibration.",
+                file=sys.stderr,
+            )
+            calibrator = None
         return NanoGPTWriteDecider(ckpt, meta, calibrator=calibrator)
 
     if kind == "llm":

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -100,6 +100,43 @@ def test_decider_without_calibrator_emits_baseline_reason():
     assert math.isclose(d.confidence, 0.72)
 
 
+def test_resolve_calibrator_from_env_default(monkeypatch):
+    """`_resolve_calibrator` returns the shipped head when env=default."""
+    from merken._shadow import _resolve_calibrator
+
+    monkeypatch.setenv("MERKEN_SHADOW_NANOGPT_CALIBRATOR", "default")
+    head = _resolve_calibrator("SHADOW")
+    assert head is not None
+    assert head.source == "SHADOW_env"
+    # Shipped head has a positive logit weight by construction.
+    assert head.w_logit > 0
+
+
+def test_resolve_calibrator_from_env_unset_returns_none(monkeypatch):
+    from merken._shadow import _resolve_calibrator
+
+    monkeypatch.delenv("MERKEN_SHADOW_NANOGPT_CALIBRATOR", raising=False)
+    assert _resolve_calibrator("SHADOW") is None
+
+
+def test_resolve_calibrator_from_env_explicit_path(tmp_path, monkeypatch):
+    from merken._shadow import _resolve_calibrator
+
+    payload = {
+        "head": {
+            "intercept": 0.1,
+            "coefficients": {"logit_P(D)": 0.9},
+        }
+    }
+    p = tmp_path / "custom_head.json"
+    p.write_text(json.dumps(payload))
+    monkeypatch.setenv("MERKEN_SHADOW_NANOGPT_CALIBRATOR", str(p))
+    head = _resolve_calibrator("SHADOW")
+    assert head is not None
+    assert math.isclose(head.intercept, 0.1)
+    assert math.isclose(head.w_logit, 0.9)
+
+
 def test_from_json_rejects_non_finite_weights(tmp_path: Path):
     payload = {
         "head": {

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -100,8 +100,16 @@ def test_decider_without_calibrator_emits_baseline_reason():
     assert math.isclose(d.confidence, 0.72)
 
 
+SHIPPED_HEAD_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "merken" / "classifiers" / "calibration_v7.json"
+)
+
+
 def test_resolve_calibrator_from_env_default(monkeypatch):
     """`_resolve_calibrator` returns the shipped head when env=default."""
+    if not SHIPPED_HEAD_PATH.exists():
+        pytest.skip("calibration_v7.json not shipped in this checkout")
     from merken._shadow import _resolve_calibrator
 
     monkeypatch.setenv("MERKEN_SHADOW_NANOGPT_CALIBRATOR", "default")
@@ -135,6 +143,21 @@ def test_resolve_calibrator_from_env_explicit_path(tmp_path, monkeypatch):
     assert head is not None
     assert math.isclose(head.intercept, 0.1)
     assert math.isclose(head.w_logit, 0.9)
+
+
+def test_resolve_calibrator_raises_on_missing_file(monkeypatch, tmp_path):
+    """Bad path should propagate, not silently return None.
+
+    Matches the "loud failure" contract documented in
+    merken/_shadow.py: _build_classifier logs + degrades gracefully,
+    but _resolve_calibrator itself raises so callers can decide.
+    """
+    from merken._shadow import _resolve_calibrator
+
+    bogus = tmp_path / "does_not_exist.json"
+    monkeypatch.setenv("MERKEN_SHADOW_NANOGPT_CALIBRATOR", str(bogus))
+    with pytest.raises(FileNotFoundError):
+        _resolve_calibrator("SHADOW")
 
 
 def test_from_json_rejects_non_finite_weights(tmp_path: Path):


### PR DESCRIPTION
## Summary

H3 earlier landed `CalibrationHead` and wired it through `NanoGPTWriteDecider(calibrator=...)`, but turning it on required writing code. Env-var callers (the live Claude Code / Desktop shadow hooks that drive shadow mode in production) had no path to use it.

This PR adds `MERKEN_<role>_NANOGPT_CALIBRATOR` to `merken/_shadow.py::_build_classifier`. Three accepted values:

| env value | behavior |
|-----------|----------|
| unset / empty | no calibration (status quo) |
| `default` / `shipped` | load `merken/classifiers/calibration_v7.json` (H10 C=1 head) |
| `/path/to/head.json` | load that JSON |

Filter pass/fail is UNCHANGED -- the calibrator only rewrites `Decision.reason` (adds `P_cal=x.xxx`) and `Decision.confidence`.

## Smoke

```
export MERKEN_SHADOW=nanogpt
export MERKEN_SHADOW_NANOGPT_CKPT=.../out-merken-bpe-v7/ckpt.pt
export MERKEN_SHADOW_NANOGPT_META=.../data/merken_bpe_v7/meta.pkl
export MERKEN_SHADOW_NANOGPT_CALIBRATOR=default
```

Live `Memory.remember("Fix: replaced pgbouncer in db/pool.py line 42. p95 180ms -> 40ms.")`:

```
Decision.reason = "P(D)=0.821 P(N)=0.176 P_cal=0.601"
Decision.confidence = 0.601
```

## Test plan

- [x] `tests/test_calibration.py`: 3 new tests cover default / unset / explicit-path. 17/17 total.
- [x] `test_resolve_calibrator_from_env_default` confirms shipped head loads with source tag `SHADOW_env`.
- [x] Smoke test shows `P_cal` appears in reason and `confidence` reflects calibrated value.
- [ ] Future: add a small `Memory(calibrated=True)` convenience constructor if direct-code callers ask for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)