### PR TITLE
feat(midloop): Phase 2 -- midloop primitive + Memory.observe_step

### DIFF
--- a/merken/audit.py
+++ b/merken/audit.py
@@ -134,6 +134,44 @@ def format_consolidate_audit_row(
     return title, body
 
 
+def format_midloop_audit_row(observation, decision) -> tuple[str, str]:
+    """Build a (title, body) pair for one midloop (should_intervene) audit row.
+
+    Lives here for symmetry with the other format_*_audit_row helpers.
+    Imports are deferred so that ``audit.py`` does not depend on the
+    midloop module if a caller never uses it -- midloop is the only
+    primitive whose dataclasses live in policies/ rather than at the
+    package root.
+
+    Body is plain key:value text so vstash FTS can find rows by
+    ``task_id:abc123`` or ``step_index:7`` or ``shadow_disagree``.
+    """
+    import json
+    ts = datetime.now(timezone.utc).isoformat(timespec="microseconds")
+    preview = " ".join((observation.output_text or "").split())[:_PREVIEW_CHARS]
+    body = (
+        f"timestamp: {ts}\n"
+        f"decision: should_intervene\n"
+        f"task_id: {observation.task_id}\n"
+        f"step_id: {observation.step_id}\n"
+        f"step_index: {observation.step_index}\n"
+        f"task_category: {observation.task_category.value}\n"
+        f"intervene: {decision.intervene}\n"
+        f"action: {decision.action.value}\n"
+        f"state: {decision.state.value}\n"
+        f"confidence: {decision.confidence:.4f}\n"
+        f"reason: {decision.reason}\n"
+        f"policy: {decision.policy}\n"
+        f"signals: {json.dumps(decision.signals, sort_keys=True)}\n"
+        f"output_preview: {preview}\n"
+    )
+    title = (
+        f"audit:should_intervene:{observation.task_id}:"
+        f"step{observation.step_index:04d}:{ts}"
+    )
+    return title, body
+
+
 def format_audit_row(event: Event, decision: Decision) -> tuple[str, str]:
     """Build a (title, body) pair for one audit entry.
 

--- a/merken/memory.py
+++ b/merken/memory.py
@@ -224,7 +224,9 @@ class Memory:
         consolidate_decider: ConsolidateDecider | None = None,
         recall_decider: RecallDecider | None = None,
         forget_decider: ForgetDecider | None = None,
+        midloop_decider: Any | None = None,
         temporal_weight: float = 0.0,
+        trajectory_window: int = 20,
     ) -> None:
         self.project = project
         self.collection = collection
@@ -241,6 +243,17 @@ class Memory:
         )
         self._recall_decider: RecallDecider = recall_decider or LayeredRecaller()
         self._forget_decider: ForgetDecider = forget_decider or NeverForget()
+
+        # Midloop default is Noop (never intervenes). The trajectory
+        # is per-Memory instance state, intentionally NOT persisted
+        # step-a-step (per midloop spec section "Trajectory, no
+        # snapshot"). Callers reuse the same Memory instance across a
+        # session to maintain trajectory coherence.
+        from collections import deque
+        from merken.policies.midloop import NoopMidloopDecider
+        self._midloop_decider = midloop_decider or NoopMidloopDecider()
+        self._trajectory: deque = deque(maxlen=trajectory_window)
+        self._prev_midloop_decision = None
 
         # Wire the write decider's hydration to vstash so cross-invocation
         # dedup works without the caller knowing about _seen sets. If the
@@ -914,6 +927,62 @@ class Memory:
             fts_only=fts_only,
         )
 
+    # --------------------------------------------------------------- midloop
+
+    def observe_step(self, observation, *, is_last_step: bool = False):
+        """Submit one step observation to the midloop and (maybe) audit it.
+
+        Per midloop spec section "Trayectoria, no snapshot":
+          - The trajectory window is per-Memory-instance state, NOT
+            persisted step-by-step. Reuse the same Memory instance
+            across a session for trajectory coherence.
+          - The full trajectory (last N observations) is passed to the
+            decider so it can compute trends.
+          - Only "interesting" steps land in the audit log. The
+            ``is_persistable_step`` filter drops on_track-with-no-change
+            rows so the audit collection does not flood. Last step
+            before task outcome always persists -- pass
+            ``is_last_step=True`` on the final observation of a task.
+
+        Returns the ``MidloopDecision`` so the caller can act on
+        ``decision.intervene`` / ``decision.action`` if it wants
+        runtime behavior to follow the midloop's recommendation.
+        """
+        from merken.policies.midloop import (
+            MidloopContext,
+            is_persistable_step,
+        )
+
+        ctx = MidloopContext(
+            project=self.project,
+            task_id=observation.task_id,
+            task_category=observation.task_category,
+            trajectory_size=len(self._trajectory),
+            task_description=observation.metadata.get("task_description", ""),
+        )
+        decision = self._midloop_decider.decide(
+            observation=observation,
+            ctx=ctx,
+            trajectory=list(self._trajectory),
+        )
+
+        if is_persistable_step(decision, self._prev_midloop_decision, is_last_step):
+            self._write_midloop_audit(observation, decision)
+
+        self._trajectory.append(observation)
+        self._prev_midloop_decision = decision
+        return decision
+
+    def reset_trajectory(self) -> None:
+        """Clear the in-process trajectory window (typically on task switch).
+
+        Call between tasks so signals from the previous task do not
+        leak into the next task's decisions. The audit log still has
+        the prior task's persisted rows.
+        """
+        self._trajectory.clear()
+        self._prev_midloop_decision = None
+
     # --------------------------------------------------------------- labels
 
     def remember_label(self, *, event_title: str, body: str) -> None:
@@ -976,6 +1045,25 @@ class Memory:
     ) -> None:
         """Audit one ``should_consolidate`` decision. Same fail-open policy."""
         title, body = format_consolidate_audit_row(decision, n_events)
+        try:
+            self._vstash.remember(
+                body,
+                title=title,
+                collection=AUDIT_COLLECTION,
+                layer=AUDIT_LAYER,
+            )
+        except Exception:
+            pass
+
+    def _write_midloop_audit(self, observation, decision) -> None:
+        """Audit one ``should_intervene`` decision.
+
+        Same fail-open policy as the other audit writers: a flaky
+        write must never break the user's call. Uses the canonical
+        format from ``merken.audit.format_midloop_audit_row``.
+        """
+        from merken.audit import format_midloop_audit_row
+        title, body = format_midloop_audit_row(observation, decision)
         try:
             self._vstash.remember(
                 body,

--- a/merken/memory.py
+++ b/merken/memory.py
@@ -54,7 +54,6 @@ from merken.policies.should_forget import (
     ForgetDecision,
     NeverForget,
 )
-from merken.sourcing import is_safely_mutable
 from merken.policies.should_recall import (
     LayeredRecaller,
     RecallContext,
@@ -67,9 +66,16 @@ from merken.policies.should_remember import (
     ShadowWriteDecider,
 )
 from merken.policies.types import Decision, Event, WriteContext, WriteDecider
+from merken.sourcing import is_safely_mutable
 
 if TYPE_CHECKING:
     from vstash import IngestResult, SearchResult
+
+    from merken.policies.midloop import (
+        MidloopDecider,
+        MidloopDecision,
+        StepObservation,
+    )
 
 DEFAULT_LAYER = "episodic"
 DEFAULT_COLLECTION = "default"
@@ -224,7 +230,7 @@ class Memory:
         consolidate_decider: ConsolidateDecider | None = None,
         recall_decider: RecallDecider | None = None,
         forget_decider: ForgetDecider | None = None,
-        midloop_decider: Any | None = None,
+        midloop_decider: MidloopDecider | None = None,
         temporal_weight: float = 0.0,
         trajectory_window: int = 20,
     ) -> None:
@@ -250,6 +256,7 @@ class Memory:
         # snapshot"). Callers reuse the same Memory instance across a
         # session to maintain trajectory coherence.
         from collections import deque
+
         from merken.policies.midloop import NoopMidloopDecider
         self._midloop_decider = midloop_decider or NoopMidloopDecider()
         self._trajectory: deque = deque(maxlen=trajectory_window)
@@ -929,7 +936,12 @@ class Memory:
 
     # --------------------------------------------------------------- midloop
 
-    def observe_step(self, observation, *, is_last_step: bool = False):
+    def observe_step(
+        self,
+        observation: StepObservation,
+        *,
+        is_last_step: bool = False,
+    ) -> MidloopDecision:
         """Submit one step observation to the midloop and (maybe) audit it.
 
         Per midloop spec section "Trayectoria, no snapshot":
@@ -1055,7 +1067,11 @@ class Memory:
         except Exception:
             pass
 
-    def _write_midloop_audit(self, observation, decision) -> None:
+    def _write_midloop_audit(
+        self,
+        observation: StepObservation,
+        decision: MidloopDecision,
+    ) -> None:
         """Audit one ``should_intervene`` decision.
 
         Same fail-open policy as the other audit writers: a flaky

--- a/merken/policies/midloop.py
+++ b/merken/policies/midloop.py
@@ -1,0 +1,582 @@
+"""``should_intervene`` policies -- the fifth decision primitive.
+
+The midloop sits between the Builder (inner loop) and the Judge
+(outer loop). Builder generates output; Judge evaluates final
+artifacts. Midloop watches the trajectory in flight and decides
+whether to intervene mid-stream (whisper guidance, escalate,
+rollback, or abort) before the Builder wastes more compute on a
+trajectory that has gone bad.
+
+Full design context: ``notes/midloop-spec.md``.
+
+This module ships the **sketch** scaffolding -- Protocol +
+dataclasses + three reference deciders. Production deployment
+follows the same shadow-mode graduation path that
+``NanoGPTWriteDecider`` did:
+
+1. ``NoopMidloopDecider`` as primary (never intervenes), live in
+   the audit log only. Acquires real (decision, task_outcome)
+   pairs.
+2. ``HeuristicMidloopDecider`` as shadow, observing every step.
+   Disagreements with the noop primary surface as
+   ``midloop_disagree`` audit tags for review.
+3. After ~200 labeled disagreements, calibrate Heuristic
+   thresholds against the labels. Only THEN promote Heuristic to
+   primary, with action clamped to ``WHISPER`` (cheapest, most
+   reversible).
+4. Eventually a ``NanoGPTMidloopDecider`` trained on the labels
+   replaces or augments the Heuristic.
+
+The thresholds in ``HeuristicMidloopDecider`` are explicitly
+PLACEHOLDERS until step 3 above produces real calibration data.
+They are documented as such in the constructor and in the audit
+log (the reason field includes the threshold values used) so a
+reader can trace which numbers shipped at which point.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol
+
+
+# ---------------------------------------------------------------- enums
+
+class TaskCategory(str, Enum):
+    """How the task type affects whether the midloop should fire.
+
+    Per the midloop spec sec "Politica de activacion":
+    - STRUCTURED: deterministic stopping criterion (compile, test,
+      DB query). Midloop monitoring on these tasks usually HURTS
+      (-0.29 d effect size in the cited Cognitive Companion paper).
+    - EXPLORATORY: open-ended (research, debugging without repro,
+      synthesis). Midloop helps most here.
+    - MIXED: only fire after step_index >= activation threshold.
+    """
+    STRUCTURED = "structured"
+    EXPLORATORY = "exploratory"
+    MIXED = "mixed"
+
+
+class CognitiveState(str, Enum):
+    """The labeled cognitive state the midloop assigned to this step."""
+    ON_TRACK = "on_track"
+    LOOPING = "looping"      # repetition, semantic or lexical
+    DRIFTING = "drifting"    # output relevance to task drops
+    STUCK = "stuck"          # progress reduces (latency up, output shrinks)
+
+
+class InterventionAction(str, Enum):
+    """The action the midloop recommends, ordered by cost."""
+    NONE = "none"
+    WHISPER = "whisper"       # silent guidance injection (cheapest)
+    ESCALATE = "escalate"     # notify Judge for partial replanning
+    ROLLBACK = "rollback"     # revert to last valid commit (Temporal)
+    ABORT = "abort"           # terminate task, report failure
+
+
+# ---------------------------------------------------------------- dataclasses
+
+@dataclass
+class ToolCall:
+    """One tool invocation summary inside a step."""
+    name: str
+    args_summary: str = ""
+    result_summary: str = ""
+
+
+@dataclass
+class StepObservation:
+    """One step in the Builder's execution -- midloop input unit."""
+    step_id: str
+    task_id: str
+    task_category: TaskCategory
+    timestamp: float                          # unix seconds
+    output_text: str                          # what the model emitted this step
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    latency_ms: int = 0
+    tokens_used: int = 0
+    step_index: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MidloopContext:
+    """Context for a midloop decision.
+
+    ``trajectory_size`` is the number of prior observations the
+    decider can see (NOT this one). ``task_description`` is the
+    user's original ask, used by relevance signals when computing
+    drift.
+    """
+    project: str
+    task_id: str
+    task_category: TaskCategory
+    trajectory_size: int = 0
+    task_description: str = ""
+
+
+@dataclass(frozen=True)
+class MidloopDecision:
+    """The output of a midloop decider.
+
+    ``intervene`` is the only field merken's downstream caller
+    acts on. The rest are for the audit log -- a future reviewer
+    needs ``signals`` to recompute thresholds, ``state`` to label
+    the failure mode, and ``reason`` to read what happened
+    without parsing signal numbers.
+    """
+    intervene: bool
+    action: InterventionAction
+    confidence: float
+    reason: str
+    state: CognitiveState
+    policy: str
+    signals: dict[str, float] = field(default_factory=dict)
+
+
+class MidloopDecider(Protocol):
+    """Protocol for ``should_intervene`` policies."""
+    name: str
+
+    def decide(
+        self,
+        observation: StepObservation,
+        ctx: MidloopContext,
+        trajectory: list[StepObservation],
+    ) -> MidloopDecision: ...
+
+
+# ---------------------------------------------------------------- noop
+
+class NoopMidloopDecider:
+    """Baseline: never intervenes.
+
+    Use as PRIMARY during shadow-mode bootstrap. The primary
+    decision controls runtime behavior; the heuristic shadow
+    annotates the audit log with what IT would have decided.
+    Disagreements between primary (Noop) and shadow (Heuristic)
+    are the labeling pool: each one needs a human or oracle to
+    judge "should the midloop have intervened here?"
+    """
+
+    name = "NoopMidloopDecider"
+
+    def decide(
+        self,
+        observation: StepObservation,
+        ctx: MidloopContext,
+        trajectory: list[StepObservation],
+    ) -> MidloopDecision:  # noqa: ARG002
+        return MidloopDecision(
+            intervene=False,
+            action=InterventionAction.NONE,
+            confidence=1.0,
+            reason="noop",
+            state=CognitiveState.ON_TRACK,
+            policy=self.name,
+        )
+
+
+# ---------------------------------------------------------------- heuristic
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not (a or b):
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _max_pairwise_jaccard(texts: Iterable[str]) -> float:
+    token_sets = [_tokenize(t) for t in texts]
+    n = len(token_sets)
+    if n < 2:
+        return 0.0
+    best = 0.0
+    for i in range(n):
+        for j in range(i + 1, n):
+            score = _jaccard(token_sets[i], token_sets[j])
+            if score > best:
+                best = score
+    return best
+
+
+def _length_trend(observations: list[StepObservation]) -> float:
+    """Negative slope = output shrinking (potential STUCK).
+
+    Returns the linear slope of len(output_text) over step_index,
+    normalized to [-1, 1] by dividing by the max length seen.
+    """
+    if len(observations) < 2:
+        return 0.0
+    xs = [float(o.step_index) for o in observations]
+    ys = [float(len(o.output_text)) for o in observations]
+    n = len(xs)
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True))
+    den = sum((x - mx) ** 2 for x in xs) or 1.0
+    slope = num / den
+    max_y = max(ys) or 1.0
+    return max(-1.0, min(1.0, slope / max_y))
+
+
+def _latency_trend(observations: list[StepObservation]) -> float:
+    """Positive slope = latency growing (potential STUCK)."""
+    if len(observations) < 2:
+        return 0.0
+    xs = [float(o.step_index) for o in observations]
+    ys = [float(o.latency_ms) for o in observations]
+    n = len(xs)
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True))
+    den = sum((x - mx) ** 2 for x in xs) or 1.0
+    slope = num / den
+    max_y = max(ys) or 1.0
+    return max(-1.0, min(1.0, slope / max_y))
+
+
+def _tool_diversity(observations: list[StepObservation]) -> float:
+    """Lower = same tool repeatedly (potential STUCK).
+
+    Returns the fraction of unique tool names over total tool
+    calls in the window. 1.0 = every tool different. 0.0 = no
+    tools called at all (treated as max diversity / on-track).
+    """
+    names = [tc.name for o in observations for tc in o.tool_calls]
+    if not names:
+        return 1.0
+    return len(set(names)) / len(names)
+
+
+def _task_relevance(
+    observation: StepObservation, task_description: str,
+) -> float:
+    """Token-set Jaccard between this step's output and the task ask.
+
+    Cheap proxy for "did the model drift away from the original
+    task". A value > 0 means there is at least token overlap.
+    Replace with embedding-cosine when a real embedder is wired
+    here without circular imports.
+    """
+    if not task_description:
+        return 1.0
+    return _jaccard(_tokenize(observation.output_text), _tokenize(task_description))
+
+
+@dataclass
+class HeuristicThresholds:
+    """All knobs for HeuristicMidloopDecider in one place.
+
+    Defaults are PLACEHOLDERS (Jay 2026-04-19): they have not been
+    calibrated against real shadow-mode labels yet. Adjust only
+    after >= 200 (decision, task_outcome) pairs are in the audit
+    log AND a held-out subset confirms the new values do not
+    regress recall on real failures. Until then the policy ships
+    in shadow mode, never as primary.
+    """
+    jaccard_looping: float = 0.5         # >= => LOOPING
+    length_trend_stuck: float = -0.4     # <= => STUCK (output shrinking)
+    latency_trend_stuck: float = 0.6     # >= => STUCK (latency growing)
+    tool_diversity_stuck: float = 0.2    # <= => STUCK (same tool repeated)
+    relevance_drifting: float = 0.05     # < => DRIFTING (drift from task)
+    min_steps_to_decide: int = 3         # need at least N prior steps
+    window_size: int = 5                 # last N observations considered
+
+
+class HeuristicMidloopDecider:
+    """Pure-Python signals decider. No LLM, no model load.
+
+    Computes four signals over a sliding window:
+      - jaccard_last_n: max pairwise lexical overlap (LOOPING)
+      - length_trend: linear slope of output length (STUCK if shrinking)
+      - latency_trend: linear slope of step latency (STUCK if growing)
+      - tool_diversity: unique tools / total calls (STUCK if repeating)
+      - task_relevance: jaccard with task description (DRIFTING if low)
+
+    First state to fire wins; falls through to ON_TRACK if none do.
+    All thresholds documented in HeuristicThresholds.
+
+    State -> action mapping (cheapest action per state):
+      LOOPING / DRIFTING / STUCK -> WHISPER
+      (ESCALATE / ROLLBACK / ABORT are reserved for future
+       deciders that have higher-confidence signals.)
+    """
+
+    name = "HeuristicMidloopDecider"
+
+    def __init__(self, thresholds: HeuristicThresholds | None = None) -> None:
+        self.thresholds = thresholds or HeuristicThresholds()
+
+    def decide(
+        self,
+        observation: StepObservation,
+        ctx: MidloopContext,
+        trajectory: list[StepObservation],
+    ) -> MidloopDecision:
+        # STRUCTURED tasks: opt out by default. Empirical evidence
+        # cited in the spec shows midloop monitoring HURTS structured
+        # tasks (-0.29 d). Override by registering the task as
+        # EXPLORATORY or MIXED.
+        if ctx.task_category == TaskCategory.STRUCTURED:
+            return MidloopDecision(
+                intervene=False,
+                action=InterventionAction.NONE,
+                confidence=1.0,
+                reason="structured_task_skip",
+                state=CognitiveState.ON_TRACK,
+                policy=self.name,
+            )
+
+        if len(trajectory) < self.thresholds.min_steps_to_decide:
+            return MidloopDecision(
+                intervene=False,
+                action=InterventionAction.NONE,
+                confidence=0.5,
+                reason=(
+                    f"insufficient_history:"
+                    f"{len(trajectory)}<{self.thresholds.min_steps_to_decide}"
+                ),
+                state=CognitiveState.ON_TRACK,
+                policy=self.name,
+            )
+
+        window = (trajectory + [observation])[-self.thresholds.window_size:]
+        signals = {
+            "jaccard_last_n": _max_pairwise_jaccard(o.output_text for o in window),
+            "length_trend": _length_trend(window),
+            "latency_trend": _latency_trend(window),
+            "tool_diversity": _tool_diversity(window),
+            "task_relevance": _task_relevance(observation, ctx.task_description),
+        }
+
+        # Decision tree -- first state to fire wins. Ordered by
+        # actionability: looping is the easiest to detect and the
+        # most likely to benefit from a whisper.
+        if signals["jaccard_last_n"] >= self.thresholds.jaccard_looping:
+            return self._intervene(
+                state=CognitiveState.LOOPING,
+                signals=signals,
+                trigger="jaccard_last_n",
+                threshold=self.thresholds.jaccard_looping,
+            )
+        if signals["task_relevance"] < self.thresholds.relevance_drifting:
+            return self._intervene(
+                state=CognitiveState.DRIFTING,
+                signals=signals,
+                trigger="task_relevance",
+                threshold=self.thresholds.relevance_drifting,
+            )
+        stuck_triggers = []
+        if signals["length_trend"] <= self.thresholds.length_trend_stuck:
+            stuck_triggers.append("length_trend")
+        if signals["latency_trend"] >= self.thresholds.latency_trend_stuck:
+            stuck_triggers.append("latency_trend")
+        if signals["tool_diversity"] <= self.thresholds.tool_diversity_stuck:
+            stuck_triggers.append("tool_diversity")
+        if stuck_triggers:
+            return self._intervene(
+                state=CognitiveState.STUCK,
+                signals=signals,
+                trigger=",".join(stuck_triggers),
+                threshold=0.0,  # multi-trigger; reason carries detail
+            )
+
+        return MidloopDecision(
+            intervene=False,
+            action=InterventionAction.NONE,
+            confidence=1.0 - max(
+                signals["jaccard_last_n"],
+                1.0 - signals["task_relevance"],
+            ),
+            reason="on_track",
+            state=CognitiveState.ON_TRACK,
+            policy=self.name,
+            signals=signals,
+        )
+
+    def _intervene(
+        self,
+        state: CognitiveState,
+        signals: dict[str, float],
+        trigger: str,
+        threshold: float,
+    ) -> MidloopDecision:
+        # Confidence = how far past the threshold we are. For LOOPING
+        # and STUCK it is the relevant signal value; for DRIFTING it
+        # is 1 - relevance (since LOW relevance => HIGH drift).
+        if state == CognitiveState.DRIFTING:
+            confidence = 1.0 - signals["task_relevance"]
+        elif trigger in signals:
+            confidence = signals[trigger]
+        else:
+            confidence = 0.5
+        return MidloopDecision(
+            intervene=True,
+            action=InterventionAction.WHISPER,  # cheapest reversible
+            confidence=max(0.0, min(1.0, abs(confidence))),
+            reason=(
+                f"{state.value}:{trigger}={signals.get(trigger, '?')}"
+                f"{f' >= {threshold}' if threshold else ''}"
+            ),
+            state=state,
+            policy=self.name,
+            signals=signals,
+        )
+
+
+# ---------------------------------------------------------------- shadow
+
+class ShadowMidloopDecider:
+    """Run two midloop deciders side by side; primary is authoritative.
+
+    Mirror of ``ShadowWriteDecider`` for the midloop primitive.
+    The primary's ``intervene`` / ``action`` is what the runtime
+    acts on; the shadow's verdict is appended to the reason string
+    as ``shadow_agree`` / ``shadow_disagree`` so the audit log can
+    be grepped for disagreements.
+
+    Use this during graduation: NoopMidloopDecider as primary
+    (never intervenes -- safe), HeuristicMidloopDecider as shadow
+    (full opinion, no runtime effect). When ~200 disagreements
+    accumulate AND a held-out subset shows the heuristic catches
+    real failures without firing on healthy tasks, swap primary
+    to the heuristic.
+    """
+
+    def __init__(
+        self,
+        primary: MidloopDecider,
+        shadow: MidloopDecider,
+    ) -> None:
+        self._primary = primary
+        self._shadow = shadow
+        primary_name = getattr(primary, "name", type(primary).__name__)
+        shadow_name = getattr(shadow, "name", type(shadow).__name__)
+        self.name = f"Shadow({primary_name}|{shadow_name})"
+
+    def decide(
+        self,
+        observation: StepObservation,
+        ctx: MidloopContext,
+        trajectory: list[StepObservation],
+    ) -> MidloopDecision:
+        primary = self._primary.decide(observation, ctx, trajectory)
+        try:
+            shadow = self._shadow.decide(observation, ctx, trajectory)
+        except Exception as exc:
+            return MidloopDecision(
+                intervene=primary.intervene,
+                action=primary.action,
+                confidence=primary.confidence,
+                reason=f"{primary.reason}|shadow_error:{exc.__class__.__name__}",
+                state=primary.state,
+                policy=self.name,
+                signals=primary.signals,
+            )
+
+        agree = (
+            shadow.intervene == primary.intervene
+            and shadow.action == primary.action
+        )
+        tag = "shadow_agree" if agree else "shadow_disagree"
+        shadow_policy = getattr(shadow, "policy", type(self._shadow).__name__)
+        annot = (
+            f"{tag}:{shadow_policy}="
+            f"{shadow.action.value}:{shadow.state.value}:{shadow.confidence:.3f}"
+        )
+        return MidloopDecision(
+            intervene=primary.intervene,
+            action=primary.action,
+            confidence=primary.confidence,
+            reason=f"{primary.reason}|{annot}",
+            state=primary.state,
+            policy=self.name,
+            signals=primary.signals,
+        )
+
+
+# ---------------------------------------------------------------- persistence filter
+
+def is_persistable_step(
+    decision: MidloopDecision,
+    prev_decision: MidloopDecision | None,
+    is_last_step: bool,
+    *,
+    confidence_change_threshold: float = 0.2,
+) -> bool:
+    """Should this step's audit row be written to merken?
+
+    Per Jay (2026-04-19): persisting EVERY step floods the audit log
+    with on_track noise. The training signal lives at the moments
+    when something changed. Persist only when:
+
+    1. The decision is non-on_track (state != ON_TRACK), OR
+    2. The state changed vs the previous decision, OR
+    3. The confidence moved by >= threshold vs previous, OR
+    4. This is the last step before task outcome.
+
+    All other steps are dropped. The full trajectory still lives in
+    the in-process deque while the task is running; only what is
+    "interesting" makes it to the persistent audit collection.
+    """
+    if is_last_step:
+        return True
+    if decision.state != CognitiveState.ON_TRACK:
+        return True
+    if prev_decision is None:
+        return False  # first step, no signal-trigger context
+    if decision.state != prev_decision.state:
+        return True
+    if abs(decision.confidence - prev_decision.confidence) >= confidence_change_threshold:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------- audit format
+
+def format_midloop_audit_row(
+    observation: StepObservation,
+    decision: MidloopDecision,
+) -> tuple[str, str]:
+    """Build a (title, body) pair for one midloop audit entry.
+
+    Body is plain key:value text so vstash FTS can find rows by
+    ``task_id:abc123`` or ``step_index:7`` or ``midloop_disagree``
+    via simple grep.
+    """
+    from datetime import datetime, timezone
+    ts = datetime.now(timezone.utc).isoformat(timespec="microseconds")
+    preview = " ".join(observation.output_text.split())[:200]
+    body = (
+        f"timestamp: {ts}\n"
+        f"decision: should_intervene\n"
+        f"task_id: {observation.task_id}\n"
+        f"step_id: {observation.step_id}\n"
+        f"step_index: {observation.step_index}\n"
+        f"task_category: {observation.task_category.value}\n"
+        f"intervene: {decision.intervene}\n"
+        f"action: {decision.action.value}\n"
+        f"state: {decision.state.value}\n"
+        f"confidence: {decision.confidence:.4f}\n"
+        f"reason: {decision.reason}\n"
+        f"policy: {decision.policy}\n"
+        f"signals: {json.dumps(decision.signals, sort_keys=True)}\n"
+        f"output_preview: {preview}\n"
+    )
+    title = (
+        f"audit:should_intervene:{observation.task_id}:"
+        f"step{observation.step_index:04d}:{ts}"
+    )
+    return title, body

