### PR TITLE
feat(midloop): Phase 3 sketch -- training plan + dataset converter

### DIFF
--- a/experiments/midloop_pilot/format_for_training.py
+++ b/experiments/midloop_pilot/format_for_training.py
@@ -7,25 +7,40 @@ Output: training_data/midloop_v0.jsonl with one sample per case:
       "case_id": "...",
       "prompt": "<original CHW question>",
       "response_tokens": ["Administer", "IV", "fluids", ...],
-      "intervene_labels": [1, 1, 1, 0, 0, 1, ...],  # 1 if token is inside an intervention span
-      "intervention_spans": [...],  # original spans for traceability
+      "intervene_labels": [1, 0, 0, 0, 1, 0, ...],  # see modes below
+      "labeling_mode": "boundary",                 # echoes --labeling
+      "intervention_spans": [...],                 # original spans for traceability
       "metadata": {...},
     }
 
-The label is per-token binary: 1 if the model_response token at that
-position falls inside any intervention span (start <= idx < end). The
-spans come from the aligner's token-level diff, so a label of 1 means
-"the aligner thinks this token is part of a divergence from the
-protocol-derived truth, AND it survived the semantic-equivalence
-filter (cosine < threshold)".
+Two label modes (--labeling {span,boundary}; default boundary):
 
-This is the dataset shape that a sequence-tagging classifier
-(NanoGPTMidloopDecider) will train on. See
-`notes/midloop-training-plan.md` for the full architecture sketch.
+- ``boundary`` (DEFAULT, recommended for v0): label = 1 ONLY at the
+  start position of each intervention span. Per-case positive
+  density on the Phase 1 dataset = 14.1%, positive count = number
+  of divergent regions. This is the v0 training signal -- detect
+  WHERE an error starts; the runtime acts there.
+
+- ``span``: label = 1 at every token position INSIDE an intervention
+  span (start <= idx < end). 86.5% positive density on the same
+  dataset; documented but NOT recommended for training (trivial
+  always-1 baseline already at 86.5% accuracy).
+
+See ``notes/midloop-training-plan.md`` for the architecture +
+calibration plan that consumes this output.
+
+Field-name note: the upstream aligned.jsonl (produced by both the
+``merken-midloop-dataset align`` CLI and ``run_pilot.py``) writes
+intervention spans with ``model_token_start`` / ``model_token_end``
+keys -- a deliberate JSONL rename of the in-memory Region
+dataclass fields ``model_start`` / ``model_end``. This converter
+accepts EITHER set of keys so it stays compatible with both
+existing artifacts and any future JSONL writers that use the
+dataclass-direct names.
 
 Usage:
   python -m experiments.midloop_pilot.format_for_training
