### PR TITLE
docs(paper): round-2 honesty fixes + H10 interaction ablation

### DIFF
--- a/experiments/h10_interaction_ablation.py
+++ b/experiments/h10_interaction_ablation.py
@@ -1,0 +1,249 @@
+# ruff: noqa: I001, E402
+"""H10 interaction-term leave-one-out ablation.
+
+Jay's paper review (2026-04-18) pointed out that H10 shipped with
+five interaction terms motivated by one smoke case and never
+ablated individually. This script runs a leave-one-out sweep: refit
+the head with each of the 5 interaction features removed, compare
+test ECE.
+
+Features dropped one at a time:
+  - short_X_numbers
+  - short_X_file_paths
+  - short_X_inline_code
+  - short_X_markdown_table
+  - ood_X_short
+
+All fits at C=1 on the same 80/20 split as H10. If no single
+interaction is load-bearing (all leave-one-out ECEs stay within
+0.005 of the full-head ECE), that's evidence the set is redundant
+and fewer features would do. If one dominates (e.g. ood_X_short),
+that's the real signal; the others are decoration.
+"""
+
+from __future__ import annotations
+
+import torch  # noqa: F401
+
+import json
+import math
+import os
+import random
+import re
+from pathlib import Path
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+from merken.classifiers.nanogpt import NanoGPTWriteDecider
+from merken.policies.types import Event, WriteContext
+
+
+REPO = Path(__file__).resolve().parent.parent
+
+SOURCES_CLEAN = [
+    (REPO / "data" / "merken_labels_agree_write.jsonl", 0),
+    (REPO / "data" / "merken_labels_ldjnr_capybara.jsonl", 1),
+    (REPO / "data" / "merken_labels_slimorca.jsonl", 1),
+]
+
+EPS = 1e-6
+
+CODE_FENCE = re.compile(r"```")
+INLINE_CODE = re.compile(r"`[^`\n]{2,}`")
+TABLE_ROW = re.compile(r"\|[^\n]*\|[^\n]*\|")
+FILE_PATH = re.compile(r"\b\S+\.(?:py|js|ts|md|json|toml|yml|yaml|go|rs|sh|sql)\b")
+NUMBER = re.compile(r"\d")
+
+FULL_FEATURES = [
+    "logit_P(D)",
+    "has_code_fence",
+    "has_inline_code",
+    "has_markdown_table",
+    "has_numbers",
+    "has_file_paths",
+    "is_short",
+    "is_long",
+    "is_ood",
+    "short_X_numbers",
+    "short_X_file_paths",
+    "short_X_inline_code",
+    "short_X_markdown_table",
+    "ood_X_short",
+]
+
+INTERACTION_NAMES = [
+    "short_X_numbers",
+    "short_X_file_paths",
+    "short_X_inline_code",
+    "short_X_markdown_table",
+    "ood_X_short",
+]
+
+
+def logit(p):
+    p = min(max(p, EPS), 1 - EPS)
+    return math.log(p / (1 - p))
+
+
+def parse_pd(s):
+    m = re.search(r"P\(D\)=(\d+\.\d+|\d+)", s or "")
+    if not m:
+        return None
+    try:
+        return float(m.group(1))
+    except ValueError:
+        return None
+
+
+def featurize(text, is_ood):
+    has_code_fence = 1 if CODE_FENCE.search(text) else 0
+    has_inline_code = 1 if INLINE_CODE.search(text) else 0
+    has_markdown_table = 1 if TABLE_ROW.search(text) else 0
+    has_numbers = 1 if len(NUMBER.findall(text)) >= 3 else 0
+    has_file_paths = 1 if FILE_PATH.search(text) else 0
+    is_short = 1 if len(text) < 300 else 0
+    is_long = 1 if len(text) >= 1000 else 0
+    return {
+        "has_code_fence": has_code_fence,
+        "has_inline_code": has_inline_code,
+        "has_markdown_table": has_markdown_table,
+        "has_numbers": has_numbers,
+        "has_file_paths": has_file_paths,
+        "is_short": is_short,
+        "is_long": is_long,
+        "is_ood": is_ood,
+        "short_X_numbers": is_short * has_numbers,
+        "short_X_file_paths": is_short * has_file_paths,
+        "short_X_inline_code": is_short * has_inline_code,
+        "short_X_markdown_table": is_short * has_markdown_table,
+        "ood_X_short": is_ood * is_short,
+    }
+
+
+def build_vector(p_raw, feats, feature_list):
+    vec = []
+    for name in feature_list:
+        if name == "logit_P(D)":
+            vec.append(logit(p_raw))
+        else:
+            vec.append(feats[name])
+    return vec
+
+
+def collect(decider):
+    ctx = WriteContext(project="h10ablation")
+    rows = []
+    for path, is_ood in SOURCES_CLEAN:
+        if not path.exists():
+            continue
+        with path.open(encoding="utf-8") as f:
+            for line in f:
+                try:
+                    r = json.loads(line)
+                except Exception:
+                    continue
+                label = r.get("label")
+                if label == "DECISION":
+                    y = 1
+                elif label == "NOISE":
+                    y = 0
+                else:
+                    continue
+                text = (r.get("text") or "").strip()
+                if not text:
+                    continue
+                p = parse_pd(r.get("shadow_reason"))
+                if p is None:
+                    d = decider.decide(Event(text=text), ctx)
+                    p = parse_pd(d.reason)
+                if p is None:
+                    continue
+                feats = featurize(text, is_ood)
+                rows.append((p, feats, y))
+    return rows
+
+
+def ece(pairs, n_bins=10):
+    bins = [(i / n_bins, (i + 1) / n_bins) for i in range(n_bins)]
+    N = len(pairs)
+    if N == 0:
+        return 0.0
+    e = 0.0
+    for lo, hi in bins:
+        in_bin = [(p, y) for p, y in pairs if lo <= p < (hi if hi < 1.0 else 1.01)]
+        n = len(in_bin)
+        if n == 0:
+            continue
+        conf = sum(p for p, _ in in_bin) / n
+        acc = sum(y for _, y in in_bin) / n
+        e += (n / N) * abs(conf - acc)
+    return e
+
+
+def fit_and_eval(rows, feature_list, C=1.0, seed=42):
+    rng = random.Random(seed)
+    pos = [r for r in rows if r[2] == 1]
+    neg = [r for r in rows if r[2] == 0]
+    rng.shuffle(pos)
+    rng.shuffle(neg)
+    sp = int(0.8 * len(pos))
+    sn = int(0.8 * len(neg))
+    train = pos[:sp] + neg[:sn]
+    test = pos[sp:] + neg[sn:]
+    rng.shuffle(train)
+    rng.shuffle(test)
+
+    X_train = np.array([build_vector(p, f, feature_list) for (p, f, _) in train])
+    y_train = np.array([y for (_, _, y) in train])
+    X_test = np.array([build_vector(p, f, feature_list) for (p, f, _) in test])
+
+    lr = LogisticRegression(C=C, fit_intercept=True, max_iter=5000).fit(X_train, y_train)
+    p_test = lr.predict_proba(X_test)[:, 1]
+    pairs = [(float(p_test[i]), test[i][2]) for i in range(len(test))]
+    return ece(pairs), float(lr.intercept_[0]), dict(zip(feature_list, [float(c) for c in lr.coef_[0]]))
+
+
+def main() -> int:
+    ckpt = os.environ.get("MERKEN_SHADOW_NANOGPT_CKPT")
+    meta = os.environ.get("MERKEN_SHADOW_NANOGPT_META")
+    if not ckpt or not meta:
+        raise SystemExit("set MERKEN_SHADOW_NANOGPT_CKPT / _META")
+    v7 = NanoGPTWriteDecider(ckpt, meta)
+    rows = collect(v7)
+    print(f"n={len(rows)}")
+
+    full_ece, _, full_coefs = fit_and_eval(rows, FULL_FEATURES, C=1.0)
+    print(f"\nFULL head (all 14 features) ECE = {full_ece:.4f}")
+
+    print(f"\nLeave-one-out (drop each interaction, refit, measure delta):")
+    print(f"{'dropped':<28} {'ECE':>7} {'delta_vs_full':>15}  dropped_feature_weight_in_full")
+    results = {"full_ece": full_ece, "full_coefficients": full_coefs, "loo": {}}
+    for dropped in INTERACTION_NAMES:
+        features = [f for f in FULL_FEATURES if f != dropped]
+        e, _, _ = fit_and_eval(rows, features, C=1.0)
+        delta = e - full_ece
+        w_in_full = full_coefs.get(dropped, 0.0)
+        print(f"{dropped:<28} {e:>6.4f}  {delta:>+7.4f}          {w_in_full:+.3f}")
+        results["loo"][dropped] = {"ece": e, "delta_vs_full": delta, "weight_in_full": w_in_full}
+
+    # No-interactions baseline (H11-style, 9 features)
+    no_inter = [f for f in FULL_FEATURES if f not in INTERACTION_NAMES]
+    e, _, _ = fit_and_eval(rows, no_inter, C=1.0)
+    delta = e - full_ece
+    print(f"\nNO interactions (9 features, H11-style)")
+    print(f"  ECE = {e:.4f}  delta_vs_full = {delta:+.4f}")
+    results["no_interactions"] = {"ece": e, "delta_vs_full": delta}
+
+    # Verdict
+    largest_effect = max(results["loo"].items(), key=lambda kv: abs(kv[1]["delta_vs_full"]))
+    print(f"\nLargest single effect: {largest_effect[0]} (delta {largest_effect[1]['delta_vs_full']:+.4f})")
+
+    out_path = REPO / "experiments" / "nanogpt" / "h10_interaction_ablation.json"
+    out_path.write_text(json.dumps(results, indent=2))
+    print(f"\nsaved to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/nanogpt/PAPER_DRAFT.md
+++ b/experiments/nanogpt/PAPER_DRAFT.md
@@ -40,21 +40,25 @@ evaluation, and a clean held-out that drove no design decisions.
 
 ## Abstract
 
-On held-out synthetic benchmarks a 4-layer 800K-parameter BPE
-transformer achieves 86% store reduction and 100% recall. On real
-Claude Code transcripts from the same author the numbers move:
-real store reduction is **7.7%**, real population-weighted
-accuracy-vs-Gemini is **80.9%**, and the filter is uniformly
-over-confident on short prose and uniformly under-confident on
-out-of-distribution public instruction-tuning data. We document
-this Production-Benchmark Gap and show that **scalar post-hoc
-calibration cannot represent opposite-direction bias across
-domains** -- a structural limit, not a fundamental one; a per-
-distribution head would. An ablation with v6 + our H10 head shows
-that calibration is largely a post-hoc fit that works on either
-base model (v6+head ECE 0.047, v7+head ECE 0.035); real-label
-training redistributes raw output mass (bimodal 93% -> 59%) but
-does NOT confer calibration the head can't recover.
+We measured a 4-layer 800K-parameter BPE write-filter transformer
+on two class distributions: a synthetic scenario with 86% NOI
+prevalence (designed to expose filter behavior on heavy noise) and
+real Claude Code transcripts with ~24% NOI prevalence. Store
+reduction is 86% on synthetic and **7.7% on real**; population-
+weighted accuracy-vs-Gemini is 99.9% on synthetic and **80.9% on
+real**. We document this Production-Benchmark Gap and show that
+**scalar post-hoc calibration cannot represent opposite-direction
+bias across domains** -- a structural limit of scalar methods, not
+of post-hoc calibration in general (a per-distribution head would
+resolve it; we did not fit one). A leave-one-out ablation on our
+14-feature calibration head reveals that the 5 interaction terms
+are mostly not load-bearing: only ``ood_X_short`` contributes
+meaningfully; the interaction we designed from a specific smoke
+case (``short_X_numbers``) contributes zero. An ablation with v6 +
+the same head shows calibration is largely a post-hoc fit that
+works on either base model (v6+head ECE 0.047, v7+head ECE 0.035);
+real-label training redistributes raw output mass (bimodal 93% ->
+59%) but does NOT confer calibration the head can't recover.
 
 ## 1. Setup
 
@@ -176,9 +180,13 @@ measured on a scenario with 86% NOI events. Real distribution is
 real decision (98.4% DEC recall), rarely prunes noise (26.8% NOI
 recall).
 
-Given the oracle ceiling (~80% from manual audit), the 80.9%
-accuracy number sits at the noise floor of Gemini's own reliability.
-We cannot claim v7 is more accurate than Gemini agrees with itself.
+Oracle reliability: the 15/20 (75%) manual audit covers the DEC
+class only. NOI-side human audit was not run. A rough upper bound
+on overall oracle reliability is therefore unverified; if NOI
+accuracy matches DEC at ~75-85%, the pooled upper bound is also
+~75-85%. The 80.9% population-weighted number sits inside that
+band and should not be read as a hard accuracy claim against
+ground truth.
 
 ## 4. Calibration
 
@@ -210,14 +218,29 @@ and on v7 outputs, both at C=1:
 | v7 | 0.056 | 0.035 | -0.020 |
 
 **The head recovers calibration for EITHER base model.** Delta
-between v6+head and v7+head is 0.012, below the "meaningful
-difference" threshold we pre-registered (>0.02). This **falsifies**
-the stronger version of our earlier claim ("uncertainty emerges
-from training, not architecture"). Honest rewrite: real-label
-training **redistributes raw output mass**, but a small post-hoc
-head recovers ECE regardless. What training buys you is
-**interpretable probabilities without a calibration wrapper**, not
-calibration per se.
+between v6+head and v7+head is 0.012.
+
+**Threshold disclosure:** the threshold of 0.02 for "meaningful
+difference" was written into the verdict logic of
+`experiments/v6_with_h10_head_ablation.py` before the script was
+run for the first time, but it was NOT recorded in HYPOTHESES.md
+with a timestamp prior to the experiment. In the weaker sense of
+pre-registration (chosen before seeing the number), 0.02 is
+pre-registered. In the stronger sense (public dated artifact), it
+is post-hoc. Stating this plainly because a hostile reviewer
+would rightly ask.
+
+Regardless of threshold semantics, the 0.012 delta is about half
+the size of the standard "0.05 = well calibrated" gap that
+framed the entire calibration section, so calling it "small" is
+the honest read.
+
+This **falsifies** the stronger version of our earlier claim
+("uncertainty emerges from training, not architecture"). Honest
+rewrite: real-label training **redistributes raw output mass**,
+but a small post-hoc head recovers ECE regardless. What training
+buys you is **interpretable probabilities without a calibration
+wrapper**, not calibration per se.
 
 ### 4.3 Structure-dependent calibration
 
@@ -269,19 +292,58 @@ Honest history of feature selection:
   file_paths, raw 0.857 -> H11 head 0.371 -> desired recovery).
   C=1, ECE 0.035.
 
-**Feature-engineering disclosure:** the 5 interaction terms were
-added AFTER observing the specific smoke case. ECE 0.035 is on a
-clean 80/20 split of the 982-label pool, but the FEATURE DESIGN
-was motivated by one training example. A reviewer would rightly
-want either (a) a held-out-from-design test set, or (b) an ablation
-showing ECE with only 0-5 of the 5 interactions retained.
-Neither was run; documented as H10 caveat, not as part of this
-section's main claim.
+**Feature-engineering disclosure + leave-one-out ablation.** The 5
+interaction terms were added after observing a specific smoke case,
+which is post-hoc feature engineering. We ran a leave-one-out
+ablation
+(`experiments/h10_interaction_ablation.py` +
+`experiments/nanogpt/h10_interaction_ablation.json`) to see how
+load-bearing each interaction actually is:
+
+| configuration | ECE | delta vs full |
+|---------------|----:|---------------:|
+| full (14 features) | 0.0354 | -- |
+| drop `short_X_numbers` | 0.0354 | +0.0000 |
+| drop `short_X_file_paths` | **0.0312** | -0.0043 (IMPROVES) |
+| drop `short_X_markdown_table` | 0.0372 | +0.0018 |
+| drop `short_X_inline_code` | 0.0414 | +0.0060 |
+| drop `ood_X_short` | 0.0439 | +0.0085 |
+| no interactions (9 features, H11) | 0.0477 | +0.0122 |
+
+Two findings that are unkind to the original H10 narrative:
+
+1. **The interaction I introduced to fix the smoke case
+   (`short_X_numbers`) contributes zero**. The smoke case was
+   "short + numbers + file_paths = concrete DEC"; I added
+   `short_X_numbers` to capture exactly that. In the fit it takes
+   weight -0.28 and removing it does not move ECE.
+
+2. **Dropping `short_X_file_paths` improves ECE**. It has weight
+   -0.33 in the full fit, i.e. it actively pushes the fit away
+   from where the smoke case wanted to land. The full head
+   compensates with other terms; a leaner head without this
+   feature is measurably better-calibrated.
+
+3. **Most of the gain over H11 (ECE 0.043 -> 0.035) comes from
+   `ood_X_short` alone** (+0.0085 when dropped). The other four
+   interaction terms net out to ~0.0037 of improvement.
+
+Honest read: the 5-feature interaction set is over-specified for
+this data. A 10-feature head (9 base + `ood_X_short` only) would
+ship the essential signal with less overfitting risk. We have not
+re-shipped the smaller head; the currently-shipped
+`merken/classifiers/calibration_v7.json` still carries the full
+14-feature fit. Proposed follow-up: re-ship with a 10-feature
+minimal head and re-run the ablation against fresh data once
+available.
 
 ### 4.6 Cross-distribution bias is opposite-direction
 
-Combining Jay HIGH-regime labels with Capybara LOW-regime events
-(`experiments/calibrate_v7_platt.py`, n=592): the two subsets have
+Combining the 494 agree_write events from Jay's transcripts
+(where v7 is over-confident DEC by construction: all P(D) >= 0.6)
+with the 98 Capybara events whose v7 P(D) fell below 0.3 (where
+v7 is under-confident; total 592 events)
+(`experiments/calibrate_v7_platt.py`): the two subsets have
 opposite bias signs. A scalar Platt fit REGRESSES ECE from 0.145
 (raw) to 0.177. Temperature scaling also regresses.
 
@@ -386,7 +448,9 @@ To move from N=1 memo to workshop paper, the gap is:
   to close the 157 FN remaining on real DECs without regressing
   markdown FPR.
 
-Estimated: 4-6 weeks of focused work. Not planned.
+Estimated: 4-6 weeks of focused work. Out of scope for this memo;
+potential follow-up if and when multi-user data becomes available
+or if a collaborator wants to drive the venue path.
 
 ## 9. Recommended disposition
 

--- a/experiments/nanogpt/h10_interaction_ablation.json
+++ b/experiments/nanogpt/h10_interaction_ablation.json
@@ -1,0 +1,50 @@
+{
+  "full_ece": 0.03543727464886015,
+  "full_coefficients": {
+    "logit_P(D)": 0.44529443525843077,
+    "has_code_fence": 0.09802715063736114,
+    "has_inline_code": 0.9153755767414963,
+    "has_markdown_table": 0.5450279805937654,
+    "has_numbers": 0.8272612640496102,
+    "has_file_paths": 0.16393431419283788,
+    "is_short": -1.8342035346258716,
+    "is_long": 0.4473917835313526,
+    "is_ood": 1.1776549569335886,
+    "short_X_numbers": -0.2766163687680083,
+    "short_X_file_paths": -0.3335942585991919,
+    "short_X_inline_code": -0.19913338021244928,
+    "short_X_markdown_table": 0.12048615295176258,
+    "ood_X_short": 1.016305277674243
+  },
+  "loo": {
+    "short_X_numbers": {
+      "ece": 0.03539728613105276,
+      "delta_vs_full": -3.998851780739193e-05,
+      "weight_in_full": -0.2766163687680083
+    },
+    "short_X_file_paths": {
+      "ece": 0.03115728302504812,
+      "delta_vs_full": -0.00427999162381203,
+      "weight_in_full": -0.3335942585991919
+    },
+    "short_X_inline_code": {
+      "ece": 0.041398961784410646,
+      "delta_vs_full": 0.005961687135550495,
+      "weight_in_full": -0.19913338021244928
+    },
+    "short_X_markdown_table": {
+      "ece": 0.03722230375591078,
+      "delta_vs_full": 0.0017850291070506258,
+      "weight_in_full": 0.12048615295176258
+    },
+    "ood_X_short": {
+      "ece": 0.04393631414118826,
+      "delta_vs_full": 0.008499039492328109,
+      "weight_in_full": 1.016305277674243
+    }
+  },
+  "no_interactions": {
+    "ece": 0.04766307437253882,
+    "delta_vs_full": 0.012225799723678668
+  }
+}


### PR DESCRIPTION
## Summary

Jay's second review of `PAPER_DRAFT.md` caught six items. All addressed in one commit. Also adds the ablation Jay asked for.

## The ablation Jay asked for

`experiments/h10_interaction_ablation.py` does leave-one-out on the 5 H10 interaction terms. Results are **unkind to the original H10 narrative**:

| configuration | ECE | delta vs full |
|---------------|----:|---------------:|
| full (14 features) | 0.0354 | -- |
| drop `short_X_numbers` | 0.0354 | +0.0000 (**zero contribution**) |
| drop `short_X_file_paths` | **0.0312** | -0.0043 (IMPROVES) |
| drop `short_X_markdown_table` | 0.0372 | +0.0018 |
| drop `short_X_inline_code` | 0.0414 | +0.0060 |
| drop `ood_X_short` | 0.0439 | +0.0085 |
| no interactions (H11, 9 features) | 0.0477 | +0.0122 |

- The interaction I added to "fix" the smoke case (`short_X_numbers`) contributes **zero**.
- `short_X_file_paths` actively regresses; dropping it improves ECE by 0.004.
- `ood_X_short` is the only load-bearing interaction. Most of H10's gain over H11 comes from this one feature.

Honest conclusion: the 5-interaction set is over-specified. A 10-feature head (9 base + `ood_X_short`) would ship essentially the same signal. Proposed follow-up: re-ship with the minimal head.

## Six honesty fixes

1. **Abstract hook**: pairs each headline number with its class prevalence so a fast reader can't walk away with the good number alone.
2. **Threshold disclosure**: the 0.02 "meaningful difference" threshold was set in-script before the experiment ran, but NOT recorded in `HYPOTHESES.md` with a timestamp. Stated plainly as "weak pre-registration, strong pre-registration missing".
3. **H10 caveat replaced with the ablation above** (was "neither was run; documented as caveat"; now is "here is the ablation + what it shows").
4. **Section 8 closing** ("Not planned.") reworded to a neutral "out of scope for this memo; potential follow-up".
5. **Section 4.6 n=592 composition** clarified: 494 agree_write (Jay, P(D) >= 0.6) + 98 Capybara LOW (public, P(D) < 0.3).
6. **Section 3.4 oracle ceiling**: 15/20 is DEC-only; NOI human audit not run; overall upper bound ~75-85% unverified. "Noise floor" language removed.

## Net effect

Weaker claims, more honest text. Shipped classifier unchanged. Only paper text + one new ablation script. Disposition remains blog post / tech report.

## Test plan

- [x] `experiments/h10_interaction_ablation.py` runs clean, produces `h10_interaction_ablation.json`.
- [x] All previous tests still pass (no code changes to `merken/` packages).
- [ ] Follow-up: re-ship 10-feature minimal head, re-run ablation once new labels available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)