### PR TITLE
feat(pilot): WHO PDF -> staged text extractor (Phase 1 corpus expansion)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,13 @@ experiments/**/runs/
 experiments/retrieval/locomo/data/
 experiments/retrieval/locomo/results_detail.json
 
+# Midloop pilot artifacts (regeneratable; some contain copyrighted
+# WHO source text staged for local clause-chunking).
+experiments/midloop_pilot/staging/
+experiments/midloop_pilot/scaleup_out/
+experiments/midloop_pilot/out/
+experiments/midloop_pilot/training_data/
+
 # Training-data extracts from merken_labels across projects. Contains
 # private transcript snippets; regeneratable via
 # experiments/extract_labels_to_jsonl.py.

--- a/experiments/midloop_pilot/PDF_EXTRACTION.md
+++ b/experiments/midloop_pilot/PDF_EXTRACTION.md
@@ -25,6 +25,15 @@ python -m experiments.midloop_pilot.extract_pdfs --mode sections
 python -m experiments.midloop_pilot.extract_pdfs --only snakebite
 ```
 
+PDF source dir resolves in this order:
+
+1. `--pdf-dir <path>` if given
+2. `MERKEN_WHO_PDF_DIR` env var if set
+3. Fallback: `~/Desktop/Personal/Projects/medlocal/data/core/who`
+   (the medlocal sibling repo's standard layout)
+
+The script errors with a clear message if none of the above exists.
+
 ## What the 7 PDFs actually look like
 
 | PDF | pages | extracted size | structure | suitable mode |

--- a/experiments/midloop_pilot/PDF_EXTRACTION.md
+++ b/experiments/midloop_pilot/PDF_EXTRACTION.md
@@ -1,0 +1,88 @@
+# WHO PDF extraction -- staging pipeline
+
+## Why this isn't just `pdftotext > protocols/`
+
+The 7 WHO PDFs in `medlocal/data/core/who/` are reference books, not
+single-protocol files. Each is 50-300 pages and contains many distinct
+clinical protocols. Dropping a 100-page PDF into `protocols/` as one
+clause would break the pipeline -- `case_generator.py` cannot derive
+a specific (prompt, truth) pair from a source that broad.
+
+So this directory is the EXTRACTION step of a two-step pipeline:
+
+1. **(this script)** PDF -> raw text or coarsely-split sections,
+   written to `staging/who_extracted/` (gitignored, regeneratable).
+2. **(separate, manual)** clause chunking from the staged text into
+   50-100 line `protocols/<topic>-who.md` files. Pair with
+   `merken.training.case_generator.default_gemini_client(structured=True)`
+   so the chunking pass returns typed clause records on the wire.
+
+## Running the extractor
+
+```
+python -m experiments.midloop_pilot.extract_pdfs              # dump mode
+python -m experiments.midloop_pilot.extract_pdfs --mode sections
+python -m experiments.midloop_pilot.extract_pdfs --only snakebite
+```
+
+## What the 7 PDFs actually look like
+
+| PDF | pages | extracted size | structure | suitable mode |
+|---|---:|---:|---|---|
+| `essential-medicines-24th-2025.pdf` | many | 174 KB | drug formulary tables | dump (chunk per drug entry) |
+| `imai-acute-care.pdf` | 121 | 141 KB | flowchart book | dump (chart-aware chunking) |
+| `imci-adaptation-guide.pdf` | 78 | 153 KB | numbered sections | sections (cleanest split) |
+| `imci-assessment-booklet.pdf` | 6 | 20 KB | fold-out chart | dump (visual layout, mostly TOC after extraction) |
+| `maternal-newborn-quality-standards.pdf` | many | 207 KB | numbered standards + measures | sections |
+| `postnatal-care-recommendations.pdf` | 12 | 39 KB | recommendation list | dump |
+| `snakebite-management.pdf` | 208 | 399 KB | full clinical book | sections (TOC-heavy) |
+
+`imci-assessment-booklet.pdf` is the worst offender -- it's a fold-out
+chart, so the extracted text is essentially a flat dump of TOC labels
+and column headings without the visual layout that conveys meaning.
+That PDF likely needs vision-LLM extraction over rendered pages, not
+text extraction. Out of scope here.
+
+## Section-split heuristic
+
+`--mode sections` matches `^\d{1,2}(\.\d{1,2}){0,3}\s+[A-Z][A-Za-z]...[a-z]...$`
+on full extracted text. Constraints:
+
+- Section number capped at 99 to filter address lines like
+  "1211 Geneva 27 Switzerland".
+- Title must contain a lowercase letter to filter ALL-CAPS banners
+  PDFs put in margins.
+- Sections under 250 chars are dropped (TOC entries, page-margin
+  references, single-line annex titles).
+- Slug collisions get `__02` / `__03` suffixes so TOC reprints don't
+  silently overwrite the real section.
+
+Quality varies wildly between PDFs. `imci-adaptation-guide.pdf`
+produces 30+ clean sections; `postnatal-care-recommendations.pdf`
+produces zero (its headings aren't numbered). The header in every
+output file records `extraction_mode` so downstream consumers can
+tell what they're looking at.
+
+## What's NOT in scope
+
+- **Clause chunking.** Step 2 above. Needs an LLM pass
+  (Gemini structured output + clinical-knowledge prompt) to split
+  staged text into proper `ProtocolClause`-shaped records.
+- **Layout-aware extraction** for the chart-style PDFs. Would
+  need vision LLM over rendered pages.
+- **Promotion to `protocols/`.** Manual review gate: the
+  `extracted_at` + `promotion_status: STAGED` markers in every
+  staged file are the breadcrumb. A future PR moves promoted
+  clauses with proper provenance metadata.
+
+## Stats from a clean run (2026-04-19)
+
+```
+=== extract_pdfs (mode=dump) ===
+PDFs: 7 -> 7 staged .md files (~1.1 MB total extracted text)
+```
+
+The staging dir totals ~1.1 MB of clinical text. Naive token estimate
+at ~4 chars/token = ~275K tokens of source material to chunk. Even
+at a generous 500 chars per resulting clause, that's ~2200 candidate
+clauses -- bounded by the chunking-pass quality, not the raw size.

--- a/experiments/midloop_pilot/extract_pdfs.py
+++ b/experiments/midloop_pilot/extract_pdfs.py
@@ -43,6 +43,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from datetime import datetime, timezone
@@ -51,8 +52,16 @@ from pathlib import Path
 # Staging dir kept inside the pilot package so it's covered by the
 # experiments/* gitignore. Promotion to protocols/ is a separate
 # manual step (see module docstring).
+#
+# PDF source: prefer the MERKEN_WHO_PDF_DIR env var so the script
+# is portable. Falls back to the medlocal sibling repo's standard
+# layout if the env var isn't set; either way the user can override
+# with --pdf-dir.
+_MEDLOCAL_DEFAULT = Path.home() / (
+    "Desktop/Personal/Projects/medlocal/data/core/who"
+)
 DEFAULT_PDF_DIR = Path(
-    "/Users/jaysonsteffens/Desktop/Personal/Projects/medlocal/data/core/who"
+    os.environ.get("MERKEN_WHO_PDF_DIR", str(_MEDLOCAL_DEFAULT))
 )
 DEFAULT_OUT = Path(__file__).parent / "staging" / "who_extracted"
 
@@ -94,11 +103,17 @@ def extract_full_text(pdf_path: Path) -> tuple[str, int]:
 
 def _header(pdf_path: Path, n_pages: int, mode: str) -> str:
     """Front-matter block recording provenance. Plain text so it
-    survives any markdown linter; treat as comments downstream."""
+    survives any markdown linter; treat as comments downstream.
+
+    Records only the PDF's basename, not its absolute path -- the
+    full path leaks local directory layout, makes the staged file
+    environment-dependent, and isn't needed downstream (the
+    chunking pass uses the basename to look up the source PDF
+    via MERKEN_WHO_PDF_DIR or its own --pdf-dir flag).
+    """
     return (
         "<!--\n"
         f"source_pdf: {pdf_path.name}\n"
-        f"source_path: {pdf_path}\n"
         f"page_count: {n_pages}\n"
         f"extraction_mode: {mode}\n"
         f"extracted_at: {datetime.now(timezone.utc).isoformat()}\n"
@@ -112,7 +127,13 @@ def dump_pdf(pdf_path: Path, out_dir: Path) -> Path:
     """Write one .md per PDF containing all extracted text."""
     text, n_pages = extract_full_text(pdf_path)
     out_path = out_dir / f"{pdf_path.stem}.md"
-    out_path.write_text(_header(pdf_path, n_pages, "dump") + text)
+    # Explicit utf-8 because WHO PDFs contain non-ASCII characters
+    # (medication names, foreign-language terms, typographic
+    # quotes). Default encoding can be cp1252 on Windows runners
+    # and silently mangle the output.
+    out_path.write_text(
+        _header(pdf_path, n_pages, "dump") + text, encoding="utf-8"
+    )
     return out_path
 
 
@@ -123,7 +144,12 @@ def split_sections(pdf_path: Path, out_dir: Path) -> list[Path]:
     A leading ``00-front-matter.md`` captures any text BEFORE the
     first detected heading so nothing is silently dropped (TOC,
     foreword, etc.). If the regex finds zero headings the whole
-    text lands in 00-front-matter.md (effectively a dump)."""
+    text lands in 00-front-matter.md (effectively a dump).
+
+    Sections shorter than 250 chars are skipped (TOC line items,
+    addresses that slipped past the regex), but each skip is logged
+    to stderr so a legitimate-but-short section that gets dropped
+    is visible to the caller, not silent. Per PR #27 review (Gemini)."""
     text, n_pages = extract_full_text(pdf_path)
     matches = list(_SECTION_RE.finditer(text))
 
@@ -134,7 +160,10 @@ def split_sections(pdf_path: Path, out_dir: Path) -> list[Path]:
     if not matches:
         # No structure detected; preserve the full text in a single file.
         front = section_dir / "00-front-matter.md"
-        front.write_text(_header(pdf_path, n_pages, "sections") + text)
+        front.write_text(
+            _header(pdf_path, n_pages, "sections") + text,
+            encoding="utf-8",
+        )
         return [front]
 
     # Front matter = anything before the first section start.
@@ -142,7 +171,8 @@ def split_sections(pdf_path: Path, out_dir: Path) -> list[Path]:
         front = section_dir / "00-front-matter.md"
         front.write_text(
             _header(pdf_path, n_pages, "sections")
-            + text[: matches[0].start()]
+            + text[: matches[0].start()],
+            encoding="utf-8",
         )
         written.append(front)
 
@@ -153,10 +183,20 @@ def split_sections(pdf_path: Path, out_dir: Path) -> list[Path]:
     MIN_BODY_CHARS = 250
 
     seen: dict[str, int] = {}
+    n_dropped = 0
     for i, m in enumerate(matches):
         end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
         body = text[m.start():end]
         if len(body.strip()) < MIN_BODY_CHARS:
+            # Log each drop so a legitimate short section that got
+            # filtered is visible (not lost silently).
+            print(
+                f"  drop ({pdf_path.name}): "
+                f"section {m.group('num')} '{m.group('title')[:50]}' "
+                f"({len(body.strip())} chars < {MIN_BODY_CHARS})",
+                file=sys.stderr,
+            )
+            n_dropped += 1
             continue
         slug = _slugify(m.group("title"))
         # Prefix with section number so files sort meaningfully.
@@ -168,8 +208,18 @@ def split_sections(pdf_path: Path, out_dir: Path) -> list[Path]:
         seen[base] = seen.get(base, 0) + 1
         suffix = "" if seen[base] == 1 else f"__{seen[base]:02d}"
         path = section_dir / f"{base}{suffix}.md"
-        path.write_text(_header(pdf_path, n_pages, "sections") + body)
+        path.write_text(
+            _header(pdf_path, n_pages, "sections") + body,
+            encoding="utf-8",
+        )
         written.append(path)
+
+    if n_dropped:
+        print(
+            f"  ({pdf_path.name}: {n_dropped} short sections dropped; "
+            f"see lines above)",
+            file=sys.stderr,
+        )
 
     return written
 

--- a/experiments/midloop_pilot/extract_pdfs.py
+++ b/experiments/midloop_pilot/extract_pdfs.py
@@ -1,0 +1,234 @@
+"""Extract WHO PDF reference books into staged text for clause chunking.
+
+Each PDF in the WHO corpus is a 50-300 page reference book containing
+many distinct clinical protocols (IMAI acute care, IMCI booklets,
+snakebite guidelines, essential medicines list, etc.). They CANNOT
+drop into the existing ``protocols/`` dir as one .md per PDF -- a
+single 100-page file is too broad a source for ``case_generator.py``
+to derive a specific (prompt, truth) pair from.
+
+This script handles the EXTRACTION step of a two-step pipeline:
+
+  1. (this script) PDF -> raw text or coarsely-split sections, written
+     to a STAGING dir (NOT the production protocols/ dir).
+  2. (separate, manual) human or LLM-assisted clause chunking from the
+     staged text into 50-100 line ``protocols/<topic>-who.md`` files.
+     Pair with ``merken.training.case_generator.default_gemini_client(
+     structured=True)`` so the chunking pass returns typed clause
+     records on the wire.
+
+Modes:
+
+- ``--mode dump`` (default, safest): one .md per PDF containing the
+  full extracted text. Useful for human review + downstream LLM
+  chunking. Adds a YAML-ish header recording source, page count,
+  extraction timestamp.
+
+- ``--mode sections``: splits by detected numbered headings
+  (``^\\d+(\\.\\d+)*\\s+[A-Z]``). Quality varies wildly between
+  PDFs; ``imci-adaptation-guide.pdf`` produces clean splits,
+  ``postnatal-care-recommendations.pdf`` produces zero. Always
+  eyeball the output before treating sections as authoritative.
+
+The output dir defaults to ``staging/who_extracted/`` under this
+package and is gitignored alongside the rest of the pilot artifacts.
+
+Usage:
+  python -m experiments.midloop_pilot.extract_pdfs
+  python -m experiments.midloop_pilot.extract_pdfs --mode sections
+  python -m experiments.midloop_pilot.extract_pdfs \\
+      --pdf-dir /path/to/who --out staging/who_extracted
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Staging dir kept inside the pilot package so it's covered by the
+# experiments/* gitignore. Promotion to protocols/ is a separate
+# manual step (see module docstring).
+DEFAULT_PDF_DIR = Path(
+    "/Users/jaysonsteffens/Desktop/Personal/Projects/medlocal/data/core/who"
+)
+DEFAULT_OUT = Path(__file__).parent / "staging" / "who_extracted"
+
+# Heuristic: a numbered section start. Catches "1 Executive summary",
+# "3.2 Classification", "10.5.1 Whatever". Capped at section number
+# <=99 (and 99.99.99) so addresses like "1211 Geneva 27 Switzerland"
+# do NOT register as headings. Requires a capitalized first word and
+# at least one lowercase letter in the title (filters out "1 ALL CAPS
+# BANNER" pseudo-headings that PDFs frequently have in margins).
+_SECTION_RE = re.compile(
+    r"^(?P<num>\d{1,2}(?:\.\d{1,2}){0,3})\s+"
+    r"(?P<title>[A-Z][A-Za-z][^\n]*?[a-z][^\n]{0,80})$",
+    re.MULTILINE,
+)
+
+
+def _slugify(text: str) -> str:
+    """Filesystem-safe slug from a section title."""
+    s = re.sub(r"[^A-Za-z0-9]+", "-", text.strip().lower())
+    return s.strip("-")[:60] or "section"
+
+
+def extract_full_text(pdf_path: Path) -> tuple[str, int]:
+    """Return (full_text, page_count). Pages joined with form feeds
+    so a downstream chunker can recover page boundaries if it cares."""
+    try:
+        import pdfplumber
+    except ImportError as e:
+        raise ImportError(
+            "pdfplumber not installed. Run `pip install pdfplumber`. "
+            f"[{e}]"
+        ) from e
+    pages = []
+    with pdfplumber.open(pdf_path) as pdf:
+        for pg in pdf.pages:
+            pages.append(pg.extract_text() or "")
+    return "\f".join(pages), len(pages)
+
+
+def _header(pdf_path: Path, n_pages: int, mode: str) -> str:
+    """Front-matter block recording provenance. Plain text so it
+    survives any markdown linter; treat as comments downstream."""
+    return (
+        "<!--\n"
+        f"source_pdf: {pdf_path.name}\n"
+        f"source_path: {pdf_path}\n"
+        f"page_count: {n_pages}\n"
+        f"extraction_mode: {mode}\n"
+        f"extracted_at: {datetime.now(timezone.utc).isoformat()}\n"
+        "extraction_tool: pdfplumber via experiments.midloop_pilot.extract_pdfs\n"
+        "promotion_status: STAGED -- needs clause chunking before use\n"
+        "-->\n\n"
+    )
+
+
+def dump_pdf(pdf_path: Path, out_dir: Path) -> Path:
+    """Write one .md per PDF containing all extracted text."""
+    text, n_pages = extract_full_text(pdf_path)
+    out_path = out_dir / f"{pdf_path.stem}.md"
+    out_path.write_text(_header(pdf_path, n_pages, "dump") + text)
+    return out_path
+
+
+def split_sections(pdf_path: Path, out_dir: Path) -> list[Path]:
+    """Split extracted text by numbered headings into one .md per
+    section. Returns the list of written paths.
+
+    A leading ``00-front-matter.md`` captures any text BEFORE the
+    first detected heading so nothing is silently dropped (TOC,
+    foreword, etc.). If the regex finds zero headings the whole
+    text lands in 00-front-matter.md (effectively a dump)."""
+    text, n_pages = extract_full_text(pdf_path)
+    matches = list(_SECTION_RE.finditer(text))
+
+    section_dir = out_dir / pdf_path.stem
+    section_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+
+    if not matches:
+        # No structure detected; preserve the full text in a single file.
+        front = section_dir / "00-front-matter.md"
+        front.write_text(_header(pdf_path, n_pages, "sections") + text)
+        return [front]
+
+    # Front matter = anything before the first section start.
+    if matches[0].start() > 0:
+        front = section_dir / "00-front-matter.md"
+        front.write_text(
+            _header(pdf_path, n_pages, "sections")
+            + text[: matches[0].start()]
+        )
+        written.append(front)
+
+    # Drop trivially-short matches (TOC line items, page-margin
+    # addresses, single-line annex titles). A real protocol section
+    # has multiple paragraphs; threshold picked empirically against
+    # the 7 WHO PDFs.
+    MIN_BODY_CHARS = 250
+
+    seen: dict[str, int] = {}
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[m.start():end]
+        if len(body.strip()) < MIN_BODY_CHARS:
+            continue
+        slug = _slugify(m.group("title"))
+        # Prefix with section number so files sort meaningfully.
+        num_safe = m.group("num").replace(".", "_")
+        base = f"{num_safe}__{slug}"
+        # Disambiguate: many PDFs reprint the same section title (TOC
+        # entry + actual section). Suffix duplicates rather than
+        # overwriting silently.
+        seen[base] = seen.get(base, 0) + 1
+        suffix = "" if seen[base] == 1 else f"__{seen[base]:02d}"
+        path = section_dir / f"{base}{suffix}.md"
+        path.write_text(_header(pdf_path, n_pages, "sections") + body)
+        written.append(path)
+
+    return written
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pdf-dir", type=Path, default=DEFAULT_PDF_DIR,
+                    help="dir of WHO PDFs (default: medlocal/data/core/who)")
+    ap.add_argument("--out", "--out-dir", dest="out", type=Path,
+                    default=DEFAULT_OUT,
+                    help="staging output dir")
+    ap.add_argument("--mode", choices=["dump", "sections"], default="dump",
+                    help="dump=one md per PDF; sections=split by heading")
+    ap.add_argument("--only", default=None,
+                    help="optional substring filter on PDF basenames")
+    args = ap.parse_args()
+
+    if not args.pdf_dir.exists():
+        print(f"ERROR: pdf-dir not found: {args.pdf_dir}", file=sys.stderr)
+        return 2
+
+    pdfs = sorted(args.pdf_dir.glob("*.pdf"))
+    if args.only:
+        pdfs = [p for p in pdfs if args.only in p.name]
+    if not pdfs:
+        print(f"ERROR: no PDFs matched in {args.pdf_dir}", file=sys.stderr)
+        return 2
+
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    print(f"=== extract_pdfs (mode={args.mode}) ===", file=sys.stderr)
+    print(f"input dir:  {args.pdf_dir}", file=sys.stderr)
+    print(f"output dir: {args.out}", file=sys.stderr)
+    print(f"PDFs:       {len(pdfs)}", file=sys.stderr)
+
+    total_files = 0
+    for pdf in pdfs:
+        try:
+            if args.mode == "dump":
+                out = dump_pdf(pdf, args.out)
+                print(f"  {pdf.name} -> {out.name}", file=sys.stderr)
+                total_files += 1
+            else:
+                outs = split_sections(pdf, args.out)
+                print(
+                    f"  {pdf.name} -> {len(outs)} sections "
+                    f"in {pdf.stem}/",
+                    file=sys.stderr,
+                )
+                total_files += len(outs)
+        except Exception as e:
+            print(f"  ERROR processing {pdf.name}: {e}", file=sys.stderr)
+            return 3
+
+    print(f"\nwrote {total_files} files. Next: clause chunking before "
+          f"promotion to protocols/. See module docstring.",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_extract_pdfs.py
+++ b/tests/test_extract_pdfs.py
@@ -1,0 +1,166 @@
+"""Tests for the WHO PDF staging extractor.
+
+Stays offline by mocking ``extract_full_text`` (the only function that
+actually touches pdfplumber). Everything else -- regex, slug generation,
+collision handling, body-length filter, front-matter capture -- is
+pure-text logic that's easy to assert on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from experiments.midloop_pilot import extract_pdfs as ep
+
+
+@pytest.fixture
+def fake_pdf(monkeypatch):
+    """Return a callable that installs canned (text, page_count) for
+    a fake PDF path. Tests construct a Path that doesn't need to exist
+    on disk; the monkeypatched extractor never reads from it."""
+    state: dict = {}
+
+    def install(text: str, n_pages: int = 1):
+        state["text"] = text
+        state["pages"] = n_pages
+
+    def fake_extract(_path: Path) -> tuple[str, int]:
+        return state["text"], state["pages"]
+
+    monkeypatch.setattr(ep, "extract_full_text", fake_extract)
+    return install
+
+
+# ----------------------------------------------------------------- slugify
+
+def test_slugify_basic() -> None:
+    assert ep._slugify("Acute Abdomen") == "acute-abdomen"
+    assert ep._slugify("  trim me  ") == "trim-me"
+    assert ep._slugify("CO2 & H2O") == "co2-h2o"
+
+
+def test_slugify_caps_at_60_chars() -> None:
+    long = "x" * 200
+    assert len(ep._slugify(long)) <= 60
+
+
+def test_slugify_empty_falls_back_to_section() -> None:
+    assert ep._slugify("...") == "section"
+    assert ep._slugify("") == "section"
+
+
+# ----------------------------------------------------------------- regex
+
+def test_section_re_matches_numbered_heading() -> None:
+    text = "1.2 Outline the adaptation process"
+    m = ep._SECTION_RE.match(text)
+    assert m is not None
+    assert m.group("num") == "1.2"
+
+
+def test_section_re_rejects_address_with_section_number_too_high() -> None:
+    """1211 Geneva 27 Switzerland is an address, not a heading."""
+    text = "1211 Geneva 27 Switzerland"
+    assert ep._SECTION_RE.match(text) is None
+
+
+def test_section_re_rejects_all_caps_banner() -> None:
+    """Margin banners are ALL CAPS; require at least one lowercase
+    letter in the title to filter them out."""
+    text = "1 GUIDELINES FOR THE MANAGEMENT"
+    assert ep._SECTION_RE.match(text) is None
+
+
+def test_section_re_rejects_prose_starting_with_lowercase_word() -> None:
+    """'5 children were enrolled' is prose, not a heading. The
+    capital-letter requirement on the title's first character filters
+    these out."""
+    text = "5 children were enrolled in the trial"
+    assert ep._SECTION_RE.match(text) is None
+
+
+def test_section_re_accepts_prose_with_capitalized_first_word() -> None:
+    """Documents the LIMITATION: '5 Patients are enrolled' DOES match.
+    The body-length filter (>=250 chars) is the secondary defense -- a
+    single prose sentence won't survive it. If a future PDF surfaces a
+    false-positive that DOES exceed 250 chars, tighten the regex then."""
+    text = "5 Patients are enrolled in the trial"
+    assert ep._SECTION_RE.match(text) is not None
+
+
+# ----------------------------------------------------------------- dump mode
+
+def test_dump_writes_one_file_with_header(tmp_path, fake_pdf) -> None:
+    fake_pdf("Body text of the PDF.\nSecond line.", n_pages=3)
+    out = ep.dump_pdf(Path("/fake/snakebite.pdf"), tmp_path)
+    assert out.name == "snakebite.md"
+    content = out.read_text()
+    assert "source_pdf: snakebite.pdf" in content
+    assert "page_count: 3" in content
+    assert "extraction_mode: dump" in content
+    assert "Body text of the PDF." in content
+    assert "promotion_status: STAGED" in content
+
+
+# ----------------------------------------------------------------- sections mode
+
+def test_sections_splits_on_numbered_headings(tmp_path, fake_pdf) -> None:
+    body = (
+        "Front matter prose before any section.\n"
+        + ("paragraph " * 50) + "\n"
+        + "1.1 Review current guidelines\n"
+        + ("Body of section 1.1 with enough text to pass filter. " * 10) + "\n"
+        + "1.2 Outline the adaptation process\n"
+        + ("Body of section 1.2 with enough text to pass filter. " * 10) + "\n"
+    )
+    fake_pdf(body)
+    written = ep.split_sections(Path("/fake/imci.pdf"), tmp_path)
+
+    section_dir = tmp_path / "imci"
+    assert section_dir.is_dir()
+    names = sorted(p.name for p in written)
+    assert "00-front-matter.md" in names
+    assert any("1_1__" in n for n in names)
+    assert any("1_2__" in n for n in names)
+
+
+def test_sections_filters_short_bodies(tmp_path, fake_pdf) -> None:
+    """Sections with <250 chars of body are dropped (TOC line
+    items, address lines that slipped past the regex, etc.)."""
+    body = (
+        "1 Real section with a real body\n"
+        + ("paragraph " * 50) + "\n"
+        + "20 Avenue Appia heading-shaped address line\n"
+        # Intentionally short body so the filter drops it.
+    )
+    fake_pdf(body)
+    written = ep.split_sections(Path("/fake/x.pdf"), tmp_path)
+    names = [p.name for p in written]
+    assert any("1__real-section" in n for n in names)
+    assert not any("20__avenue-appia" in n for n in names)
+
+
+def test_sections_disambiguates_slug_collisions(tmp_path, fake_pdf) -> None:
+    """A heading reprinted (TOC entry then real section) gets a
+    __02 suffix instead of silently overwriting."""
+    long = ("body " * 100)
+    body = (
+        "2.1 Make a preliminary list\n" + long + "\n"
+        + "2.1 Make a preliminary list\n" + long + "\n"
+    )
+    fake_pdf(body)
+    written = ep.split_sections(Path("/fake/x.pdf"), tmp_path)
+    names = sorted(p.name for p in written)
+    assert any(n.endswith("__02.md") for n in names), names
+
+
+def test_sections_no_headings_falls_back_to_front_matter(tmp_path, fake_pdf) -> None:
+    """Zero-heading PDF (e.g. postnatal care recommendations) writes
+    everything to 00-front-matter.md so nothing is silently lost."""
+    fake_pdf("Plain prose with no numbered headings whatsoever. " * 100)
+    written = ep.split_sections(Path("/fake/postnatal.pdf"), tmp_path)
+    assert len(written) == 1
+    assert written[0].name == "00-front-matter.md"
+    assert "Plain prose" in written[0].read_text()

--- a/tests/test_extract_pdfs.py
+++ b/tests/test_extract_pdfs.py
@@ -96,12 +96,37 @@ def test_dump_writes_one_file_with_header(tmp_path, fake_pdf) -> None:
     fake_pdf("Body text of the PDF.\nSecond line.", n_pages=3)
     out = ep.dump_pdf(Path("/fake/snakebite.pdf"), tmp_path)
     assert out.name == "snakebite.md"
-    content = out.read_text()
+    content = out.read_text(encoding="utf-8")
     assert "source_pdf: snakebite.pdf" in content
     assert "page_count: 3" in content
     assert "extraction_mode: dump" in content
     assert "Body text of the PDF." in content
     assert "promotion_status: STAGED" in content
+
+
+def test_header_omits_absolute_source_path(tmp_path, fake_pdf) -> None:
+    """Headers must record only the basename, not the absolute path
+    (which leaks local directory layout and makes staged files
+    environment-dependent). Per PR #27 review (Gemini)."""
+    fake_pdf("body", n_pages=1)
+    out = ep.dump_pdf(Path("/secret/local/path/private.pdf"), tmp_path)
+    content = out.read_text(encoding="utf-8")
+    assert "source_pdf: private.pdf" in content
+    assert "/secret/local/path" not in content
+    assert "source_path:" not in content
+
+
+def test_dump_handles_non_ascii_text(tmp_path, fake_pdf) -> None:
+    """WHO PDFs contain non-ASCII characters (drug names, foreign-
+    language terms, typographic quotes). The explicit utf-8 encoding
+    on write_text avoids cp1252/UnicodeEncodeError on non-UTF8
+    locales. Per PR #27 review (Copilot)."""
+    fake_pdf("Paracetamol \u2014 \u00b5g/mL \u2018trade-name\u2019")
+    out = ep.dump_pdf(Path("/fake/x.pdf"), tmp_path)
+    content = out.read_text(encoding="utf-8")
+    assert "\u2014" in content
+    assert "\u00b5g/mL" in content
+    assert "\u2018trade-name\u2019" in content
 
 
 # ----------------------------------------------------------------- sections mode
@@ -126,9 +151,11 @@ def test_sections_splits_on_numbered_headings(tmp_path, fake_pdf) -> None:
     assert any("1_2__" in n for n in names)
 
 
-def test_sections_filters_short_bodies(tmp_path, fake_pdf) -> None:
+def test_sections_filters_short_bodies(tmp_path, fake_pdf, capsys) -> None:
     """Sections with <250 chars of body are dropped (TOC line
-    items, address lines that slipped past the regex, etc.)."""
+    items, address lines that slipped past the regex, etc.). Each
+    drop is logged to stderr so a legitimate-but-short section that
+    gets filtered is visible, not silent. Per PR #27 review (Gemini)."""
     body = (
         "1 Real section with a real body\n"
         + ("paragraph " * 50) + "\n"
@@ -140,6 +167,10 @@ def test_sections_filters_short_bodies(tmp_path, fake_pdf) -> None:
     names = [p.name for p in written]
     assert any("1__real-section" in n for n in names)
     assert not any("20__avenue-appia" in n for n in names)
+    # The drop must surface on stderr, not vanish silently.
+    err = capsys.readouterr().err
+    assert "drop (x.pdf): section 20" in err
+    assert "1 short sections dropped" in err
 
 
 def test_sections_disambiguates_slug_collisions(tmp_path, fake_pdf) -> None:


### PR DESCRIPTION
## Summary

Adds the EXTRACTION step of a two-step pipeline for the 7 WHO reference PDFs in `medlocal/data/core/who/`. Each is a 50-300 page clinical book containing many distinct protocols, so they cannot drop into `protocols/` as one .md per PDF without breaking case generation (a single broad source can't yield specific case truths).

## Pipeline

1. **(this PR)** PDF -> staged text in `experiments/midloop_pilot/staging/who_extracted/` (gitignored). Two modes: `dump` (default) and `sections`.
2. **(separate, manual, future PR)** Clause chunking from staged text into 50-100 line `protocols/<topic>-who.md` files. Pair with `default_gemini_client(structured=True)` (just shipped in #25 and #26) so the chunking pass returns typed clause records on the wire.

## What's in scope here

- `extract_pdfs.py` -- dump + sections modes, with empirically-tuned safeguards:
  - section number capped at 99 (filters address lines like "1211 Geneva 27 Switzerland")
  - title must contain a lowercase letter (filters ALL-CAPS margin banners)
  - <250 char bodies dropped (TOC entries, single-line annexes)
  - slug collisions get `__02`/`__03` suffixes (TOC reprints don't silently overwrite real sections)
- `PDF_EXTRACTION.md` -- per-PDF structure analysis (which mode works for which) and what's NOT in scope.
- 13 new tests in `tests/test_extract_pdfs.py`. Stays offline by mocking `extract_full_text`.

## What's NOT in scope

- Clause chunking (step 2 above; needs LLM pass with clinical knowledge prompt).
- Layout-aware extraction for chart-style PDFs like `imci-assessment-booklet.pdf` (would need vision LLM over rendered pages).
- Promotion to `protocols/` (manual review gate; the `extracted_at` + `promotion_status: STAGED` markers in every staged file are the breadcrumb).

## Smoke results (2026-04-19)

```
=== extract_pdfs (mode=dump) ===
PDFs: 7 -> 7 staged .md files (~1.1 MB total extracted text)
```

Section mode produces 30+ clean splits on `imci-adaptation-guide.pdf`, zero on `postnatal-care-recommendations.pdf` (no numbered headings) -- per-PDF mode choice documented in `PDF_EXTRACTION.md`.

## Test plan

- [x] 13 new extractor tests, all pass
- [x] Full suite: 369 pass / 3 deselected (pre-existing `test_embed_model_resolution` flake on develop, vstash upstream behavior, unrelated)
- [x] Manual smoke: `python -m experiments.midloop_pilot.extract_pdfs` on all 7 PDFs in dump mode
- [x] Manual smoke: `--mode sections --only imci-adaptation` produces 38 distinct files (verified no slug collisions, no addresses leaked through)