-  python -m experiments.midloop_pilot.format_for_training --in custom.jsonl --out custom_training.jsonl
+  python -m experiments.midloop_pilot.format_for_training --in custom.jsonl --out custom_training.jsonl --labeling span
 """
 
 from __future__ import annotations
@@ -76,8 +91,17 @@ def labels_for_response(
         raise ValueError(f"unknown labeling mode: {mode!r}")
     labels = [0] * len(response_tokens)
     for span in interventions:
-        start = span.get("model_token_start", 0)
-        end = span.get("model_token_end", 0)
+        # Accept BOTH the JSONL-renamed keys (model_token_start /
+        # model_token_end, as written by the align CLI + run_pilot.py)
+        # AND the in-memory Region dataclass keys (model_start /
+        # model_end). Future writers that emit JSONL directly from
+        # Region without renaming stay compatible.
+        start = span.get("model_token_start")
+        if start is None:
+            start = span.get("model_start", 0)
+        end = span.get("model_token_end")
+        if end is None:
+            end = span.get("model_end", 0)
         if mode == "boundary":
             if 0 <= start < len(labels):
                 labels[start] = 1
@@ -109,8 +133,16 @@ def convert_case(row: dict, *, labeling: str = "span") -> dict | None:
         "labeling_mode": labeling,
         "intervention_spans": [
             {
-                "model_token_start": s.get("model_token_start", 0),
-                "model_token_end": s.get("model_token_end", 0),
+                # Pass through the JSONL keys verbatim so the
+                # output stays a faithful re-export of the input
+                # spans. The accept-both-shapes logic in
+                # labels_for_response handles either dialect.
+                "model_token_start": (
+                    s.get("model_token_start", s.get("model_start", 0))
+                ),
+                "model_token_end": (
+                    s.get("model_token_end", s.get("model_end", 0))
+                ),
                 "truth_text": s.get("truth_text", ""),
                 "model_text": s.get("model_text", ""),
                 "cosine_sim": s.get("cosine_sim"),
@@ -128,13 +160,15 @@ def main() -> int:
     ap.add_argument("--out", "--output", dest="output", type=Path,
                     default=DEFAULT_OUT, help="training-format output path")
     ap.add_argument(
-        "--labeling", choices=["span", "boundary"], default="span",
+        "--labeling", choices=["span", "boundary"], default="boundary",
         help=(
-            "label shape: 'span' marks every token inside an "
-            "intervention span (~86%% positive on Phase 1 dataset); "
-            "'boundary' marks ONLY the first token of each span "
-            "(~14%% positive, recommended for v0 training). See "
-            "notes/midloop-training-plan.md for the rationale."
+            "label shape (default: boundary, recommended for v0). "
+            "'boundary' marks ONLY the first token of each "
+            "intervention span (~14%% positive on Phase 1 dataset). "
+            "'span' marks every token inside an intervention span "
+            "(~86%% positive; documented but NOT recommended -- "
+            "trivial always-1 baseline already at 86%% accuracy). "
+            "See notes/midloop-training-plan.md for the rationale."
         ),
     )
     args = ap.parse_args()
@@ -152,7 +186,12 @@ def main() -> int:
     case_label_dist: Counter[int] = Counter()
 
     with args.input.open() as fin, args.output.open("w") as fout:
-        for line in fin:
+        # ``lineno`` is the actual file line number (1-indexed,
+        # blank lines counted) so warnings point at the right
+        # place in the source file. ``n_in`` counts non-empty
+        # rows for the summary. The two are intentionally
+        # different.
+        for lineno, line in enumerate(fin, start=1):
             line = line.strip()
             if not line:
                 continue
@@ -160,7 +199,7 @@ def main() -> int:
             try:
                 row = json.loads(line)
             except json.JSONDecodeError as e:
-                print(f"warn: skipping malformed line {n_in}: {e}",
+                print(f"warn: skipping malformed line {lineno}: {e}",
                       file=sys.stderr)
                 continue
             sample = convert_case(row, labeling=args.labeling)
@@ -182,8 +221,8 @@ def main() -> int:
     print(f"  total tokens:    {n_tokens_total}", file=sys.stderr)
     print(f"  positive tokens: {n_positive_total} ({100*pos_rate:.1f}%)",
           file=sys.stderr)
-    print(f"  per-case positive distribution (top 10):", file=sys.stderr)
-    for k, v in sorted(case_label_dist.items())[:10]:
+    print(f"  per-case positive distribution (10 most common):", file=sys.stderr)
+    for k, v in case_label_dist.most_common(10):
         print(f"    {k} positive tokens: {v} cases", file=sys.stderr)
     print(f"  output: {args.output}", file=sys.stderr)
     return 0

--- a/experiments/midloop_pilot/format_for_training.py
+++ b/experiments/midloop_pilot/format_for_training.py
@@ -1,0 +1,193 @@
+"""Convert aligned.jsonl into per-token training samples for Phase 3.
+
+Input: scaleup_out/aligned.jsonl (385 cases, 1136 intervention spans).
+Output: training_data/midloop_v0.jsonl with one sample per case:
+
+    {
+      "case_id": "...",
+      "prompt": "<original CHW question>",
+      "response_tokens": ["Administer", "IV", "fluids", ...],
+      "intervene_labels": [1, 1, 1, 0, 0, 1, ...],  # 1 if token is inside an intervention span
+      "intervention_spans": [...],  # original spans for traceability
+      "metadata": {...},
+    }
+
+The label is per-token binary: 1 if the model_response token at that
+position falls inside any intervention span (start <= idx < end). The
+spans come from the aligner's token-level diff, so a label of 1 means
+"the aligner thinks this token is part of a divergence from the
+protocol-derived truth, AND it survived the semantic-equivalence
+filter (cosine < threshold)".
+
+This is the dataset shape that a sequence-tagging classifier
+(NanoGPTMidloopDecider) will train on. See
+`notes/midloop-training-plan.md` for the full architecture sketch.
+
+Usage:
+  python -m experiments.midloop_pilot.format_for_training
+  python -m experiments.midloop_pilot.format_for_training --in custom.jsonl --out custom_training.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+DEFAULT_IN = Path(__file__).parent / "scaleup_out" / "aligned.jsonl"
+DEFAULT_OUT = Path(__file__).parent / "training_data" / "midloop_v0.jsonl"
+
+# Word-level whitespace tokenization, MUST match
+# merken/training/midloop_dataset.py:tokenize so token indices stay
+# consistent across the alignment + training pipeline.
+_TOKEN_RE = re.compile(r"\S+")
+
+
+def tokenize(text: str) -> list[str]:
+    return _TOKEN_RE.findall(text)
+
+
+def labels_for_response(
+    response_tokens: list[str],
+    interventions: list[dict],
+    *,
+    mode: str = "span",
+) -> list[int]:
+    """Build per-token binary labels.
+
+    Two label shapes (see notes/midloop-training-plan.md for the
+    rationale):
+
+    - mode="span" (Option A): a token at position i gets label 1
+      if any intervention span (model_token_start, model_token_end)
+      contains i (start <= i < end). Produces ~86% positive density
+      on the Phase 1 dataset; documented but NOT recommended for
+      training (positive class swamps the trivial baseline).
+
+    - mode="boundary" (Option B, RECOMMENDED for v0): label 1 ONLY
+      at the start position of each intervention span. Produces
+      ~14% positive density; teaches the model "where does an
+      error START" -- the actionable runtime decision.
+    """
+    if mode not in ("span", "boundary"):
+        raise ValueError(f"unknown labeling mode: {mode!r}")
+    labels = [0] * len(response_tokens)
+    for span in interventions:
+        start = span.get("model_token_start", 0)
+        end = span.get("model_token_end", 0)
+        if mode == "boundary":
+            if 0 <= start < len(labels):
+                labels[start] = 1
+        else:  # mode == "span"
+            for i in range(max(0, start), min(len(labels), end)):
+                labels[i] = 1
+    return labels
+
+
+def convert_case(row: dict, *, labeling: str = "span") -> dict | None:
+    """Convert one aligned.jsonl row to one training sample.
+
+    Returns None if the row is malformed or has zero response tokens
+    (cannot train on an empty sequence).
+    """
+    response = row.get("model_response", "")
+    if not response:
+        return None
+    tokens = tokenize(response)
+    if not tokens:
+        return None
+    interventions = row.get("interventions", []) or []
+    labels = labels_for_response(tokens, interventions, mode=labeling)
+    return {
+        "case_id": row.get("case_id", ""),
+        "prompt": row.get("prompt", ""),
+        "response_tokens": tokens,
+        "intervene_labels": labels,
+        "labeling_mode": labeling,
+        "intervention_spans": [
+            {
+                "model_token_start": s.get("model_token_start", 0),
+                "model_token_end": s.get("model_token_end", 0),
+                "truth_text": s.get("truth_text", ""),
+                "model_text": s.get("model_text", ""),
+                "cosine_sim": s.get("cosine_sim"),
+            }
+            for s in interventions
+        ],
+        "metadata": row.get("metadata", {}),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", "--input", dest="input", type=Path,
+                    default=DEFAULT_IN, help="aligned.jsonl path")
+    ap.add_argument("--out", "--output", dest="output", type=Path,
+                    default=DEFAULT_OUT, help="training-format output path")
+    ap.add_argument(
+        "--labeling", choices=["span", "boundary"], default="span",
+        help=(
+            "label shape: 'span' marks every token inside an "
+            "intervention span (~86%% positive on Phase 1 dataset); "
+            "'boundary' marks ONLY the first token of each span "
+            "(~14%% positive, recommended for v0 training). See "
+            "notes/midloop-training-plan.md for the rationale."
+        ),
+    )
+    args = ap.parse_args()
+
+    if not args.input.exists():
+        print(f"ERROR: input not found: {args.input}", file=sys.stderr)
+        return 2
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    n_in = 0
+    n_out = 0
+    n_tokens_total = 0
+    n_positive_total = 0
+    case_label_dist: Counter[int] = Counter()
+
+    with args.input.open() as fin, args.output.open("w") as fout:
+        for line in fin:
+            line = line.strip()
+            if not line:
+                continue
+            n_in += 1
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as e:
+                print(f"warn: skipping malformed line {n_in}: {e}",
+                      file=sys.stderr)
+                continue
+            sample = convert_case(row, labeling=args.labeling)
+            if sample is None:
+                continue
+            n_out += 1
+            n_tokens_total += len(sample["response_tokens"])
+            n_positive_total += sum(sample["intervene_labels"])
+            case_label_dist[sum(sample["intervene_labels"])] += 1
+            fout.write(json.dumps(sample, ensure_ascii=False) + "\n")
+
+    pos_rate = (
+        n_positive_total / n_tokens_total if n_tokens_total else 0.0
+    )
+
+    print(f"\n=== format_for_training ===", file=sys.stderr)
+    print(f"  input rows:      {n_in}", file=sys.stderr)
+    print(f"  output samples:  {n_out}", file=sys.stderr)
+    print(f"  total tokens:    {n_tokens_total}", file=sys.stderr)
+    print(f"  positive tokens: {n_positive_total} ({100*pos_rate:.1f}%)",
+          file=sys.stderr)
+    print(f"  per-case positive distribution (top 10):", file=sys.stderr)
+    for k, v in sorted(case_label_dist.items())[:10]:
+        print(f"    {k} positive tokens: {v} cases", file=sys.stderr)
+    print(f"  output: {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/notes/midloop-training-plan.md
+++ b/notes/midloop-training-plan.md
@@ -1,0 +1,285 @@
+# Phase 3: NanoGPTMidloopDecider training plan
+
+The Phase 1 pipeline (PR #20-23) produced a 1136-intervention
+dataset over 385 cases drawn from 77 WHO/IMCI clinical protocols.
+The Phase 2 primitive (PR #22) shipped the runtime scaffolding
+(``StepObservation`` -> ``MidloopDecision``) with three reference
+deciders, of which only the heuristic one is non-trivial.
+
+This note plans Phase 3: a trained classifier that replaces the
+heuristic. **It is design only -- no training run lives in this
+note.** When the plan ships as code, it will follow the
+NanoGPTWriteDecider precedent (PRs #1, #4, #5, #11) -- shadow
+mode first, calibrated against fresh disagreements, graduated
+only when the numeric bars are met.
+
+## What the model needs to predict
+
+Per the midloop spec section "NanoGPTMidloopDecider":
+
+> Es decisión binaria intrínseca al pipeline de generación...
+> token-level con sampling adaptativo.
+
+The runtime question at inference time is:
+
+> Given the user's prompt + the tokens the LLM has already emitted,
+> SHOULD I intervene RIGHT NOW (at the next token boundary)?
+
+So the prediction is:
+- input: `prompt + response_tokens[:i]` (causal context)
+- output: per-position binary `intervene` / `continue`
+
+The training data shape must match this. Phase 1 produces aligned
+divergence SPANS, not per-token labels. There are three reasonable
+label-shape choices; each makes the model learn a different signal.
+
+## Three label-shape options
+
+### Option A. Span-inside (the obvious naive choice)
+
+Label `1` at every token position that lies inside any intervention
+span; `0` elsewhere.
+
+```
+truth:  REFER URGENTLY to a hospital with surgical capacity
+model:  Administer IV fluids and obtain urgent abdominal ultrasound
+
+response_tokens:    Administer IV fluids and obtain urgent abdominal ultrasound
+intervene_labels:   1          1  1      1   1      1      1         1
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                    one big span [0, 8) covers the whole response
+```
+
+**Properties measured on the 385-case dataset:**
+- 8053 total response tokens
+- 6965 positive (86.5%) -- the small model's response is wrong-most-of-the-time
+- positive-per-case median is 16 of 21 tokens
+
+**Why this is BAD for training:**
+The class imbalance is the wrong way around. A trivial "always
+predict 1" baseline gets 86.5% accuracy. The model would need to
+learn the specific tokens that DON'T need intervention (typically
+bridge words like "and", "to", "the" that overlap with the truth
+sequence in the diff alignment). Those bridge words are not
+clinically meaningful; learning them just memorizes diff artifacts.
+
+This option is documented for completeness only. **DO NOT USE.**
+
+### Option B. Span-boundary (recommended for v0)
+
+Label `1` ONLY at the START of each intervention span; `0` elsewhere.
+
+```
+response_tokens:    Administer IV fluids and obtain urgent abdominal ultrasound
+intervene_labels:   1          0  0      0   0      0      0         0
+                    ^
+                    only the start of [0, 8) gets labeled
+```
+
+For a case with 3 intervention spans, exactly 3 positive labels
+(one per span start). Per-case positive count = number of
+divergence regions = 1136 / 385 ~= 3 per case ~= 14% positive token
+density.
+
+**Properties (estimated):**
+- 8053 total response tokens (same)
+- ~1136 positive (~14.1%) -- one per span
+- positive-per-case median ~3 of 21 tokens
+
+**Why this is the right v0 signal:**
+It teaches the model "where does an error START" -- the actionable
+signal at inference time. The runtime can then flag intervention
+RIGHT THERE, before the model commits to the whole bad span.
+Detecting the span start is the production-relevant decision; the
+fact that tokens 1-7 of the span are also wrong is downstream
+context, not a separate prediction.
+
+The 14% positive rate is still imbalanced but tractable. Class
+weighting at ~6:1 (negative_weight=1, positive_weight=6) brings
+loss contributions roughly even.
+
+**This is what v0 should ship.**
+
+### Option C. Case-level binary (the lazy fallback)
+
+One label per case: "did the response need intervention at all?"
+
+For our dataset every case has at least one intervention, so every
+case is labeled 1. Useless as a training signal -- nothing to
+discriminate. Documented to explicitly close it off as not worth
+trying.
+
+## Recommended dataset format (v0)
+
+`format_for_training.py` emits Option A by default (it's the
+straightforward span-inside computation). For Phase 3 v0, switch
+to Option B by passing `--labeling boundary`. Output schema stays
+the same; only the label vector changes.
+
+```jsonl
+{
+  "case_id": "acute-abdomen-who__case_000",
+  "prompt": "<CHW question>",
+  "response_tokens": ["Administer", "IV", "fluids", ...],
+  "intervene_labels": [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...],
+  "intervention_spans": [...],   // for traceability + eval
+  "metadata": {"protocol_id": "...", ...}
+}
+```
+
+The training loader reads this directly. No tokenization
+mismatch concern -- response_tokens already match
+merken/training/midloop_dataset.py:tokenize.
+
+## Architecture sketch
+
+Same recipe as NanoGPTWriteDecider (the v7 graduated baseline) but
+with a sequence-tagging head instead of a sequence-classification
+head:
+
+| | NanoGPTWriteDecider v7 | NanoGPTMidloopDecider v0 |
+|---|---|---|
+| arch | 4L/4H/128d, block=256, vocab=512 | same |
+| param count | ~800K | ~800K (+ tiny tagging head) |
+| loss | cross-entropy on a single label token after `<|label|>` | per-position BCE on intervene_labels |
+| input | one event text | prompt `<sep>` response_tokens (causal) |
+| output | DECISION / NOISE token logits at the last position | per-position {intervene: 0 or 1} |
+| dataset | 3046 events (1026 transcript + 1922 synth + ...) | 385 cases (Phase 1 dataset) |
+| training | next-token CE | per-position BCE w/ class weight ~6:1 |
+
+The same nanoGPT codebase + tokenizer infrastructure ports. The
+only real change is a `tagging_head: Linear(n_embd, 1)` applied to
+EVERY position's hidden state instead of just the last.
+
+## Data prep before training
+
+1. Hold out a TEST set: 10% of cases stratified by protocol_id so
+   no protocol leaks across train/test. ~38 test cases / 350
+   train cases.
+2. Train BPE tokenizer on prompt + response text only (NOT on
+   labels -- those are post-hoc per-position).
+3. Materialize a single sequence per case:
+   `[BOS] <prompt tokens> [SEP] <response tokens> [EOS]`
+   Labels: `0` for prompt + sep, `intervene_labels` for response
+   tokens, `0` for EOS. Loss masked to response region only.
+
+## Loss + training
+
+- Per-position binary cross-entropy with `pos_weight = 6.0` (rough
+  inverse of the 14% positive rate). Calibrate on a sweep
+  [3, 5, 6, 8, 10] against held-out F1.
+- Loss masked: only response-region positions contribute. Prompt
+  + special tokens excluded from gradient.
+- Optimizer: same as v7 (AdamW lr=1e-3, weight_decay=0.1, cosine
+  schedule, warmup=100, max_iters TBD).
+- Save best F1 (not loss) on held-out.
+
+## Evaluation metrics
+
+Asymmetric per the spec's clinical-use bias:
+
+| metric | target | rationale |
+|---|---|---|
+| Precision (intervention-start detection) | >= 80% | False alarm = whisper that didn't need to fire. Annoying but reversible. |
+| Recall (intervention-start detection) | >= 70% | Missed intervention = clinical error reaches the CHW. Costly. |
+| F1 | >= 0.75 | Headline number for graduation gate. |
+| Per-protocol breakdown | no protocol < 50% recall | Catches "model learned 5 protocols and ignored 72". |
+
+**Baseline to beat:**
+- "always predict 0" gets 0% recall = 0 F1.
+- "always predict 1" gets 100% recall, ~14% precision = 0.25 F1.
+- HeuristicMidloopDecider (NOT trained on this data) on the same
+  held-out -- TBD; expect very low F1 because it operates at step
+  level not token level.
+
+## Graduation criteria (numeric bars per spec)
+
+Per midloop-spec.md section "Phases of execution":
+
+1. **Phase 0 -- pilot validates pipeline** (DONE in PR #21).
+2. **Phase 1 -- data pipeline produces dataset** (DONE in PRs
+   #20-23, 1136 labels).
+3. **Phase 2 -- midloop primitive ships** (DONE in PR #22).
+4. **Phase 3 -- v0 NanoGPTMidloopDecider trains:**
+   - F1 >= 0.75 on held-out (38 cases)
+   - No per-protocol recall < 50%
+   - Acceptance training time <= 30 min on MPS
+5. **Phase 4 -- shadow mode in production:**
+   - Wrap as `ShadowMidloopDecider(NoopMidloopDecider(),
+     NanoGPTMidloopDecider(ckpt))`
+   - Accumulate >= 200 (decision, task_outcome) pairs
+   - Calibrate threshold on real labels
+6. **Phase 5 -- graduation:**
+   - Promote to PRIMARY only if shadow disagreements show >= 70%
+     "agree-with-oracle" rate on the >= 200 labels
+   - Action initially clamped to WHISPER
+
+## What NOT to do in v0
+
+Per Silt's rule + the v7 saga lessons:
+- Do NOT bump architecture above 4L/4H/128d before measuring v0
+  (H8 confirmed capacity is rarely the bottleneck on small data).
+- Do NOT add contrastive losses in v0 (the H2/H2b/H2c trio
+  showed those saturate fast on small bucket pools).
+- Do NOT use the full 8053 tokens × 385 cases as a flat training
+  set -- the protocol-id dependency is real (similar phrasings
+  across cases of the same protocol). Stratified split + held-out
+  keeps generalization claims honest.
+- Do NOT optimize threshold on the test set. Use a separate
+  validation slice (10% of train).
+
+## Open questions for v0 implementation
+
+1. **Tokenizer choice**: BPE trained on prompt+response (~few MB
+   of clinical text) vs reuse v7's BPE tokenizer. Reuse is easier
+   but v7's vocab was tuned for write-filter content (decisions
+   vs noise from Claude transcripts), not clinical advice. Probably
+   train a fresh BPE; keep the architecture identical.
+2. **Block size**: Phase 1 cases have prompt + response averaging
+   ~50 + 21 = 71 tokens. block_size=128 is safe; 256 might be
+   waste. Confirm distribution on the actual training data.
+3. **Hidden dim of tagging head**: a single linear layer over
+   n_embd=128 -> 1 gives 129 params. Tiny. Could add an MLP
+   (128 -> 64 -> 1) for slightly more capacity. Bench both.
+
+## Open questions blocking Phase 4 (shadow deployment)
+
+These don't block Phase 3 implementation but should be answered
+before the trained model goes live:
+
+1. **What is a "step" in the LLM-runtime context?** The midloop
+   primitive operates on `StepObservation` which assumes a
+   discrete step. For token-level intervention, the "step" is
+   one token. The runtime needs to call `Memory.observe_step` per
+   token, which is performance-sensitive. Streaming-callback
+   architecture vs batch-after-N-tokens is a downstream design.
+2. **Whisper injection mechanism**: when `intervene=True,
+   action=WHISPER` fires, HOW does the Builder consume that?
+   For Anthropic streaming API: cannot inject mid-stream cleanly.
+   For local-model setups (lmstudio, llama.cpp): can prepend a
+   guidance token. For Reforge: depends on its execution model.
+3. **Latency budget**: a token-level call to a small classifier
+   per generated token at ~1ms each adds up. For 200-token
+   responses, +200ms overhead. Within budget for non-realtime
+   clinical advice; not for chat UX. Sampling adaptive (every
+   N tokens) is the documented mitigation.
+
+## Timeline estimate
+
+- v0 dataset reformat to Option B: 30 min (extend
+  format_for_training.py with --labeling flag).
+- v0 nanoGPT training script: 1 day (fork v7 train, swap head +
+  loss, add per-position masking).
+- v0 first training run + eval: 1 hour (~30 min train + 30 min
+  eval, MPS).
+- Iteration to F1 >= 0.75: probably 1-3 weeks of small tweaks
+  (class weight sweep, threshold calibration, maybe a wider
+  hidden dim if tagging-head capacity is the bottleneck).
+- Phase 4 shadow integration: 1 day (NanoGPTMidloopDecider class
+  mirrors NanoGPTWriteDecider; same file shape).
+- Phase 4 -> Phase 5 (real-data calibration): months of organic
+  use to accumulate the 200 pairs.
+
+Phase 3 v0 is realistically ~1-3 weeks of focused work for
+a publication-grade result. Phase 5 graduation is calendar-bound
+on real-world traffic, not engineering effort.

--- a/tests/test_format_for_training.py
+++ b/tests/test_format_for_training.py
@@ -1,0 +1,124 @@
+"""Tests for the Phase 3 dataset format converter.
+
+Verifies the two label-shape options match what
+``notes/midloop-training-plan.md`` documents and what the
+NanoGPTMidloopDecider trainer will expect.
+"""
+
+from __future__ import annotations
+
+from experiments.midloop_pilot.format_for_training import (
+    convert_case,
+    labels_for_response,
+    tokenize,
+)
+
+
+def test_tokenize_matches_aligner_contract() -> None:
+    """The converter MUST tokenize the same way the aligner did,
+    otherwise token indices in intervention spans are nonsense.
+    """
+    from merken.training.midloop_dataset import tokenize as aligner_tokenize
+    s = "Administer IV fluids and obtain urgent abdominal ultrasound"
+    assert tokenize(s) == aligner_tokenize(s)
+
+
+def test_span_labeling_marks_every_token_inside_span() -> None:
+    tokens = ["a", "b", "c", "d", "e"]
+    spans = [{"model_token_start": 1, "model_token_end": 4}]  # b,c,d
+    labels = labels_for_response(tokens, spans, mode="span")
+    assert labels == [0, 1, 1, 1, 0]
+
+
+def test_boundary_labeling_marks_only_start() -> None:
+    tokens = ["a", "b", "c", "d", "e"]
+    spans = [{"model_token_start": 1, "model_token_end": 4}]
+    labels = labels_for_response(tokens, spans, mode="boundary")
+    # Only index 1 (start of [1,4)) gets the label.
+    assert labels == [0, 1, 0, 0, 0]
+
+
+def test_multi_span_boundary_one_label_per_span() -> None:
+    tokens = ["a", "b", "c", "d", "e", "f"]
+    spans = [
+        {"model_token_start": 0, "model_token_end": 2},
+        {"model_token_start": 4, "model_token_end": 6},
+    ]
+    labels = labels_for_response(tokens, spans, mode="boundary")
+    assert labels == [1, 0, 0, 0, 1, 0]
+
+
+def test_unknown_mode_raises() -> None:
+    import pytest
+    with pytest.raises(ValueError, match="unknown labeling mode"):
+        labels_for_response(["a"], [], mode="bogus")
+
+
+def test_convert_case_full_round_trip() -> None:
+    row = {
+        "case_id": "test_001",
+        "prompt": "what dose for kid pneumonia?",
+        "model_response": "Administer IV fluids urgently",
+        "interventions": [
+            {
+                "model_token_start": 0,
+                "model_token_end": 4,
+                "truth_text": "REFER URGENTLY to hospital",
+                "model_text": "Administer IV fluids urgently",
+                "cosine_sim": 0.55,
+            }
+        ],
+        "metadata": {"protocol_id": "pneumonia"},
+    }
+    out = convert_case(row, labeling="boundary")
+    assert out is not None
+    assert out["case_id"] == "test_001"
+    assert out["prompt"] == "what dose for kid pneumonia?"
+    assert out["response_tokens"] == [
+        "Administer", "IV", "fluids", "urgently",
+    ]
+    # boundary -> only first token labeled
+    assert out["intervene_labels"] == [1, 0, 0, 0]
+    assert out["labeling_mode"] == "boundary"
+    assert out["metadata"] == {"protocol_id": "pneumonia"}
+    # spans preserved for traceability
+    assert len(out["intervention_spans"]) == 1
+    assert out["intervention_spans"][0]["truth_text"] == "REFER URGENTLY to hospital"
+
+
+def test_convert_case_skips_empty_response() -> None:
+    row = {"case_id": "x", "model_response": "", "interventions": []}
+    assert convert_case(row) is None
+
+
+def test_convert_case_skips_whitespace_only_response() -> None:
+    row = {"case_id": "x", "model_response": "   \n\t  ", "interventions": []}
+    assert convert_case(row) is None
+
+
+def test_convert_case_no_interventions_all_zero_labels() -> None:
+    row = {
+        "case_id": "perfect",
+        "prompt": "trivial",
+        "model_response": "exactly the right answer",
+        "interventions": [],
+        "metadata": {},
+    }
+    out = convert_case(row, labeling="boundary")
+    assert out is not None
+    assert out["intervene_labels"] == [0, 0, 0, 0]  # 4 tokens
+
+
+def test_span_labeling_clamps_to_token_bounds() -> None:
+    # Span end > len(tokens) should not crash; just clamps.
+    tokens = ["a", "b", "c"]
+    spans = [{"model_token_start": 1, "model_token_end": 99}]
+    labels = labels_for_response(tokens, spans, mode="span")
+    assert labels == [0, 1, 1]
+
+
+def test_boundary_labeling_skips_out_of_range_start() -> None:
+    tokens = ["a", "b", "c"]
+    spans = [{"model_token_start": 99, "model_token_end": 100}]
+    labels = labels_for_response(tokens, spans, mode="boundary")
+    assert labels == [0, 0, 0]

--- a/tests/test_format_for_training.py
+++ b/tests/test_format_for_training.py
@@ -122,3 +122,28 @@ def test_boundary_labeling_skips_out_of_range_start() -> None:
     spans = [{"model_token_start": 99, "model_token_end": 100}]
     labels = labels_for_response(tokens, spans, mode="boundary")
     assert labels == [0, 0, 0]
+
+
+def test_accepts_dataclass_direct_field_names() -> None:
+    """JSONL writers can use either dialect:
+       - model_token_start / model_token_end (CLI rename)
+       - model_start / model_end (direct from Region dataclass)
+    Per PR #24 review (Gemini); both must work for forward compat.
+    """
+    tokens = ["a", "b", "c", "d", "e"]
+    # dataclass-direct shape
+    spans_direct = [{"model_start": 1, "model_end": 4}]
+    assert labels_for_response(tokens, spans_direct, mode="boundary") == [0, 1, 0, 0, 0]
+    assert labels_for_response(tokens, spans_direct, mode="span") == [0, 1, 1, 1, 0]
+
+
+def test_token_keys_take_precedence_when_both_present() -> None:
+    """If a span has BOTH key shapes, the explicit ``model_token_*``
+    keys win -- consistent with the upstream CLI being the canonical
+    JSONL writer."""
+    tokens = ["a", "b", "c", "d", "e"]
+    spans = [{
+        "model_token_start": 1, "model_token_end": 2,
+        "model_start": 3, "model_end": 4,
+    }]
+    assert labels_for_response(tokens, spans, mode="boundary") == [0, 1, 0, 0, 0]


### PR DESCRIPTION
## Summary

Phase 3 of the midloop initiative lands as documentation + a small data-prep utility. **No training run in this PR.** Per the spec, Phase 3 v0 is ~1-3 weeks of focused work; this PR sets up the inputs and decides the label shape so the training work has a clear plan to execute against.

Builds on:
- PR #21 (1097-label pilot dataset)
- PR #22 (Phase 2 midloop primitive: Protocol + 3 deciders + Memory.observe_step)
- PR #23 (tech-debt recovery: +39 labels, 1136 total)

## What's in here

### Design doc: `notes/midloop-training-plan.md`

- **Three label-shape options** with positive-class rates measured on the actual Phase 1 dataset:
  - Option A (span-inside): 86.5% positive -- documented as a trap, NOT recommended
  - **Option B (span-boundary): 14.1% positive -- recommended for v0**
  - Option C (case-level): 100% positive on this dataset, useless
- **Architecture sketch**: same nanoGPT recipe as the v7 write filter (4L/4H/128d, ~800K params) with a per-position tagging head instead of last-position classification head.
- **Loss + class weighting**: per-position BCE with `pos_weight=6.0` (rough inverse of 14% positive). Calibrate on a sweep [3, 5, 6, 8, 10] vs held-out F1.
- **Asymmetric eval metrics** (precision >=80%, recall >=70%, F1 >=0.75) per the clinical bias.
- **5-phase graduation gate** following the NanoGPTWriteDecider precedent (shadow first, calibration on real disagreements, promotion only when 200 labels confirm).
- **Open questions blocking Phase 4** (whisper injection mechanism, latency budget, runtime "step" definition for token-level operation).

### Converter: `experiments/midloop_pilot/format_for_training.py`

Input: `scaleup_out/aligned.jsonl` (385 cases, 1136 spans).
Output: `training_data/midloop_v0.jsonl` with per-token labels.

```bash
python -m experiments.midloop_pilot.format_for_training --labeling boundary
```

Empirical results on the Phase 1 dataset:

| labeling | total tokens | positive | density |
|---|---:|---:|---:|
| span | 8053 | 6965 | 86.5% |
| **boundary** | 8053 | **1132** | **14.1%** |

Per-case boundary distribution: median 3, range 1-7. The shape matches what a sequence-tagging classifier expects.

### Tests: `tests/test_format_for_training.py` (11)

- Tokenize MUST match `merken.training.midloop_dataset.tokenize` (load-bearing -- mismatch would silently invalidate all span indices).
- Span labeling: every token inside [start, end) gets 1.
- Boundary labeling: only the start position gets 1.
- Multi-span boundary: one label per span.
- Unknown mode: clear error.
- Full round-trip on convert_case.
- Edge cases (empty response, whitespace-only, out-of-range indices).

## Test plan

- [x] 11 new tests pass.
- [x] Full suite: 349 pass (was 338).
- [x] Both `--labeling span` and `--labeling boundary` produce the documented positive-class rates on the actual dataset.
- [ ] Reviewer to confirm the boundary-labeling recommendation is the intended v0 starting point.
- [ ] Reviewer to confirm the F1 >= 0.75 graduation bar is calibrated to MedLocal's clinical-stakes asymmetry.

## What this does NOT do

- Does NOT train a model (Phase 3 v0 execution, 1-3 weeks).
- Does NOT add a `NanoGPTMidloopDecider` class (Phase 3 v0 deliverable; mirrors `NanoGPTWriteDecider` once a checkpoint exists).
- Does NOT ingest the 7 WHO PDFs (still deferred -- separate larger effort needing pypdf + section splitting).
- Does NOT promote `response_schema` from the recovery script to `case_generator.py` (filed as production follow-up).

Full design context: `notes/midloop-training-plan.md`. The doc names every open question + every numeric bar so the v0 implementation has a clear target.