### PR TITLE
feat(case-generator): default_anthropic_client structured-output mode

### DIFF
--- a/merken/training/case_generator.py
+++ b/merken/training/case_generator.py
@@ -299,10 +299,17 @@ def default_anthropic_client(
                 system=system,
                 messages=[{"role": "user", "content": user}],
             )
-            if not resp.content:
-                return ""
-            block = resp.content[0]
-            return getattr(block, "text", "") or ""
+            # Iterate to find the first text-bearing block. Newer
+            # models can prepend a `thought` (extended thinking) or
+            # other non-text block; reading content[0] blindly drops
+            # the actual answer. Per PR #26 review (Gemini).
+            for block in resp.content or []:
+                if getattr(block, "type", None) != "text":
+                    continue
+                text = getattr(block, "text", "") or ""
+                if text:
+                    return text
+            return ""
         return _fn_text
 
     def _fn_struct(system: str, user: str) -> list[dict]:
@@ -317,8 +324,22 @@ def default_anthropic_client(
         for block in resp.content or []:
             if getattr(block, "type", None) != "tool_use":
                 continue
-            payload = getattr(block, "input", None) or {}
-            cases = payload.get("cases", [])
+            # Validate the tool input shape rather than silently
+            # returning []. The runtime SHOULD enforce the schema,
+            # but a SDK regression or upstream change shouldn't
+            # corrupt the dataset. Per PR #26 review (Copilot).
+            payload = getattr(block, "input", None)
+            if not isinstance(payload, dict):
+                raise ValueError(
+                    f"Anthropic tool_use returned non-dict input: "
+                    f"{type(payload).__name__}"
+                )
+            cases = payload.get("cases")
+            if not isinstance(cases, list):
+                raise ValueError(
+                    f"Anthropic tool_use payload missing/invalid "
+                    f"`cases` field: got {type(cases).__name__}"
+                )
             return [
                 {"prompt": c["prompt"], "truth": c["truth"]}
                 for c in cases

--- a/merken/training/case_generator.py
+++ b/merken/training/case_generator.py
@@ -29,6 +29,14 @@ structured-mode client so the parser step is skipped. The recovery
 script in ``experiments/midloop_pilot/recover_failed.py`` (PR #23)
 demonstrated structured-mode is faster + zero JSON parse failures
 on the live MedLocal corpus.
+
+Both backends support structured mode:
+
+- ``default_gemini_client(structured=True)``: SDK enforces a
+  Pydantic schema on the wire via ``response_schema``.
+- ``default_anthropic_client(structured=True)``: forces the model
+  to call a single ``emit_clinical_cases`` tool whose input schema
+  is validated by the Anthropic runtime before the response returns.
 """
 
 from __future__ import annotations
@@ -209,12 +217,53 @@ class CaseGenerator:
         return cases
 
 
+_ANTHROPIC_TOOL_NAME = "emit_clinical_cases"
+_ANTHROPIC_CASES_TOOL = {
+    "name": _ANTHROPIC_TOOL_NAME,
+    "description": (
+        "Emit the generated clinical scenarios. Each item must derive "
+        "STRICTLY from the supplied protocol clause."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "cases": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "description": (
+                                "Realistic clinician question or "
+                                "situation, 1-3 sentences."
+                            ),
+                        },
+                        "truth": {
+                            "type": "string",
+                            "description": (
+                                "Correct answer derived strictly from "
+                                "the protocol clause."
+                            ),
+                        },
+                    },
+                    "required": ["prompt", "truth"],
+                },
+            },
+        },
+        "required": ["cases"],
+    },
+}
+
+
 def default_anthropic_client(
     api_key: str,
     model: str = "claude-sonnet-4-6",
     max_tokens: int = 4096,
-) -> LLMClient:
-    """Build an LLMClient backed by the anthropic SDK.
+    *,
+    structured: bool = False,
+) -> "LLMClient | LLMStructuredClient":
+    """Build a client backed by the anthropic SDK.
 
     Lazy-imports anthropic so the module remains importable without
     the SDK installed (tests use fake clients). When the SDK is
@@ -224,24 +273,65 @@ def default_anthropic_client(
     use the latest Sonnet for case generation (capable enough to
     follow the strict-derivation instruction without leaking
     out-of-clause info).
+
+    ``structured=False`` (default) returns an ``LLMClient`` (text
+    mode) that returns the raw model text for ``_extract_json_array``
+    to parse.
+
+    ``structured=True`` returns an ``LLMStructuredClient`` that
+    forces the model to call a single ``emit_clinical_cases`` tool
+    with a typed ``list[{prompt, truth}]`` input. The Anthropic
+    runtime validates the tool input against the JSON schema before
+    returning, so the response is GUARANTEED to be valid JSON with
+    the right shape -- mirrors the parse-failure-free guarantee
+    that ``default_gemini_client(structured=True)`` provides via
+    ``response_schema``. Pair with ``CaseGenerator(client, structured=True)``.
     """
     import anthropic
 
     client = anthropic.Anthropic(api_key=api_key)
 
-    def _fn(system: str, user: str) -> str:
+    if not structured:
+        def _fn_text(system: str, user: str) -> str:
+            resp = client.messages.create(
+                model=model,
+                max_tokens=max_tokens,
+                system=system,
+                messages=[{"role": "user", "content": user}],
+            )
+            if not resp.content:
+                return ""
+            block = resp.content[0]
+            return getattr(block, "text", "") or ""
+        return _fn_text
+
+    def _fn_struct(system: str, user: str) -> list[dict]:
         resp = client.messages.create(
             model=model,
             max_tokens=max_tokens,
             system=system,
             messages=[{"role": "user", "content": user}],
+            tools=[_ANTHROPIC_CASES_TOOL],
+            tool_choice={"type": "tool", "name": _ANTHROPIC_TOOL_NAME},
         )
-        if not resp.content:
-            return ""
-        block = resp.content[0]
-        return getattr(block, "text", "") or ""
+        for block in resp.content or []:
+            if getattr(block, "type", None) != "tool_use":
+                continue
+            payload = getattr(block, "input", None) or {}
+            cases = payload.get("cases", [])
+            return [
+                {"prompt": c["prompt"], "truth": c["truth"]}
+                for c in cases
+                if isinstance(c, dict) and "prompt" in c and "truth" in c
+            ]
+        # Tool-forcing should make this unreachable; surface the
+        # failure clearly rather than returning [] silently.
+        raise ValueError(
+            "Anthropic structured call returned no tool_use block; "
+            "likely a transient API issue or model refusal."
+        )
 
-    return _fn
+    return _fn_struct
 
 
 def default_gemini_client(

--- a/tests/test_case_generator.py
+++ b/tests/test_case_generator.py
@@ -203,11 +203,13 @@ def test_text_mode_rejects_list_return_with_actionable_error() -> None:
 # ---------------------------------------------------- anthropic structured
 
 class _FakeBlock:
-    """Minimal stand-in for anthropic SDK content blocks."""
-    def __init__(self, *, type: str, text: str = "", input: dict | None = None):
+    """Minimal stand-in for anthropic SDK content blocks. Stores
+    `input` as-passed (not coerced) so tests can inject None to
+    simulate SDK regressions."""
+    def __init__(self, *, type: str, text: str = "", input=None):
         self.type = type
         self.text = text
-        self.input = input or {}
+        self.input = input
 
 
 class _FakeMessages:
@@ -319,3 +321,52 @@ def test_anthropic_text_mode_unchanged_by_structured_flag(monkeypatch) -> None:
     assert out == '[{"prompt":"p","truth":"t"}]'
     assert "tools" not in capture
     assert "tool_choice" not in capture
+
+
+def test_anthropic_text_mode_skips_thought_block(monkeypatch) -> None:
+    """Newer Claude models can prepend a `thought` (extended thinking)
+    block before the actual text. Reading content[0] blindly would
+    drop the answer; iterate to find the first text block instead.
+    Per PR #26 review (Gemini)."""
+    from merken.training.case_generator import default_anthropic_client
+
+    capture: dict = {}
+    response = [
+        _FakeBlock(type="thinking", text="(reasoning trace)"),
+        _FakeBlock(type="text", text='[{"prompt":"p","truth":"t"}]'),
+    ]
+    _install_fake_anthropic(monkeypatch, response, capture)
+
+    fn = default_anthropic_client(api_key="test")
+    out = fn("s", "u")
+    assert out == '[{"prompt":"p","truth":"t"}]'
+
+
+def test_anthropic_structured_raises_on_missing_cases_field(monkeypatch) -> None:
+    """If the SDK ever returns a tool_use block whose input is missing
+    or has the wrong shape (regression / upstream change), surface a
+    clear ValueError rather than silently returning []. Per PR #26
+    review (Copilot)."""
+    from merken.training.case_generator import default_anthropic_client
+
+    capture: dict = {}
+    # tool_use block whose input is None (could happen on a SDK regression).
+    response = [_FakeBlock(type="tool_use", input=None)]
+    _install_fake_anthropic(monkeypatch, response, capture)
+
+    fn = default_anthropic_client(api_key="test", structured=True)
+    with pytest.raises(ValueError, match="non-dict input"):
+        fn("s", "u")
+
+
+def test_anthropic_structured_raises_on_non_list_cases(monkeypatch) -> None:
+    """tool_use input present but `cases` field is wrong type."""
+    from merken.training.case_generator import default_anthropic_client
+
+    capture: dict = {}
+    response = [_FakeBlock(type="tool_use", input={"cases": "not a list"})]
+    _install_fake_anthropic(monkeypatch, response, capture)
+
+    fn = default_anthropic_client(api_key="test", structured=True)
+    with pytest.raises(ValueError, match="missing/invalid `cases`"):
+        fn("s", "u")

--- a/tests/test_case_generator.py
+++ b/tests/test_case_generator.py
@@ -198,3 +198,124 @@ def test_text_mode_rejects_list_return_with_actionable_error() -> None:
     gen = CaseGenerator(structured_like)  # MISSING structured=True
     with pytest.raises(TypeError, match="text-mode client must return str"):
         gen.generate(ProtocolClause("p", "..."), n=1)
+
+
+# ---------------------------------------------------- anthropic structured
+
+class _FakeBlock:
+    """Minimal stand-in for anthropic SDK content blocks."""
+    def __init__(self, *, type: str, text: str = "", input: dict | None = None):
+        self.type = type
+        self.text = text
+        self.input = input or {}
+
+
+class _FakeMessages:
+    def __init__(self, response_content, capture):
+        self._response_content = response_content
+        self._capture = capture
+
+    def create(self, **kwargs):
+        self._capture.update(kwargs)
+        class _Resp:
+            content = self._response_content
+        return _Resp()
+
+
+class _FakeAnthropicClient:
+    def __init__(self, response_content, capture):
+        self.messages = _FakeMessages(response_content, capture)
+
+
+def _install_fake_anthropic(monkeypatch, response_content, capture):
+    """Inject a fake `anthropic` module so the lazy import resolves
+    to our stub. Test-local: removed when monkeypatch tears down."""
+    import sys
+    import types as pytypes
+    fake_module = pytypes.ModuleType("anthropic")
+    fake_module.Anthropic = lambda api_key: _FakeAnthropicClient(
+        response_content, capture
+    )
+    monkeypatch.setitem(sys.modules, "anthropic", fake_module)
+
+
+def test_anthropic_structured_forces_tool_use_and_parses(monkeypatch) -> None:
+    """structured=True forces a single emit_clinical_cases tool call
+    and pulls the cases out of the tool_use block."""
+    from merken.training.case_generator import default_anthropic_client
+
+    capture: dict = {}
+    response = [
+        _FakeBlock(
+            type="tool_use",
+            input={"cases": [
+                {"prompt": "kid 5y/o cough", "truth": "amox 50mg/kg"},
+                {"prompt": "kid 3y/o fever", "truth": "amox 50mg/kg"},
+            ]},
+        ),
+    ]
+    _install_fake_anthropic(monkeypatch, response, capture)
+
+    fn = default_anthropic_client(api_key="test", structured=True)
+    out = fn("system prompt", "user prompt")
+
+    assert out == [
+        {"prompt": "kid 5y/o cough", "truth": "amox 50mg/kg"},
+        {"prompt": "kid 3y/o fever", "truth": "amox 50mg/kg"},
+    ]
+    # Verify the request actually forced the tool.
+    assert capture["tool_choice"] == {
+        "type": "tool", "name": "emit_clinical_cases",
+    }
+    assert capture["tools"][0]["name"] == "emit_clinical_cases"
+    assert capture["system"] == "system prompt"
+
+
+def test_anthropic_structured_skips_text_blocks_finds_tool_use(monkeypatch) -> None:
+    """If the response interleaves text + tool_use, the parser still
+    finds the tool_use (e.g. a future model emits commentary first)."""
+    from merken.training.case_generator import default_anthropic_client
+
+    capture: dict = {}
+    response = [
+        _FakeBlock(type="text", text="Here are the cases:"),
+        _FakeBlock(
+            type="tool_use",
+            input={"cases": [{"prompt": "p", "truth": "t"}]},
+        ),
+    ]
+    _install_fake_anthropic(monkeypatch, response, capture)
+
+    fn = default_anthropic_client(api_key="test", structured=True)
+    out = fn("s", "u")
+    assert out == [{"prompt": "p", "truth": "t"}]
+
+
+def test_anthropic_structured_raises_on_no_tool_use(monkeypatch) -> None:
+    """No tool_use block in the response surfaces a clear ValueError
+    rather than a silent empty list."""
+    from merken.training.case_generator import default_anthropic_client
+
+    capture: dict = {}
+    response = [_FakeBlock(type="text", text="I refuse")]
+    _install_fake_anthropic(monkeypatch, response, capture)
+
+    fn = default_anthropic_client(api_key="test", structured=True)
+    with pytest.raises(ValueError, match="no tool_use block"):
+        fn("s", "u")
+
+
+def test_anthropic_text_mode_unchanged_by_structured_flag(monkeypatch) -> None:
+    """structured=False preserves the existing behavior: returns the
+    first text block's text. No tools, no tool_choice in the request."""
+    from merken.training.case_generator import default_anthropic_client
+
+    capture: dict = {}
+    response = [_FakeBlock(type="text", text='[{"prompt":"p","truth":"t"}]')]
+    _install_fake_anthropic(monkeypatch, response, capture)
+
+    fn = default_anthropic_client(api_key="test")  # structured=False default
+    out = fn("s", "u")
+    assert out == '[{"prompt":"p","truth":"t"}]'
+    assert "tools" not in capture
+    assert "tool_choice" not in capture


### PR DESCRIPTION
## Summary

Mirrors the `structured=True` path added for Gemini in #25, using Anthropic's tool_use forcing as the strict-JSON mechanism.

API stays symmetric:
- `default_gemini_client(api_key, structured=True)` -- via `response_schema` (#25)
- `default_anthropic_client(api_key, structured=True)` -- via forced `tool_use` (this PR)

Both pair with `CaseGenerator(client, structured=True)`.

## Why

In the 77-protocol scale-up we lost 2 protocols to JSON parse failures from the Anthropic text-mode path. PR #25 fixed it for Gemini by switching to schema-validated structured output. This PR brings the same guarantee to the Anthropic backend so anyone using `default_anthropic_client` gets parse-failure-free generation by passing `structured=True`.

## How it works

A single tool definition (`emit_clinical_cases`) with `input_schema = {cases: array of {prompt, truth}}`. `tool_choice={type:"tool", name:"emit_clinical_cases"}` forces the call. Anthropic's runtime validates the tool input against the schema before the response returns -- so the shape is guaranteed on the wire.

Parser scans content blocks for `tool_use`, extracts `payload.cases`. Raises `ValueError` if no `tool_use` block returned (transient API issue or model refusal); never silently returns `[]`.

## Test plan

- [x] 4 new tests in `tests/test_case_generator.py` (21 total in that suite, all green):
  - `test_anthropic_structured_forces_tool_use_and_parses` -- structured mode pulls cases from tool_use
  - `test_anthropic_structured_skips_text_blocks_finds_tool_use` -- robust to interleaved text+tool_use
  - `test_anthropic_structured_raises_on_no_tool_use` -- clear error vs silent empty list
  - `test_anthropic_text_mode_unchanged_by_structured_flag` -- structured=False request has no tools/tool_choice
- [x] Full suite: 362 pass / 2 pre-existing failures on `develop` (test_embed_model_resolution.py, vstash upstream behavior, unrelated)