### PR TITLE
feat(case-generator): default_gemini_client + structured-output mode

### DIFF
--- a/merken/training/case_generator.py
+++ b/merken/training/case_generator.py
@@ -8,9 +8,27 @@ WITHOUT the protocol; the gap between truth and small-model response
 is the midloop training signal.
 
 Mock-friendly design: ``CaseGenerator`` takes a ``LLMClient``
-callable. The default implementation wraps the anthropic SDK, but
-tests pass a fake that returns canned JSON. This keeps the suite
-offline + zero-cost while preserving the real-world path.
+callable. The default implementations wrap the anthropic SDK or the
+google-genai SDK; tests pass a fake that returns canned JSON or a
+canned list. This keeps the suite offline + zero-cost while preserving
+the real-world path.
+
+Two client contracts are supported:
+
+- **Text-mode** (default): the client returns a raw JSON string and
+  ``CaseGenerator`` parses it with ``_extract_json_array`` (tolerant
+  of markdown fences + leading prose). Use this when the upstream
+  API doesn't enforce JSON structure on the wire.
+- **Structured-mode**: the client returns ``list[dict]`` directly,
+  bypassing the text parsing. Use this when the API guarantees the
+  shape via response_mime_type / response_schema (Gemini's
+  structured output, OpenAI's response_format=json_schema, etc).
+
+Pass ``structured=True`` to ``CaseGenerator`` when wiring a
+structured-mode client so the parser step is skipped. The recovery
+script in ``experiments/midloop_pilot/recover_failed.py`` (PR #23)
+demonstrated structured-mode is faster + zero JSON parse failures
+on the live MedLocal corpus.
 """
 
 from __future__ import annotations
@@ -21,8 +39,13 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-# (system_prompt, user_prompt) -> raw model output text.
+# Text-mode: (system_prompt, user_prompt) -> raw model output text.
 LLMClient = Callable[[str, str], str]
+
+# Structured-mode: (system_prompt, user_prompt) -> parsed list of dicts.
+# Used by clients backed by structured-output APIs that guarantee the
+# response shape on the wire (e.g. Gemini response_schema).
+LLMStructuredClient = Callable[[str, str], list[dict]]
 
 
 @dataclass
@@ -114,8 +137,28 @@ class CaseGenerator:
     aside from the LLM client reference.
     """
 
-    def __init__(self, llm_client: LLMClient) -> None:
+    def __init__(
+        self,
+        llm_client: LLMClient | LLMStructuredClient,
+        *,
+        structured: bool = False,
+    ) -> None:
+        """Build a CaseGenerator.
+
+        ``structured=False`` (default): ``llm_client`` returns a raw
+        JSON string; we parse it with ``_extract_json_array``
+        (tolerant of markdown fences + prose). Use with
+        ``default_anthropic_client`` and any API where you cannot
+        enforce JSON structure on the wire.
+
+        ``structured=True``: ``llm_client`` returns ``list[dict]``
+        directly, bypassing text parsing. Use with
+        ``default_gemini_client(structured=True)`` and any API that
+        guarantees the response shape (Gemini response_schema,
+        OpenAI json_schema, etc).
+        """
         self._llm = llm_client
+        self._structured = structured
 
     def generate(self, clause: ProtocolClause, n: int = 5) -> list[GeneratedCase]:
         if n <= 0:
@@ -125,8 +168,16 @@ class CaseGenerator:
             protocol_text=clause.text,
             n=n,
         )
-        raw = self._llm(_SYSTEM_PROMPT, user)
-        rows = _extract_json_array(raw)
+        result = self._llm(_SYSTEM_PROMPT, user)
+        if self._structured:
+            if not isinstance(result, list):
+                raise TypeError(
+                    f"structured=True client must return list[dict]; "
+                    f"got {type(result).__name__}"
+                )
+            rows = result
+        else:
+            rows = _extract_json_array(result)
 
         cases: list[GeneratedCase] = []
         for i, row in enumerate(rows):
@@ -179,3 +230,96 @@ def default_anthropic_client(
         return getattr(block, "text", "") or ""
 
     return _fn
+
+
+def default_gemini_client(
+    api_key: str,
+    model: str = "gemini-2.5-flash",
+    *,
+    structured: bool = True,
+    timeout_s: float = 60.0,
+) -> "LLMStructuredClient | LLMClient":
+    """Build a Gemini-backed client. Defaults to structured-output mode.
+
+    Lazy-imports google-genai so the module is importable without
+    the SDK installed (tests use fake clients).
+
+    ``structured=True`` (RECOMMENDED, default) returns an
+    ``LLMStructuredClient`` -- the SDK enforces a Pydantic schema
+    (``list[_GeneratedCaseSchema]``) on the wire so the response
+    is GUARANTEED to be valid JSON with the right shape. The
+    recovery script in ``experiments/midloop_pilot/recover_failed.py``
+    demonstrated this is faster + zero JSON parse failures on the
+    77-protocol MedLocal corpus that text-mode left 2 protocols
+    failing on. Pair with ``CaseGenerator(client, structured=True)``.
+
+    ``structured=False`` returns an ``LLMClient`` (text mode) for
+    callers who explicitly want raw text + tolerant parsing.
+
+    Wrapped in a per-call ``concurrent.futures`` timeout (default
+    60s) because the google-genai SDK can hang in SSL_read
+    indefinitely under transient network conditions; we observed a
+    23-min hang during the 77-protocol scale-up before adding this
+    protection. ``timeout_s=0`` disables the wrapper.
+    """
+    try:
+        from google import genai
+        from google.genai import types
+    except ImportError as e:  # pragma: no cover - env-specific
+        raise SystemExit(
+            "google-genai not installed. Run `pip install google-genai`. "
+            f"[{e}]"
+        ) from e
+    from pydantic import BaseModel
+
+    class _GeneratedCaseSchema(BaseModel):
+        prompt: str
+        truth: str
+
+    client = genai.Client(api_key=api_key)
+    config = (
+        types.GenerateContentConfig(
+            response_mime_type="application/json",
+            response_schema=list[_GeneratedCaseSchema],
+        )
+        if structured
+        else None
+    )
+
+    def _do_call(system: str, user: str):
+        full = f"{system}\n\n{user}"
+        resp = client.models.generate_content(
+            model=model, contents=full, config=config,
+        )
+        if structured:
+            parsed = resp.parsed
+            if parsed is not None:
+                return [
+                    {"prompt": c.prompt, "truth": c.truth} for c in parsed
+                ]
+            # Fallback: schema didn't materialize; surface a clear
+            # error rather than returning [] silently.
+            text = (resp.text or "").strip()
+            if not text:
+                raise ValueError(
+                    "Gemini structured call returned no parsed schema "
+                    "and no text; likely a transient API issue."
+                )
+            return _extract_json_array(text)
+        return (resp.text or "").strip()
+
+    if timeout_s and timeout_s > 0:
+        import concurrent.futures
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+        def _fn(system: str, user: str):
+            future = pool.submit(_do_call, system, user)
+            try:
+                return future.result(timeout=timeout_s)
+            except concurrent.futures.TimeoutError as e:
+                future.cancel()
+                raise TimeoutError(
+                    f"Gemini call exceeded {timeout_s}s timeout"
+                ) from e
+        return _fn
+    return _do_call

--- a/merken/training/case_generator.py
+++ b/merken/training/case_generator.py
@@ -177,6 +177,18 @@ class CaseGenerator:
                 )
             rows = result
         else:
+            # Symmetric defensive check: a structured client passed
+            # without `structured=True` would return a list and the
+            # downstream _extract_json_array(...).strip() would fail
+            # with an unhelpful AttributeError. Surface the misuse
+            # explicitly. Per PR #25 review (Copilot, 2026-04-19).
+            if not isinstance(result, str):
+                raise TypeError(
+                    f"text-mode client must return str (got "
+                    f"{type(result).__name__}). If your client returns "
+                    f"list[dict] (e.g. default_gemini_client(structured=True)), "
+                    f"pass `structured=True` to CaseGenerator."
+                )
             rows = _extract_json_array(result)
 
         cases: list[GeneratedCase] = []
@@ -242,7 +254,17 @@ def default_gemini_client(
     """Build a Gemini-backed client. Defaults to structured-output mode.
 
     Lazy-imports google-genai so the module is importable without
-    the SDK installed (tests use fake clients).
+    the SDK installed (tests use fake clients). Per PR #25 review
+    (Gemini code-assist + Copilot, 2026-04-19) we use the SDK's
+    NATIVE features instead of wrapping calls in a thread pool:
+
+    - ``system_instruction`` on ``GenerateContentConfig`` carries
+      the system prompt without manual string concat.
+    - ``http_options.timeout`` on the same config gives the SDK's
+      HTTP layer a hard deadline. The SDK closes the connection
+      cleanly on timeout, unlike a futures.Future cancel() which
+      cannot stop in-flight Python work and leaves a poisoned
+      worker thread behind.
 
     ``structured=True`` (RECOMMENDED, default) returns an
     ``LLMStructuredClient`` -- the SDK enforces a Pydantic schema
@@ -256,17 +278,20 @@ def default_gemini_client(
     ``structured=False`` returns an ``LLMClient`` (text mode) for
     callers who explicitly want raw text + tolerant parsing.
 
-    Wrapped in a per-call ``concurrent.futures`` timeout (default
-    60s) because the google-genai SDK can hang in SSL_read
-    indefinitely under transient network conditions; we observed a
-    23-min hang during the 77-protocol scale-up before adding this
-    protection. ``timeout_s=0`` disables the wrapper.
+    ``timeout_s=0`` disables the per-call timeout (NOT recommended
+    -- the SDK can hang in SSL_read for many minutes under
+    transient network conditions; we observed a 23-min hang during
+    the 77-protocol scale-up before adding this protection).
     """
     try:
         from google import genai
         from google.genai import types
-    except ImportError as e:  # pragma: no cover - env-specific
-        raise SystemExit(
+    except ImportError as e:
+        # Library code raises ImportError (not SystemExit) so the
+        # caller can catch + degrade. The install hint is in the
+        # message so a top-level handler can show it to the user
+        # without a traceback.
+        raise ImportError(
             "google-genai not installed. Run `pip install google-genai`. "
             f"[{e}]"
         ) from e
@@ -276,20 +301,28 @@ def default_gemini_client(
         prompt: str
         truth: str
 
-    client = genai.Client(api_key=api_key)
-    config = (
-        types.GenerateContentConfig(
-            response_mime_type="application/json",
-            response_schema=list[_GeneratedCaseSchema],
-        )
-        if structured
+    # http_options.timeout is in milliseconds. timeout_s=0 -> omit
+    # the http_options entirely (SDK default = no per-call timeout).
+    http_options = (
+        types.HttpOptions(timeout=int(timeout_s * 1000))
+        if timeout_s and timeout_s > 0
         else None
     )
 
-    def _do_call(system: str, user: str):
-        full = f"{system}\n\n{user}"
+    client = genai.Client(api_key=api_key, http_options=http_options)
+
+    def _build_config(system: str):
+        kwargs: dict = {"system_instruction": system}
+        if structured:
+            kwargs["response_mime_type"] = "application/json"
+            kwargs["response_schema"] = list[_GeneratedCaseSchema]
+        return types.GenerateContentConfig(**kwargs)
+
+    def _fn(system: str, user: str):
         resp = client.models.generate_content(
-            model=model, contents=full, config=config,
+            model=model,
+            contents=user,
+            config=_build_config(system),
         )
         if structured:
             parsed = resp.parsed
@@ -308,18 +341,4 @@ def default_gemini_client(
             return _extract_json_array(text)
         return (resp.text or "").strip()
 
-    if timeout_s and timeout_s > 0:
-        import concurrent.futures
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-
-        def _fn(system: str, user: str):
-            future = pool.submit(_do_call, system, user)
-            try:
-                return future.result(timeout=timeout_s)
-            except concurrent.futures.TimeoutError as e:
-                future.cancel()
-                raise TimeoutError(
-                    f"Gemini call exceeded {timeout_s}s timeout"
-                ) from e
-        return _fn
-    return _do_call
+    return _fn

--- a/tests/test_case_generator.py
+++ b/tests/test_case_generator.py
@@ -186,3 +186,15 @@ def test_text_mode_default_unchanged() -> None:
     cases = gen.generate(ProtocolClause("p", "..."), n=1)
     assert len(cases) == 1
     assert cases[0].prompt == "p_text"
+
+
+def test_text_mode_rejects_list_return_with_actionable_error() -> None:
+    """A structured client passed WITHOUT structured=True surfaces
+    a clear TypeError pointing at the misuse. Symmetric to the
+    structured-mode str check. Per PR #25 review (Copilot)."""
+    structured_like = _fake_structured_client(
+        [{"prompt": "p", "truth": "t"}]
+    )
+    gen = CaseGenerator(structured_like)  # MISSING structured=True
+    with pytest.raises(TypeError, match="text-mode client must return str"):
+        gen.generate(ProtocolClause("p", "..."), n=1)

--- a/tests/test_case_generator.py
+++ b/tests/test_case_generator.py
@@ -124,3 +124,65 @@ def test_generate_propagates_extraction_errors() -> None:
     gen = CaseGenerator(_fake_client("totally not json"))
     with pytest.raises(ValueError):
         gen.generate(ProtocolClause("p", "..."), n=1)
+
+
+# ----------------------------------------------------------------- structured
+
+def _fake_structured_client(canned: list):
+    """Build a structured client that returns a canned list."""
+    def _fn(system: str, user: str) -> list:
+        return canned
+    return _fn
+
+
+def test_structured_mode_skips_text_parsing() -> None:
+    """structured=True path takes the list directly; never calls
+    _extract_json_array. Verifiable because we pass a canned list
+    with 2 valid entries."""
+    canned = [
+        {"prompt": "child fever 38.5", "truth": "amoxicillin 50 mg/kg"},
+        {"prompt": "adult cough 5 days", "truth": "wait and observe"},
+    ]
+    gen = CaseGenerator(_fake_structured_client(canned), structured=True)
+    cases = gen.generate(ProtocolClause("p_struct", "..."), n=2)
+    assert len(cases) == 2
+    assert cases[0].case_id == "p_struct__case_000"
+    assert cases[0].prompt == "child fever 38.5"
+    assert cases[0].truth == "amoxicillin 50 mg/kg"
+
+
+def test_structured_mode_rejects_non_list_return() -> None:
+    """A structured client MUST return list[dict]; raising on a
+    string return surfaces a clear TypeError instead of corrupting
+    the output silently."""
+    def bad_client(system: str, user: str):
+        return "this is text not a list"
+
+    gen = CaseGenerator(bad_client, structured=True)
+    with pytest.raises(TypeError, match="must return list"):
+        gen.generate(ProtocolClause("p", "..."), n=1)
+
+
+def test_structured_mode_skips_malformed_entries_same_as_text() -> None:
+    """Validation on prompt/truth presence is identical between modes."""
+    canned = [
+        {"prompt": "ok", "truth": "ok"},
+        {"prompt": "missing truth"},        # incomplete
+        "not even a dict",                  # wrong type
+        {"prompt": "valid two", "truth": "valid"},
+    ]
+    gen = CaseGenerator(_fake_structured_client(canned), structured=True)
+    cases = gen.generate(ProtocolClause("p", "..."), n=4)
+    assert len(cases) == 2
+    assert cases[0].prompt == "ok"
+    assert cases[1].prompt == "valid two"
+
+
+def test_text_mode_default_unchanged() -> None:
+    """structured=False (default) preserves the existing behavior:
+    raw text in, _extract_json_array parses, cases come out."""
+    raw = '[{"prompt": "p_text", "truth": "t_text"}]'
+    gen = CaseGenerator(_fake_client(raw))  # no structured= kwarg
+    cases = gen.generate(ProtocolClause("p", "..."), n=1)
+    assert len(cases) == 1
+    assert cases[0].prompt == "p_text"


### PR DESCRIPTION
## Summary

Promotes the response_schema fix from PR #23's recovery script (`experiments/midloop_pilot/recover_failed.py`) to the production `CaseGenerator`. Closes the tech-debt item filed in that PR.

## What changes

Two backwards-compatible additions to `merken/training/case_generator.py`:

### 1. `LLMStructuredClient` callable type

Returns `list[dict]` directly instead of raw text. For APIs that guarantee response shape on the wire:
- Gemini `response_mime_type` + `response_schema`
- OpenAI `response_format=json_schema`
- Anthropic `tool_use` (filed as separate follow-up)

### 2. `CaseGenerator(client, structured=True)`

When `structured=True`, the LLM result is taken as the parsed list directly -- no `_extract_json_array` call, no markdown-fence stripping, no leading-prose handling. The text-mode path (`structured=False`, the default) is unchanged: existing `default_anthropic_client` and any custom text clients keep working.

### 3. `default_gemini_client` factory

```python
from merken.training.case_generator import CaseGenerator, default_gemini_client

gen = CaseGenerator(default_gemini_client(api_key=os.environ["GEMINI_API_KEY"]), structured=True)
cases = gen.generate(clause, n=5)
```

- Lazy imports `google-genai` and `pydantic` (optional deps for this code path).
- Default `structured=True` -- Gemini's `response_schema` enforces a Pydantic `list[_GeneratedCaseSchema]` shape so the response is GUARANTEED valid. PR #23 demonstrated this is faster and produces zero JSON parse failures vs the 2 protocols out of 77 that text-mode left failing.
- `concurrent.futures` per-call timeout (default 60s) mirrors `run_pilot.gemini_client` -- the SDK can hang in `SSL_read` indefinitely under transient network conditions; we observed a 23-min hang during the original scale-up before adding this protection.
- `structured=False` returns a text-mode client for callers who explicitly want raw text + tolerant parsing.

## Test plan

- [x] 12 existing text-mode tests still pass (regression guard).
- [x] 4 new structured-mode tests:
  - structured=True with valid list passes through and produces cases
  - structured=True with non-list return raises clear TypeError
  - structured=True applies the same prompt/truth validation as text mode
  - structured=False default is unchanged
- [x] Full suite: 355 pass (was 351 + 4 new). 3 pre-existing deselected.
- [ ] Reviewer to confirm `default_gemini_client` is the right home for the structured-output factory (vs `default_gemini_structured_client` to mirror the Anthropic naming exactly).

## What this does NOT do

- Does NOT remove `recover_failed.py`. It stays as the reference run that proved the fix works on the live MedLocal corpus.
- Does NOT touch `default_anthropic_client`. The Anthropic strict-JSON path (via `tool_use` block with a JSON schema) is filed as a separate follow-up; not blocking.
- Does NOT switch the existing pilot runs to structured mode automatically. Future runs that want it should pass `CaseGenerator(default_gemini_client(...), structured=True)` explicitly.