--- a/merken/policies/midloop.py
+++ b/merken/policies/midloop.py
@@ -19,7 +19,7 @@ follows the same shadow-mode graduation path that
    pairs.
 2. ``HeuristicMidloopDecider`` as shadow, observing every step.
    Disagreements with the noop primary surface as
-   ``midloop_disagree`` audit tags for review.
+   ``shadow_disagree`` audit tags for review.
 3. After ~200 labeled disagreements, calibrate Heuristic
    thresholds against the labels. Only THEN promote Heuristic to
    primary, with action clamped to ``WHISPER`` (cheapest, most
@@ -36,13 +36,11 @@ reader can trace which numbers shipped at which point.
 
 from __future__ import annotations
 
-import json
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Protocol
-
 
 # ---------------------------------------------------------------- enums
 
@@ -539,9 +537,9 @@ def is_persistable_step(
         return False  # first step, no signal-trigger context
     if decision.state != prev_decision.state:
         return True
-    if abs(decision.confidence - prev_decision.confidence) >= confidence_change_threshold:
-        return True
-    return False
+    return abs(
+        decision.confidence - prev_decision.confidence
+    ) >= confidence_change_threshold
 
 
 # ---------------------------------------------------------------- audit format

--- a/merken/policies/midloop.py
+++ b/merken/policies/midloop.py
@@ -546,37 +546,8 @@ def is_persistable_step(
 
 # ---------------------------------------------------------------- audit format
 
-def format_midloop_audit_row(
-    observation: StepObservation,
-    decision: MidloopDecision,
-) -> tuple[str, str]:
-    """Build a (title, body) pair for one midloop audit entry.
-
-    Body is plain key:value text so vstash FTS can find rows by
-    ``task_id:abc123`` or ``step_index:7`` or ``midloop_disagree``
-    via simple grep.
-    """
-    from datetime import datetime, timezone
-    ts = datetime.now(timezone.utc).isoformat(timespec="microseconds")
-    preview = " ".join(observation.output_text.split())[:200]
-    body = (
-        f"timestamp: {ts}\n"
-        f"decision: should_intervene\n"
-        f"task_id: {observation.task_id}\n"
-        f"step_id: {observation.step_id}\n"
-        f"step_index: {observation.step_index}\n"
-        f"task_category: {observation.task_category.value}\n"
-        f"intervene: {decision.intervene}\n"
-        f"action: {decision.action.value}\n"
-        f"state: {decision.state.value}\n"
-        f"confidence: {decision.confidence:.4f}\n"
-        f"reason: {decision.reason}\n"
-        f"policy: {decision.policy}\n"
-        f"signals: {json.dumps(decision.signals, sort_keys=True)}\n"
-        f"output_preview: {preview}\n"
-    )
-    title = (
-        f"audit:should_intervene:{observation.task_id}:"
-        f"step{observation.step_index:04d}:{ts}"
-    )
-    return title, body
+# format_midloop_audit_row lives in merken.audit alongside the other
+# format_*_audit_row helpers. Re-exported here so existing
+# `from merken.policies.midloop import format_midloop_audit_row`
+# imports keep working.
+from merken.audit import format_midloop_audit_row  # noqa: E402, F401

--- a/tests/test_midloop.py
+++ b/tests/test_midloop.py
@@ -1,0 +1,450 @@
+"""Tests for the midloop primitive (Phase 2 sketch).
+
+Coverage targets:
+- StepObservation / MidloopDecision dataclasses behave as expected.
+- NoopMidloopDecider always returns NONE / ON_TRACK.
+- HeuristicMidloopDecider:
+  - Skips STRUCTURED tasks unconditionally.
+  - Returns insufficient_history when trajectory is too small.
+  - Detects LOOPING (high jaccard) -> WHISPER.
+  - Detects DRIFTING (low task_relevance) -> WHISPER.
+  - Detects STUCK (length / latency / tool_diversity triggers) -> WHISPER.
+  - Returns ON_TRACK with low confidence when no signal fires.
+- ShadowMidloopDecider:
+  - Primary's decision is authoritative.
+  - Reason string carries shadow_agree / shadow_disagree tag.
+  - Shadow exception is caught with shadow_error: tag.
+- is_persistable_step filter rules.
+- format_midloop_audit_row body shape.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from merken.policies.midloop import (
+    CognitiveState,
+    HeuristicMidloopDecider,
+    HeuristicThresholds,
+    InterventionAction,
+    MidloopContext,
+    MidloopDecision,
+    NoopMidloopDecider,
+    ShadowMidloopDecider,
+    StepObservation,
+    TaskCategory,
+    ToolCall,
+    format_midloop_audit_row,
+    is_persistable_step,
+)
+
+
+# ----------------------------------------------------------------- helpers
+
+def _obs(
+    *,
+    step_index: int = 0,
+    output: str = "the model said something",
+    task_id: str = "t1",
+    category: TaskCategory = TaskCategory.EXPLORATORY,
+    latency_ms: int = 1000,
+    tool_calls: list[ToolCall] | None = None,
+) -> StepObservation:
+    return StepObservation(
+        step_id=f"s{step_index}",
+        task_id=task_id,
+        task_category=category,
+        timestamp=time.time(),
+        output_text=output,
+        step_index=step_index,
+        latency_ms=latency_ms,
+        tool_calls=tool_calls or [],
+    )
+
+
+def _ctx(
+    *,
+    category: TaskCategory = TaskCategory.EXPLORATORY,
+    task_description: str = "",
+) -> MidloopContext:
+    return MidloopContext(
+        project="test_midloop",
+        task_id="t1",
+        task_category=category,
+        task_description=task_description,
+    )
+
+
+# ----------------------------------------------------------------- noop
+
+class TestNoopMidloopDecider:
+    def test_always_returns_none(self) -> None:
+        d = NoopMidloopDecider()
+        result = d.decide(_obs(), _ctx(), [])
+        assert result.intervene is False
+        assert result.action == InterventionAction.NONE
+        assert result.state == CognitiveState.ON_TRACK
+        assert result.policy == "NoopMidloopDecider"
+
+    def test_ignores_trajectory_length(self) -> None:
+        d = NoopMidloopDecider()
+        traj = [_obs(step_index=i, output=f"step {i}") for i in range(20)]
+        result = d.decide(_obs(step_index=20), _ctx(), traj)
+        assert result.intervene is False
+
+
+# ----------------------------------------------------------------- heuristic
+
+class TestHeuristicStructuredSkip:
+    def test_structured_task_never_intervenes(self) -> None:
+        d = HeuristicMidloopDecider()
+        ctx = _ctx(category=TaskCategory.STRUCTURED)
+        traj = [_obs(step_index=i, output="repeat repeat repeat") for i in range(5)]
+        # Even with looping pattern, STRUCTURED skips.
+        result = d.decide(
+            _obs(step_index=5, output="repeat repeat repeat", category=TaskCategory.STRUCTURED),
+            ctx, traj,
+        )
+        assert result.intervene is False
+        assert result.reason == "structured_task_skip"
+
+
+class TestHeuristicHistoryGate:
+    def test_returns_insufficient_history_when_too_few_observations(self) -> None:
+        d = HeuristicMidloopDecider()
+        result = d.decide(_obs(), _ctx(), [])
+        assert result.intervene is False
+        assert "insufficient_history" in result.reason
+
+    def test_below_min_steps_does_not_fire_even_on_looping(self) -> None:
+        d = HeuristicMidloopDecider(HeuristicThresholds(min_steps_to_decide=5))
+        traj = [_obs(step_index=i, output="same same same") for i in range(3)]
+        result = d.decide(
+            _obs(step_index=3, output="same same same"), _ctx(), traj,
+        )
+        assert result.intervene is False
+        assert "insufficient_history" in result.reason
+
+
+class TestHeuristicLooping:
+    def test_high_jaccard_triggers_looping_whisper(self) -> None:
+        d = HeuristicMidloopDecider()
+        # 4 nearly identical outputs in a row -> LOOPING.
+        traj = [
+            _obs(step_index=i, output="let me check the cache configuration")
+            for i in range(4)
+        ]
+        result = d.decide(
+            _obs(step_index=4, output="let me check the cache configuration again"),
+            _ctx(), traj,
+        )
+        assert result.intervene is True
+        assert result.state == CognitiveState.LOOPING
+        assert result.action == InterventionAction.WHISPER
+        assert result.signals["jaccard_last_n"] >= 0.5
+        assert "looping" in result.reason
+
+
+class TestHeuristicDrifting:
+    def test_low_task_relevance_triggers_drifting(self) -> None:
+        # Outputs MUST have low pairwise overlap so LOOPING does not
+        # fire before DRIFTING. Each step uses a disjoint vocabulary.
+        d = HeuristicMidloopDecider(
+            HeuristicThresholds(relevance_drifting=0.5)
+        )
+        traj = [
+            _obs(step_index=0, output="alpha bravo charlie delta echo"),
+            _obs(step_index=1, output="foxtrot golf hotel india juliet"),
+            _obs(step_index=2, output="kilo lima mike november oscar"),
+            _obs(step_index=3, output="papa quebec romeo sierra tango"),
+        ]
+        ctx = _ctx(task_description="rust async runtime tokio scheduler")
+        result = d.decide(
+            _obs(step_index=4, output="uniform victor whiskey xray yankee"),
+            ctx, traj,
+        )
+        assert result.intervene is True
+        assert result.state == CognitiveState.DRIFTING
+        assert result.action == InterventionAction.WHISPER
+
+    def test_empty_task_description_does_not_trigger_drifting(self) -> None:
+        # task_relevance defaults to 1.0 when description is empty,
+        # so the drifting check never fires regardless of output.
+        d = HeuristicMidloopDecider()
+        traj = [
+            _obs(step_index=0, output="alpha bravo charlie"),
+            _obs(step_index=1, output="delta echo foxtrot"),
+            _obs(step_index=2, output="golf hotel india"),
+            _obs(step_index=3, output="juliet kilo lima"),
+        ]
+        result = d.decide(
+            _obs(step_index=4, output="mike november oscar"),
+            _ctx(),  # no task_description
+            traj,
+        )
+        # Either ON_TRACK or some other state, but NOT drifting.
+        assert result.state != CognitiveState.DRIFTING
+
+
+class TestHeuristicStuck:
+    def test_shrinking_output_triggers_stuck(self) -> None:
+        # Output length monotonically shrinks. Outputs must have
+        # NEAR-ZERO pairwise jaccard so LOOPING does not fire first.
+        d = HeuristicMidloopDecider(
+            HeuristicThresholds(length_trend_stuck=-0.05, jaccard_looping=0.99)
+        )
+        traj = [
+            _obs(step_index=0, output=" ".join(f"alpha{i}" for i in range(200))),
+            _obs(step_index=1, output=" ".join(f"bravo{i}" for i in range(160))),
+            _obs(step_index=2, output=" ".join(f"charlie{i}" for i in range(120))),
+            _obs(step_index=3, output=" ".join(f"delta{i}" for i in range(80))),
+        ]
+        result = d.decide(
+            _obs(step_index=4, output=" ".join(f"echo{i}" for i in range(40))),
+            _ctx(), traj,
+        )
+        assert result.intervene is True
+        assert result.state == CognitiveState.STUCK
+        assert "length_trend" in result.reason
+
+    def test_growing_latency_triggers_stuck(self) -> None:
+        d = HeuristicMidloopDecider(
+            HeuristicThresholds(latency_trend_stuck=0.05, jaccard_looping=0.99)
+        )
+        # Each step has unique vocabulary; latency monotonically grows.
+        traj = [
+            _obs(step_index=i, output=f"alpha{i} bravo{i} charlie{i}",
+                 latency_ms=100 * (i + 1))
+            for i in range(4)
+        ]
+        result = d.decide(
+            _obs(step_index=4, output="delta zeta theta", latency_ms=500),
+            _ctx(), traj,
+        )
+        assert result.intervene is True
+        assert result.state == CognitiveState.STUCK
+        assert "latency_trend" in result.reason
+
+    def test_repeating_tool_calls_triggers_stuck(self) -> None:
+        d = HeuristicMidloopDecider(
+            HeuristicThresholds(tool_diversity_stuck=0.5, jaccard_looping=0.99)
+        )
+        traj = [
+            _obs(
+                step_index=i, output=f"alpha{i} bravo{i} charlie{i} delta{i}",
+                tool_calls=[ToolCall(name="grep")],
+            )
+            for i in range(4)
+        ]
+        result = d.decide(
+            _obs(
+                step_index=4, output="echo foxtrot golf hotel",
+                tool_calls=[ToolCall(name="grep")],
+            ),
+            _ctx(), traj,
+        )
+        assert result.intervene is True
+        assert result.state == CognitiveState.STUCK
+        assert "tool_diversity" in result.reason
+
+
+class TestHeuristicOnTrack:
+    def test_diverse_outputs_no_intervention(self) -> None:
+        d = HeuristicMidloopDecider()
+        traj = [
+            _obs(
+                step_index=0,
+                output="reading the auth module to understand session handling",
+            ),
+            _obs(
+                step_index=1,
+                output="found the login flow uses jwt cookies for stateful sessions",
+            ),
+            _obs(
+                step_index=2,
+                output="now examining the refresh token rotation behavior",
+            ),
+            _obs(
+                step_index=3,
+                output="the rotation interval is configured at fifteen minutes by default",
+            ),
+        ]
+        result = d.decide(
+            _obs(
+                step_index=4,
+                output="checking how the middleware enforces the rotation policy",
+            ),
+            _ctx(),
+            traj,
+        )
+        assert result.intervene is False
+        assert result.state == CognitiveState.ON_TRACK
+        assert result.action == InterventionAction.NONE
+
+
+# ----------------------------------------------------------------- shadow
+
+class TestShadowMidloopDecider:
+    def test_primary_decision_wins(self) -> None:
+        # primary=Noop, shadow=Heuristic that WOULD intervene on
+        # looping. Primary's NONE must be the final action.
+        primary = NoopMidloopDecider()
+        shadow = HeuristicMidloopDecider()
+        chained = ShadowMidloopDecider(primary=primary, shadow=shadow)
+        traj = [_obs(step_index=i, output="repeat repeat repeat") for i in range(4)]
+        result = chained.decide(
+            _obs(step_index=4, output="repeat repeat repeat"),
+            _ctx(), traj,
+        )
+        assert result.intervene is False
+        assert result.action == InterventionAction.NONE
+        assert "shadow_disagree" in result.reason
+        # Shadow's policy + would-be action embedded in reason.
+        assert "HeuristicMidloopDecider" in result.reason
+        assert "whisper" in result.reason
+        # Primary's signals propagate (Noop has none).
+        assert result.signals == {}
+
+    def test_agreement_tagged(self) -> None:
+        # Both deciders agree (both are Noop -> never intervene).
+        chained = ShadowMidloopDecider(
+            primary=NoopMidloopDecider(),
+            shadow=NoopMidloopDecider(),
+        )
+        result = chained.decide(_obs(), _ctx(), [])
+        assert result.intervene is False
+        assert "shadow_agree" in result.reason
+
+    def test_shadow_exception_caught(self) -> None:
+        class BoomDecider:
+            name = "BoomDecider"
+
+            def decide(self, observation, ctx, trajectory):
+                raise RuntimeError("kaboom")
+
+        chained = ShadowMidloopDecider(
+            primary=NoopMidloopDecider(),
+            shadow=BoomDecider(),
+        )
+        result = chained.decide(_obs(), _ctx(), [])
+        # Primary still wins, exception annotated.
+        assert result.intervene is False
+        assert "shadow_error:RuntimeError" in result.reason
+
+
+# ----------------------------------------------------------------- persistence
+
+class TestIsPersistableStep:
+    def _decision(
+        self,
+        state: CognitiveState = CognitiveState.ON_TRACK,
+        confidence: float = 1.0,
+        intervene: bool = False,
+    ) -> MidloopDecision:
+        return MidloopDecision(
+            intervene=intervene,
+            action=InterventionAction.NONE if not intervene else InterventionAction.WHISPER,
+            confidence=confidence,
+            reason="test",
+            state=state,
+            policy="test",
+        )
+
+    def test_on_track_with_no_change_drops(self) -> None:
+        prev = self._decision()
+        cur = self._decision()
+        assert is_persistable_step(cur, prev, is_last_step=False) is False
+
+    def test_first_step_drops_when_on_track(self) -> None:
+        cur = self._decision()
+        assert is_persistable_step(cur, None, is_last_step=False) is False
+
+    def test_intervention_state_always_persists(self) -> None:
+        prev = self._decision()
+        cur = self._decision(state=CognitiveState.LOOPING, intervene=True)
+        assert is_persistable_step(cur, prev, is_last_step=False) is True
+
+    def test_state_change_persists(self) -> None:
+        prev = self._decision(state=CognitiveState.LOOPING)
+        cur = self._decision(state=CognitiveState.ON_TRACK)
+        assert is_persistable_step(cur, prev, is_last_step=False) is True
+
+    def test_confidence_jump_persists(self) -> None:
+        prev = self._decision(confidence=0.5)
+        cur = self._decision(confidence=0.9)
+        assert is_persistable_step(cur, prev, is_last_step=False) is True
+
+    def test_small_confidence_change_drops(self) -> None:
+        prev = self._decision(confidence=0.5)
+        cur = self._decision(confidence=0.55)
+        assert is_persistable_step(cur, prev, is_last_step=False) is False
+
+    def test_last_step_always_persists(self) -> None:
+        prev = self._decision()
+        cur = self._decision()
+        assert is_persistable_step(cur, prev, is_last_step=True) is True
+
+
+# ----------------------------------------------------------------- audit row
+
+class TestFormatMidloopAuditRow:
+    def test_title_includes_task_and_step(self) -> None:
+        obs = _obs(step_index=42, task_id="task_xyz")
+        decision = NoopMidloopDecider().decide(obs, _ctx(), [])
+        title, body = format_midloop_audit_row(obs, decision)
+        assert "audit:should_intervene" in title
+        assert "task_xyz" in title
+        assert "step0042" in title
+
+    def test_body_carries_required_fields(self) -> None:
+        obs = _obs(
+            step_index=3,
+            output="some output that is long enough to preview",
+        )
+        traj = [_obs(step_index=i, output="repeat repeat") for i in range(4)]
+        decision = HeuristicMidloopDecider().decide(
+            _obs(step_index=4, output="repeat repeat"),
+            _ctx(),
+            traj,
+        )
+        _, body = format_midloop_audit_row(obs, decision)
+        # FTS-friendly fields embedded in body.
+        for key in (
+            "task_id:", "step_id:", "step_index:",
+            "task_category:", "intervene:", "action:",
+            "state:", "confidence:", "reason:", "policy:",
+            "signals:", "output_preview:",
+        ):
+            assert key in body, f"missing {key} in audit body"
+
+    def test_signals_serialized_as_json(self) -> None:
+        obs = _obs(step_index=4, output="output")
+        traj = [_obs(step_index=i, output="x" * 100) for i in range(4)]
+        decision = HeuristicMidloopDecider().decide(obs, _ctx(), traj)
+        _, body = format_midloop_audit_row(obs, decision)
+        # Find the signals: line and parse it.
+        signals_line = next(
+            line for line in body.split("\n") if line.startswith("signals:")
+        )
+        payload = json.loads(signals_line[len("signals:"):].strip())
+        assert isinstance(payload, dict)
+
+
+# ----------------------------------------------------------------- protocol
+
+def test_decider_protocol_is_satisfied_by_all_three() -> None:
+    """Structural typing -- if these compile, all three deciders
+    satisfy the MidloopDecider Protocol."""
+    from merken.policies.midloop import MidloopDecider
+
+    deciders: list[MidloopDecider] = [
+        NoopMidloopDecider(),
+        HeuristicMidloopDecider(),
+        ShadowMidloopDecider(NoopMidloopDecider(), NoopMidloopDecider()),
+    ]
+    for d in deciders:
+        assert hasattr(d, "name") and isinstance(d.name, str)
+        assert callable(d.decide)

--- a/tests/test_midloop_integration.py
+++ b/tests/test_midloop_integration.py
@@ -1,0 +1,190 @@
+"""Integration tests for Memory.observe_step and the audit-row format.
+
+The unit tests for the deciders themselves live in test_midloop.py.
+This file verifies the WIRING:
+- Memory.observe_step calls the configured midloop_decider.
+- Trajectory state lives across calls on the same instance.
+- The is_persistable_step filter is applied (audit doesn't flood).
+- format_midloop_audit_row in audit.py matches what midloop.py
+  exports (Phase 2b moved the canonical home; midloop.py re-exports).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from merken import Memory
+from merken.audit import format_midloop_audit_row as audit_module_fn
+from merken.policies.midloop import (
+    HeuristicMidloopDecider,
+    HeuristicThresholds,
+    MidloopDecision,
+    NoopMidloopDecider,
+    ShadowMidloopDecider,
+    StepObservation,
+    TaskCategory,
+)
+from merken.policies.midloop import format_midloop_audit_row as midloop_module_fn
+
+
+def _obs(step_index: int, output: str = "step output text", task_id: str = "t1"):
+    return StepObservation(
+        step_id=f"s{step_index}",
+        task_id=task_id,
+        task_category=TaskCategory.EXPLORATORY,
+        timestamp=time.time(),
+        output_text=output,
+        step_index=step_index,
+        latency_ms=100,
+    )
+
+
+def _new_memory(tmp_path: Path, midloop=None) -> Memory:
+    return Memory(
+        project="test_midloop_integration",
+        db=str(tmp_path / "midloop.db"),
+        midloop_decider=midloop,
+    )
+
+
+# ----------------------------------------------------------------- canonical export
+
+def test_format_midloop_audit_row_is_same_function() -> None:
+    """audit.format_midloop_audit_row IS what midloop.format_midloop_audit_row points at."""
+    assert midloop_module_fn is audit_module_fn
+
+
+# ----------------------------------------------------------------- observe_step
+
+def test_observe_step_returns_decision(tmp_path: Path) -> None:
+    mem = _new_memory(tmp_path)
+    decision = mem.observe_step(_obs(0))
+    assert isinstance(decision, MidloopDecision)
+    assert decision.intervene is False  # default Noop
+
+
+def test_observe_step_appends_to_trajectory(tmp_path: Path) -> None:
+    mem = _new_memory(tmp_path)
+    for i in range(5):
+        mem.observe_step(_obs(i))
+    assert len(mem._trajectory) == 5
+
+
+def test_observe_step_passes_trajectory_to_decider(tmp_path: Path) -> None:
+    """Decider receives prior observations; can compute trends."""
+    captured = {"sizes": []}
+
+    class CapturingDecider:
+        name = "CapturingDecider"
+
+        def decide(self, observation, ctx, trajectory):
+            captured["sizes"].append(len(trajectory))
+            from merken.policies.midloop import (
+                CognitiveState, InterventionAction,
+            )
+            return MidloopDecision(
+                intervene=False,
+                action=InterventionAction.NONE,
+                confidence=1.0,
+                reason="captured",
+                state=CognitiveState.ON_TRACK,
+                policy=self.name,
+            )
+
+    mem = _new_memory(tmp_path, midloop=CapturingDecider())
+    for i in range(5):
+        mem.observe_step(_obs(i))
+    # Trajectory grows monotonically: 0, 1, 2, 3, 4.
+    assert captured["sizes"] == [0, 1, 2, 3, 4]
+
+
+def test_reset_trajectory_clears_window(tmp_path: Path) -> None:
+    mem = _new_memory(tmp_path)
+    for i in range(3):
+        mem.observe_step(_obs(i))
+    assert len(mem._trajectory) == 3
+    mem.reset_trajectory()
+    assert len(mem._trajectory) == 0
+    assert mem._prev_midloop_decision is None
+
+
+def test_trajectory_window_caps_at_default(tmp_path: Path) -> None:
+    """trajectory_window=20 by default; deque drops oldest beyond that."""
+    mem = _new_memory(tmp_path)
+    for i in range(25):
+        mem.observe_step(_obs(i))
+    assert len(mem._trajectory) == 20  # capped
+
+
+def test_trajectory_window_override(tmp_path: Path) -> None:
+    mem = Memory(
+        project="t",
+        db=str(tmp_path / "x.db"),
+        trajectory_window=5,
+    )
+    for i in range(10):
+        mem.observe_step(_obs(i))
+    assert len(mem._trajectory) == 5
+
+
+# ----------------------------------------------------------------- audit persistence
+
+def test_on_track_steps_dont_persist_to_audit(tmp_path: Path) -> None:
+    """The is_persistable_step filter drops on_track-with-no-change rows."""
+    mem = _new_memory(tmp_path)  # default Noop -> always on_track
+    for i in range(5):
+        mem.observe_step(_obs(i))
+    # Query audit collection for should_intervene rows -- expect 0
+    # because all 5 steps were on_track with no state change.
+    hits = mem.audit("should_intervene", top_k=20)
+    assert len(hits) == 0
+
+
+def test_intervention_step_persists_to_audit(tmp_path: Path) -> None:
+    """When the heuristic fires (intervene=True), the row IS persisted."""
+    mem = _new_memory(tmp_path, midloop=HeuristicMidloopDecider())
+    # Build a looping trajectory so the heuristic fires.
+    for i in range(4):
+        mem.observe_step(_obs(i, output="repeat repeat repeat"))
+    final = mem.observe_step(
+        _obs(4, output="repeat repeat repeat once more"),
+    )
+    assert final.intervene is True
+    hits = mem.audit("should_intervene", top_k=20)
+    # At least the looping intervention persists.
+    assert len(hits) >= 1
+
+
+def test_last_step_always_persists(tmp_path: Path) -> None:
+    """is_last_step=True forces persistence even on ON_TRACK."""
+    mem = _new_memory(tmp_path)
+    mem.observe_step(_obs(0), is_last_step=True)
+    hits = mem.audit("should_intervene", top_k=10)
+    assert len(hits) == 1
+
+
+# ----------------------------------------------------------------- shadow integration
+
+def test_shadow_midloop_decider_via_memory(tmp_path: Path) -> None:
+    """ShadowMidloopDecider as Memory's midloop -- primary controls,
+    shadow audit-tags. End-to-end through observe_step."""
+    primary = NoopMidloopDecider()
+    shadow = HeuristicMidloopDecider()
+    mem = _new_memory(
+        tmp_path, midloop=ShadowMidloopDecider(primary, shadow),
+    )
+    # Build looping trajectory: heuristic shadow would intervene.
+    for i in range(4):
+        mem.observe_step(_obs(i, output="same content same content"))
+    final = mem.observe_step(
+        _obs(4, output="same content same content again"),
+        is_last_step=True,
+    )
+    # Primary (Noop) wins -> no intervention at runtime.
+    assert final.intervene is False
+    # Shadow (Heuristic) disagreed -> annotation in reason.
+    assert "shadow_disagree" in final.reason
+    # Audit persists because is_last_step=True.
+    hits = mem.audit("shadow_disagree", top_k=10, fts_only=True)
+    assert len(hits) >= 1

--- a/tests/test_midloop_integration.py
+++ b/tests/test_midloop_integration.py
@@ -18,7 +18,6 @@ from merken import Memory
 from merken.audit import format_midloop_audit_row as audit_module_fn
 from merken.policies.midloop import (
     HeuristicMidloopDecider,
-    HeuristicThresholds,
     MidloopDecision,
     NoopMidloopDecider,
     ShadowMidloopDecider,
@@ -81,7 +80,8 @@ def test_observe_step_passes_trajectory_to_decider(tmp_path: Path) -> None:
         def decide(self, observation, ctx, trajectory):
             captured["sizes"].append(len(trajectory))
             from merken.policies.midloop import (
-                CognitiveState, InterventionAction,
+                CognitiveState,
+                InterventionAction,
             )
             return MidloopDecision(
                 intervene=False,


### PR DESCRIPTION
## Summary

Phase 2 of the midloop initiative: the 5th decision primitive (`should_intervene`) lands as a Protocol + 3 reference deciders + Memory wiring, all in shadow-mode-safe defaults. NO automatic intervention by default; the primitive is observation-only until shadow data justifies promotion.

Builds on:
- PR #19 (v7 frontier closure)
- PR #20 (Phase 0/1 groundwork: Type A/B + dataset pipeline)
- PR #21 (3-protocol pilot + 77-protocol scale-up: 1097 intervention labels ready)

## What's in here

### Phase 2a -- the primitive in isolation

`merken/policies/midloop.py`:
- `TaskCategory` (STRUCTURED / EXPLORATORY / MIXED)
- `CognitiveState` (ON_TRACK / LOOPING / DRIFTING / STUCK)
- `InterventionAction` (NONE / WHISPER / ESCALATE / ROLLBACK / ABORT)
- `StepObservation`, `MidloopContext`, `MidloopDecision` dataclasses
- `MidloopDecider` Protocol
- `NoopMidloopDecider` -- never intervenes (safe default)
- `HeuristicMidloopDecider` -- 5 signals, decision tree, WHISPER on fire. STRUCTURED tasks unconditionally skip per spec evidence (-0.29 d effect of monitoring on deterministic tasks).
- `ShadowMidloopDecider` -- combinator, mirror of `ShadowWriteDecider`
- `is_persistable_step` -- the spec's filter that keeps audit from flooding
- `format_midloop_audit_row` -- canonical at `merken/audit.py`, re-exported from midloop module

Thresholds in `HeuristicThresholds` are PLACEHOLDERS until shadow-mode data exists. Documented as such.

### Phase 2b -- Memory wiring

`merken/memory.py`:
- `Memory.__init__` accepts `midloop_decider` (default Noop) + `trajectory_window` (default 20)
- `Memory.observe_step(observation, *, is_last_step=False) -> MidloopDecision` -- calls decider, applies persistence filter, writes audit row only when relevant
- `Memory.reset_trajectory()` -- clears window between tasks
- `Memory._write_midloop_audit` -- fail-open write, same pattern as the other audit writers
- Trajectory state is per-instance, NOT persisted (per spec: "Trayectoria, no snapshot")

## Test plan

- [x] 26 unit tests in `tests/test_midloop.py`: deciders, persistence filter, audit row format
- [x] 11 integration tests in `tests/test_midloop_integration.py`: Memory.observe_step end-to-end, trajectory state, audit persistence, shadow combinator through Memory
- [x] Full suite: 338 pass (was 300; +38 net)
- [ ] Reviewer to confirm the shadow-mode bootstrap recipe (Noop primary + Heuristic shadow) is the intended graduation path

## Recommended bootstrap

```python
mem = Memory(
    project="my_app",
    midloop_decider=ShadowMidloopDecider(
        primary=NoopMidloopDecider(),       # safe runtime default
        shadow=HeuristicMidloopDecider(),   # full opinion, audit only
    ),
)

# Per step in the Builder loop:
decision = mem.observe_step(StepObservation(...), is_last_step=False)
# decision.intervene is False (Noop primary). The audit log records
# the heuristic's verdict via shadow_agree / shadow_disagree tags
# for retrospective analysis.

# At task completion:
mem.observe_step(final_obs, is_last_step=True)
mem.reset_trajectory()  # clean slate for next task
```

After ~200 `(decision, task_outcome)` pairs accumulate, calibrate `HeuristicThresholds` against the labels and promote the heuristic to primary with action clamped to `WHISPER`.

## What this does NOT do

- Does NOT automatically intervene. The default `NoopMidloopDecider` makes intervention opt-in.
- Does NOT include a `NanoGPTMidloopDecider` (Phase 3, gated on real shadow-mode data plus the 1097-label dataset shipped in PR #21).
- Does NOT add the WHISPER injection mechanism to user-facing surfaces. That belongs to the Builder (Reforge), not merken. The midloop emits the decision; downstream code acts on it.
- Does NOT calibrate the HeuristicThresholds to real data. They are placeholders documented in source.

Full design context: `notes/midloop-spec.md`.