### PR TITLE
feat(midloop): Phase 3 v1 corpus expansion (77 -> 312 protocols) + capacity bump

### DIFF
--- a/experiments/midloop_pilot/RESULTS_v0.md
+++ b/experiments/midloop_pilot/RESULTS_v0.md
@@ -1,0 +1,206 @@
+# midloop v0 -- first training run (2026-04-20)
+
+First end-to-end run of the midloop boundary-tagger per
+`notes/midloop-training-plan.md`. Training infra lives in
+`nanoGPT` sibling repo (model + trainer) plus the BPE prep script at
+`nanoGPT/data/midloop_v0/prepare.py`. Engram-side scripts:
+
+- `experiments/midloop_pilot/split_train_test.py` -- 8-protocol
+  holdout, deterministic seed=42.
+
+## Setup
+
+- Dataset: `midloop_v0.jsonl` (385 cases, 77 protocols, 5 per protocol).
+- Split: 8 protocols holdout (40 test cases) / 69 protocols train
+  (345 train cases). No protocol leak, no case_id overlap.
+- Architecture: 4L/4H/128d GPT backbone + `Linear(n_embd, 1)`
+  tagging head. 0.90M params. block_size=320 (covers max observed
+  265 subword sequence length).
+- BPE tokenizer: trained on train cases only, vocab=512, specials
+  `<|pad|>`, `<|prompt|>`, `<|sep|>`, `<|end|>`.
+- Labels: boundary mode (v0.jsonl already). Subword-BPE collapses
+  per-word positive density 14.1% -> per-subword 5.21%. Boundary
+  label stays at the FIRST subword of each intervention-start word.
+- Loss: per-position BCE with pos_weight=10 (covers subword
+  neg/pos=18:1 partway), masked to response-region only.
+- Training: 800 iters, batch_size=32, AdamW lr=1e-3, warmup=100,
+  cosine decay, MPS float32.
+
+## Result
+
+- Training wall time: 51 seconds on M-series MPS.
+- Best F1 on held-out: **0.318 @ iter 300** (early in run; overfit
+  after that, F1 drifts down to 0.301 at the final iter).
+- At best-F1 checkpoint: P=0.206, R=0.692, TP=72, FP=277, FN=32,
+  TN=1955.
+
+Per-protocol recall at best-F1 iter:
+
+    0.385  depression-mhgap-who        <-- below the 50% per-protocol bar
+    0.571  gestational-diabetes-who
+    0.700  herpes-shingles-who
+    0.733  meningitis-who
+    0.750  medication-side-effects-expected-vs-alarm-who
+    0.769  chest-pain-who
+    0.818  fever-differential-tropical
+    0.833  measles-who
+
+## Graduation gate
+
+| criterion                   | target   | observed | verdict |
+|-----------------------------|---------:|---------:|:-------:|
+| F1 on held-out              | >= 0.75  | 0.318    | FAIL    |
+| min per-protocol recall     | >= 50%   | 38.5%    | FAIL    |
+| training wall <= 30min MPS  | <= 30m   | 51s      | PASS    |
+
+1 of 3. v0 does not ship as shadow yet.
+
+## Interpretation
+
+- Model IS learning: recall 0.69 at threshold 0.5 means it catches
+  most intervention starts. It also catches way too much noise
+  (277 FP vs 72 TP), so precision 0.21.
+- Training loss collapses to ~0.03 by iter 750 while val F1 drops
+  from 0.32 -> 0.30. Classic small-data overfit with early stopping
+  already saving the best ckpt.
+- Per-protocol recall spread (0.385 - 0.833) is reasonable for n=5
+  cases per test protocol; the 1 protocol below 50% is driven by
+  only 13 positive subwords total, CIs are wide.
+
+## Iteration round 1 (2026-04-20, same session) -- knobs do NOT lift F1
+
+Ran the plan's "open levers" to measure whether any cheap knob
+closes the gate gap. Takeaway: **the bottleneck is not calibration
+or head capacity; it is protocol-level transfer.**
+
+### Threshold sweep on the pw=10 best ckpt
+
+Full grid [0.10, 0.95] in steps of 0.05. F1 stays in [0.281, 0.329]
+across the entire grid. Peak F1=0.329 at thr=0.55 (+0.011 over the
+default thr=0.50). Threshold tuning is a 1-point lever, not a
+10-point lever. Artifact: `nanoGPT/out-midloop-v0/pr_sweep.json`.
+
+### pos_weight sweep [3, 5, 6, 8, 10, 15, 18]
+
+Ran 6 additional training runs (800 iters each, ~50s each, MPS).
+
+| pos_weight | best F1 | best iter | ckpt dir (under nanoGPT/) |
+|-----------:|--------:|----------:|:---------------------------|
+| 3.0        | 0.352   | 200       | out-midloop-v0-pw3.0 |
+| 5.0        | 0.346   | 600       | out-midloop-v0-pw5.0 |
+| 6.0        | 0.330   | 250       | out-midloop-v0-pw6.0 |
+| 8.0        | 0.317   | 300       | out-midloop-v0-pw8.0 |
+| 10.0       | 0.318   | 300       | out-midloop-v0 |
+| 15.0       | 0.346   | 350       | out-midloop-v0-pw15.0 |
+| 18.0       | 0.337   | 750       | out-midloop-v0-pw18.0 |
+
+Best F1 over the 6x range: 0.352. Worst: 0.317. Spread of 0.035.
+The knob moves the P-R balance (low pw -> higher P, lower R; high
+pw -> higher R, lower P) but F1 plateaus. Per-protocol recall
+worst-case stays in [0, 0.385] across all pos_weights.
+
+### MLP head (128 -> 64 -> 1, 8.3K params vs 129)
+
+Reran pw=[3, 5, 10, 15] with `--head_type=mlp`. At pw=3: F1=0.343.
+At pw>=5: the model collapses to all-negative predictions
+(F1=0.000). 60x more head capacity does NOT break the plateau.
+
+### Train vs val diagnostic (best ckpts, full threshold sweep)
+
+|   pw | best iter | TRAIN F1 | VAL F1 | gap       |
+|-----:|----------:|---------:|-------:|----------:|
+|   3  |      200  |  0.480   |  0.352 | **+0.128**|
+|  10  |      300  |  0.582   |  0.329 | **+0.253**|
+|  15  |      350  |  0.624   |  0.348 | **+0.276**|
+
+TRAIN F1 climbs with pos_weight (the model CAN learn the training
+protocols); VAL F1 plateau is tight (0.33-0.35). **Cross-protocol
+generalization is the wall, not optimization.**
+
+### Verdict
+
+Per Silt's rule (look at the distribution before proposing a new
+algorithm), the distribution says:
+
+1. The model learns in-distribution (TRAIN F1 up to 0.62).
+2. Held-out protocols stay at F1 ~ 0.35 regardless of knob choice.
+3. The 7-point F1 spread across pos_weight [3..18] is smaller than
+   the 12-25 point train-val gap.
+
+Interpretation: with 69 train protocols * 5 cases, the model
+memorises per-protocol phrasings and has little cross-protocol
+signal. The plan anticipated this ("similar phrasings across cases
+of the same protocol -- protocol-id dependency is real") but did
+not anticipate the gap would be this wide at v0. **Closing the
+gate on this data alone is unlikely.**
+
+## What IS the right next move
+
+1. **Expand the corpus.** 7 WHO PDFs are already staged via PR #27
+   in `staging/who_extracted/` (~1.1MB). Phase 1 pipeline is
+   idempotent; re-run on 100-200 protocols instead of 77. More
+   protocols, not more cases per protocol, is the generalization
+   lever.
+
+   **Corpus expansion started 2026-04-20:**
+   - Filtered `epfl-llm/guidelines` by `source in {who, icrc}` and
+     saved 272 full documents (28MB text) at
+     `staging/hf_guidelines/who_icrc.jsonl`.
+   - `chunk_hf_guidelines.py` produces 16619 chunks with default
+     filters; density >= 5.0 narrows to **5515 clinically-dense
+     chunks** (WHO 4041, ICRC 1474) at
+     `staging/hf_guidelines/chunks/{who,icrc}/*.md`.
+   - 7 WHO PDFs re-extracted to `staging/who_extracted/` (were
+     missing since the gitignored dir got cleaned).
+   - **Validation run 2026-04-20**: sampled 10 chunks (7 WHO +
+     3 ICRC, density >=29) through `default_gemini_client(structured=True)`.
+     **100% pass rate** (50/50 cases), 95s wall time, ~$0.05 USD.
+     Spot-check on MgSO4, PLAN C, EFV prophylaxis: truths derived
+     strictly from chunk text (no hallucination). Pipeline scales.
+     Artifacts: `staging/hf_guidelines/sample_cases.jsonl` +
+     `sample_report.md`.
+
+   - **Next**: pick 300-500 chunks (diverse by doc_id, balance
+     source proportions) and regenerate Phase 1 at scale. Wall
+     time estimate: ~50 min. Cost estimate: ~$1.50 USD.
+2. **Lower the v0 gate for shadow.** F1 >= 0.75 is out of reach on
+   this data. Drop to F1 >= 0.50 as a shadow-only bar (action
+   clamped to WHISPER per spec), accumulate real (decision, outcome)
+   pairs through the existing midloop primitive, and re-train v1 on
+   the accumulated pool. Mirror of how v7 graduated the write-filter.
+3. **Audit the label distribution.** 5% per-subword positive rate
+   is much lower than the 14% per-word estimate. If the boundary
+   mode labels are correct, the BPE effect is natural. If many
+   boundary spans got lost in the word->subword mapping, re-inspect
+   the prep logic.
+
+## Open levers (plan's "1-3 weeks" iteration) -- DEFERRED
+
+From notes/midloop-training-plan.md -- round 1 above explored
+pos_weight and MLP head. Remaining levers are unlikely to close
+the 40-point gap to F1=0.75 on the current data, but might inform
+a v0.1 run:
+
+1. **pos_weight sweep [3, 5, 6, 8, 10]** against held-out F1.
+   Current 10 pushes recall at precision's expense; 6 is the plan's
+   original estimate (word-level) and may be a better midpoint.
+2. **Threshold calibration on a held-out VAL slice** (10% of train,
+   not test). Current hard 0.5 is untuned.
+3. **Early stopping**: best was iter 300 but we ran 800. Cap iters
+   or add patience logic.
+4. **Wider tagging head**: Linear(128,1) is 129 params. Try an MLP
+   (128 -> 64 -> 1, 8257 params) in case capacity is the bottleneck
+   -- cheap test before changing backbone.
+5. **Regularization**: dropout=0.1 is light. Try 0.2 - 0.3.
+
+Anti-patterns per CLAUDE.md + v7 saga:
+- Do NOT bump backbone above 4L/4H/128d before exhausting the
+  above levers.
+- Do NOT optimize threshold on TEST.
+
+## Artifacts
+
+- `nanoGPT/out-midloop-v0/ckpt.pt` -- best-F1 checkpoint (iter 300).
+- `nanoGPT/out-midloop-v0/final_metrics.json` -- final-iter metrics.
+- `nanoGPT/data/midloop_v0/{train,val}.npz, tokenizer.json, meta.pkl`.
+- `experiments/midloop_pilot/training_data/midloop_v0_{train,test}.jsonl`.

--- a/experiments/midloop_pilot/RESULTS_v1.md
+++ b/experiments/midloop_pilot/RESULTS_v1.md
@@ -1,0 +1,330 @@
+# midloop v1 -- corpus-expansion retrain (2026-04-20)
+
+First retrain with the expanded corpus (HF epfl-llm/guidelines
+WHO+ICRC subset, chunked by clinical-action density). Tests the
+hypothesis from RESULTS_v0 round 1: "cross-protocol transfer is the
+wall, more protocols is the fix."
+
+## Setup
+
+- **v1 dataset = v0 medlocal (77 protocols) + v1_hf (235 HF chunks)
+  = 312 protocols, 1560 cases.** Merged by `merge_datasets.py`.
+- Phase 1 re-run on the HF chunks used `default_gemini_client(structured=True)`:
+  - 235 chunks -> 1175 cases in 2101s (8.9s/proto, 0 Gemini failures).
+  - 1175 responses via lmstudio gemma-4-e4b-it-mlx in 1093s (0.93s/resp, 0 failures).
+  - Aligner: 3601 divergent regions -> 3577 interventions (99.3% retention at cos=0.85).
+  - format_for_training boundary mode: 1175 rows written.
+- Split: 32 protocols held out (10% of 312) = **160 test / 1400 train cases**.
+  Protocol-level group split, seed=42. No protocol/case leak.
+- nanoGPT data prep (data/midloop_v1/): **vocab=512 BPE**, max seq=438,
+  subword positive density 4.70% train / 4.49% val
+  (neg/pos ~20:1, matches v0).
+- Trainer: same as v0 (4L/4H/128d, 0.90M params, block_size=320,
+  pos_weight=10, 800 iters, batch=32, AdamW lr=1e-3, cosine schedule,
+  MPS float32, linear tagging head).
+
+## Result -- hypothesis CONFIRMED on gap, gate NOT met
+
+Training wall time: **55 seconds** (same as v0 -- model size unchanged).
+
+### Headline F1 with threshold sweep, best ckpt (iter 700)
+
+|                  | TRAIN F1 | VAL F1 | gap    |
+|------------------|---------:|-------:|-------:|
+| v0 best (pw=15)  | 0.624    | 0.348  | +0.276 |
+| v1 best (pw=10)  | 0.426    | **0.349** | **+0.077** |
+
+**Gap closed from +0.276 to +0.077.** Model no longer memorizes
+training protocols. This confirms round-1's cross-protocol hypothesis.
+
+VAL F1 plateau stayed at ~0.35 (v0 and v1 indistinguishable at
+threshold-tuned best). The bottleneck is no longer memorisation;
+it is now **global capacity + label quality** with 312 protocols of
+moderate per-protocol signal.
+
+### Graduation gate criteria
+
+| criterion                   | target   | v0       | v1     | verdict |
+|-----------------------------|---------:|---------:|-------:|:-------:|
+| F1 on held-out              | >= 0.75  | 0.349    | 0.349  | FAIL    |
+| min per-protocol recall     | >= 50%   | 38.5%    | 9.1%   | FAIL    |
+| training wall <= 30min MPS  | <= 30m   | 51s      | 55s    | PASS    |
+
+The min-per-protocol-recall dropped because the val set now has
+32 protocols (vs 8 in v0). With 5 cases per protocol (median ~14
+positive subwords), a single difficult protocol hits very low recall
+due to variance, not necessarily model failure. **The right read:
+v1 is better at the global-F1 level; the gate's per-protocol bar
+needs re-specification for >32 test protocols.**
+
+### Training loop evolution (val @ thr=0.5)
+
+| iter | F1     | P     | R     | worst_proto_R |
+|-----:|-------:|------:|------:|--------------:|
+|  100 | 0.242  | 0.139 | 0.946 | **0.818**     |
+|  200 | 0.247  | 0.143 | 0.918 | 0.636         |
+|  300 | 0.277  | 0.167 | 0.809 | 0.636         |
+|  500 | 0.279  | 0.170 | 0.774 | 0.545         |
+|  700 | **0.283** | 0.177 | 0.710 | 0.545     |
+
+**Worst-protocol recall peaks at 0.818 early (iter 100)** and
+degrades as the model specializes. This is a DIFFERENT failure mode
+than v0 (where worst stayed flat around 0.38-0.55 throughout).
+
+**Interesting lever**: early stopping at iter 100 satisfies the
+"no protocol < 50% recall" gate criterion but not the F1 >= 0.75
+gate. Shadow-only deployment with a recall-heavy threshold might be
+viable from the iter-100 ckpt.
+
+### Threshold sweep at best ckpt (iter 700) -- VAL
+
+| thr  | P     | R     | F1    | TP  | FP   | FN  |
+|-----:|------:|------:|------:|----:|-----:|----:|
+| 0.30 | 0.146 | 0.871 | 0.250 | 405 | 2364 |  60 |
+| 0.50 | 0.177 | 0.710 | 0.283 | 330 | 1534 | 135 |
+| 0.60 | 0.216 | 0.510 | 0.303 | 237 |  860 | 228 |
+| 0.65 | 0.250 | 0.409 | 0.310 | 190 |  571 | 275 |
+| 0.70 | 0.325 | 0.368 | 0.345 | 171 |  355 | 294 |
+| **0.80** | 0.437 | 0.290 | **0.349** | 135 | 174 | 330 |
+
+Precision-recall curve is monotone (no plateau inflections), and
+thr=0.80 maxes F1. v1 has a much more informative P-R curve than v0
+(which stayed essentially flat across the grid).
+
+## Interpretation
+
+1. **Corpus expansion WORKED at the generalization axis.** The
+   train-val gap collapsed (+0.276 -> +0.077), proving the round-1
+   diagnosis was correct: v0 was memorising 77 medlocal protocols.
+2. **VAL F1 did not improve.** Still ~0.35. This tells us the
+   remaining gap is not "cross-protocol transfer" but "task
+   signal-to-noise with 4L/4H/128d capacity at 4.7% positive density
+   on boundary labels". Possible causes:
+   - Label noise: the semantic-drop filter dropped only 24/3601
+     divergences (0.7%), keeping many false boundaries. A tighter
+     threshold might help.
+   - Insufficient capacity for 312-protocol pattern diversity.
+   - Boundary labels are inherently noisy: the "start" position of
+     an intervention span is one subword among dozens.
+3. **The gate's "no protocol recall < 50%" criterion needs to be
+   re-specified** for 32+ test protocols. The 8-protocol v0 gate
+   was easier to satisfy by chance; 32 protocols exposes real
+   distributional variance in the underlying label density.
+
+## Round 5 -- extended training (NEGATIVE, 2026-04-20)
+
+Hypothesis: v1-6L best ckpt was at iter 1050 of 1200 with training
+loss still dropping and cosine schedule ending. Maybe more iters
+would continue lifting VAL F1.
+
+### Method
+
+Re-ran v1-6L with max_iters=2000 and lr_decay_iters=2000 (stretched
+cosine schedule), everything else identical.
+
+### Result
+
+| variant              | best iter | TRAIN F1 | VAL F1 | gap    |
+|----------------------|----------:|---------:|-------:|-------:|
+| v1-6L @ 1200 iters   |      1050 |    0.733 | **0.442** | +0.291 |
+| v1-6L-long @ 2000    |      1600 |    0.965 | 0.440  | +0.525 |
+
+TRAIN F1 jumped 0.733 -> 0.965 (nearly perfect memorisation). VAL
+F1 essentially unchanged: -0.002. The extra iters just memorize
+the training set further.
+
+### Conclusion -- real plateau
+
+v1-6L's VAL F1 = 0.442 is the real ceiling for this architecture
+at this data size. More iters trade no-gain against exploding gap.
+The remaining gap to F1>=0.50 shadow bar (0.058) can ONLY come
+from:
+
+- More data (more protocols, not more iters)
+- Different labels (smaller label-noise ceiling)
+- Architectural change that attacks label-noise directly
+
+No more iter increases.
+
+## Round 4 -- tighter aligner (NEGATIVE, 2026-04-20)
+
+Hypothesis: remaining 0.06 gap to F1>=0.50 shadow bar is driven
+by label noise in divergence regions that the semantic-drop
+filter lets through at cosine=0.85.
+
+### Method
+
+Re-ran `step_align` on existing responses.jsonl with two tighter
+thresholds while holding everything else constant:
+
+| cosine threshold | divergent regions | interventions kept | retention |
+|-----------------:|------------------:|-------------------:|----------:|
+|             0.85 |              3601 |               3577 |    99.3%  |
+|             0.90 |              3601 |               3592 |    99.7%  |
+|             0.95 |              3601 |               3599 |    99.9%  |
+
+Going from 0.85 to 0.95 drops 22 MORE interventions out of 3601 --
+0.6% change. The filter is already barely active at 0.85.
+
+### Conclusion -- not the bottleneck
+
+The ruido isn't in "falsely-flagged divergences with high cosine";
+real divergences between the small model's output and the truth
+have cosine much lower than 0.85 already, so they all pass at any
+stringent threshold.
+
+The boundary-label noise is **intrinsic to the shape**: within a
+divergence region, labelling the FIRST subword as the boundary is
+noisy because the true boundary may be between words, inside a
+phrase, or tokenized ambiguously by BPE.
+
+Not retraining at higher threshold -- no label distribution change
+worth measuring. `aligned.jsonl` restored to cos=0.85 state.
+
+## Round 3 -- capacity bump sweep (2026-04-20, same session)
+
+With the train-val gap closed in v1 baseline, the CLAUDE.md anti-
+pattern "do not bump backbone above 4L/4H/128d before measuring"
+was finally satisfied. We measured, then bumped.
+
+### Runs
+
+All on the same v1 dataset (1400 train / 160 val, 312/32 protocols).
+Threshold sweep [0.30, 0.95] in steps of 0.025.
+
+| variant               | params | dropout | wd  | iters | TRAIN F1 | VAL F1 | gap    | wall  |
+|-----------------------|-------:|--------:|----:|------:|---------:|-------:|-------:|------:|
+| v1 baseline 4L/4H/128d| 0.90M  | 0.10    | 0.1 |   800 | 0.431    | 0.359  | +0.072 |  55s  |
+| **v1-6L 6L/6H/192d**  | **2.83M**| 0.15 | 0.1 |  1200 | 0.733    | **0.442** | +0.291 | 203s  |
+| v1-6L-reg (heavy reg) | 2.83M  | 0.25    | 0.2 |  1200 | 0.517    | 0.375  | +0.142 | 184s  |
+| v1-8L 8L/8H/256d      | 6.53M  | 0.15    | 0.1 |  1500 | 0.917    | 0.453  | +0.464 | 436s  |
+
+### Verdicts
+
+- **v1-6L is the new best.** +0.08 VAL F1 over baseline (0.359 -> 0.442).
+  Gap opened (+0.29) but that is expected with capacity -- the
+  evidence it's capacity-signal not memorisation-noise is the VAL
+  F1 jump in parallel.
+- **v1-6L-reg: over-regularized.** dropout 0.25 + wd 0.2 collapsed
+  VAL F1 from 0.442 -> 0.375 while closing gap from +0.29 to +0.14.
+  Worse on both axes (VAL and TRAIN). Sweet spot is mild reg.
+- **v1-8L: capacity saturated.** 2.3x more params (6.5M), only +0.011
+  VAL F1 (0.442 -> 0.453), gap exploded to +0.46. Further capacity
+  mainly memorizes training protocols; returns diminish fast.
+
+### Pareto frontier after round 3
+
+VAL F1 best: 0.453 (v1-8L) but marginal over 6L. **v1-6L (~3M, F1=0.442)
+is the recommended deployment candidate.** Below proposed shadow gate
+(F1>=0.50) by only 0.058.
+
+### Graduation gate re-eval
+
+| criterion                  | target   | v1-6L  | verdict |
+|----------------------------|---------:|-------:|:-------:|
+| F1 on held-out             | >= 0.75  | 0.442  | FAIL    |
+| F1 on held-out (shadow bar)| >= 0.50  | 0.442  | FAIL by 0.058 |
+| min per-protocol recall    | >= 50%   | ~0.09  | FAIL (variance with 32 protos) |
+| training wall <= 30min MPS | <= 30m   | 203s   | PASS    |
+
+Neither published gate passes yet. The F1 >= 0.50 shadow bar is
+within striking distance.
+
+## What IS next (priority order)
+
+1. **Tighten aligner threshold (free, re-run align+format only).**
+   Bump cosine 0.85 -> 0.90 on the existing responses.jsonl. If
+   label noise is part of the remaining 0.06 gap, this surfaces it
+   fast. ~5 min wall time, no API cost.
+2. **Chunk the 7 WHO PDFs (task #10, free, adds protocols).** Adds
+   ~50-100 more clinical protocols for generalisation diversity.
+   Total pipeline re-run ~1h, ~$0.50 Gemini.
+3. **Pull more fuentes in epfl-llm/guidelines (WHO+ICRC+CDC+NICE
+   = 2549 docs vs 272 WHO+ICRC).** 10x the source doc count but
+   CDC/NICE may be less CHW-focused. Gated on (1) + (2) not being
+   enough.
+4. **Lower-risk aux objectives:** multi-task with protocol-id
+   classification as auxiliary head. Adds inductive bias around
+   protocol identity without adding labels.
+5. **Consider dropping the gate to F1 >= 0.50 shadow-only** (task
+   #8). We're closer than v0 was.
+
+## What we are NOT doing next (explicit)
+
+- Further capacity bumps above 8L/8H/256d. Returns diminish;
+  memorisation grows.
+- Contrastive losses (H2/H2b/H2c anti-pattern from v7 saga).
+- Re-running v0 iteration at 77 protocols. Conclusively resolved.
+
+## Code review (2026-04-20, post-session) + fixes landed
+
+Ran code-reviewer agent against all 15 new/modified files. Key
+findings + fixes applied:
+
+### Blocker (fixed)
+
+**eval_midloop_train.py and eval_midloop_pr.py hardcoded
+`data/midloop_v0`.** When either was run against a v1 ckpt, it
+loaded v1 weights but evaluated using v0's BPE tokenizer (different
+vocab mapping, same size 512 -> no dimension error, silent garbage
+metrics). THIS WAS THE ROOT CAUSE of the reported F1=0.112 bug in
+round 2 reporting. The inline debug swept-threshold one-liner used
+`data/midloop_v1` and got 0.345 correctly.
+
+Fix: both scripts now infer the dataset from
+`ckpt['config']['dataset']` (which train_midloop.py saves since v0)
+with a regex-based fallback on the parent dir name. Validated via
+smoke test -- eval_midloop_train on v1-6L now reports VAL F1=0.442
+matching the manual sweep.
+
+### Important (fixed)
+
+1. `scaleup_phase1_hf.step_format`: `convert_case` returns None on
+   empty/untokenizable rows. Now counted and logged.
+2. `chunk_hf_guidelines.write_chunk`: `chunk['source']` becomes a
+   subdir name; added whitelist check to prevent path traversal.
+3. `sample_case_gen.select_chunks`: `sorted(glob())` for cross-
+   filesystem reproducibility; under-fill warning when the corpus
+   cannot supply the requested mix; parse_chunk errors now logged.
+4. `retrain_v1.sh`: added `set -u` and `N_PROTO >= 20` guardrail.
+5. `merge_datasets.py`: collision detection between v0/v1 protocol_ids
+   and case_ids; aborts loudly on collision (silent corruption risk).
+6. `train_midloop.py`: coerces numeric configurator overrides to
+   float so `--pos_weight=3` stops failing the assertion silently.
+7. `prepare.py` (v0 + v1): added "KEEP IN SYNC" header comment.
+
+### Minor (fixed)
+
+- Dropped unused `thr` parameter from `eval_split`.
+- Dropped the single-iteration outer loop in `evaluate()`.
+
+### Minor (documented, not fixed)
+
+- Gemini API non-determinism (structured mode) acknowledged.
+- MPS reduction non-determinism (torch upstream limitation).
+- `prepare.py v0/v1` duplication left with sync comment vs lifting
+  to `midloop_common/prepare_lib.py` -- deferred; costs 5 LoC savings
+  against ~100 LoC duplication, worth revisiting if v2 ships.
+- `requests.Session` not in a context manager (one-shot process;
+  negligible).
+
+### Not a bug
+
+`self.gpt.lm_head = nn.Identity()`: verified no memory leak, no
+gradient issue, no state_dict incompatibility. The tied
+`wte.weight` tensor stays alive referenced via `transformer.wte`.
+Linear wrapper is GC'd. Intentional aesthetic hack; adequate for
+the research phase.
+
+## Artifacts
+
+- `experiments/midloop_pilot/scaleup_out_hf/` -- full Phase 1
+  artifacts (protocols / cases / responses / aligned / training JSONL).
+- `experiments/midloop_pilot/training_data/midloop_v1.jsonl` --
+  merged 1560-case dataset.
+- `experiments/midloop_pilot/training_data/midloop_v1_{train,test}.jsonl`
+  -- 1400 / 160 split.
+- `nanoGPT/data/midloop_v1/` -- BPE tokenizer, tokenized arrays,
+  meta.pkl.
+- `nanoGPT/out-midloop-v1/ckpt.pt` -- best-F1 ckpt at iter 700.
+- `experiments/midloop_pilot/retrain_v1.sh` -- idempotent driver.

--- a/experiments/midloop_pilot/chunk_hf_guidelines.py
+++ b/experiments/midloop_pilot/chunk_hf_guidelines.py
@@ -1,0 +1,239 @@
+"""Chunk epfl-llm/guidelines filtered JSONL into per-protocol .md files.
+
+Each input row is a full guideline document (sometimes 100KB+). We
+split it on markdown-style `#` headings and write one .md per chunk
+that passes size / content sanity. Output goes to
+``staging/hf_guidelines/chunks/<source>/<doc_id>-<chunk_idx>-<slug>.md``
+so the protocol-promotion step is a simple `cp` into
+``experiments/midloop_pilot/protocols/``.
+
+Filters (conservative; too-small or too-large chunks are dropped):
+  - min_chars: drop boilerplate and navigation stubs (default 400).
+  - max_chars: drop chunks that look like whole sections rather than
+    protocols (default 8000). Larger chunks are re-split on ``##``
+    sub-headings if that produces at least 2 sub-chunks passing the
+    size filter; otherwise they are skipped.
+  - content sanity: chunk must contain at least 3 lowercase words
+    after stripping headings, rules out ALL-CAPS banners.
+
+Frontmatter per output .md:
+
+    ---
+    source: who|icrc
+    doc_id: <sha1 40 chars>
+    chunk_idx: <int>
+    heading: <first heading of the chunk>
+    url: <parent URL or 'None'>
+    chars: <len>
+    ---
+
+Usage:
+  python -m experiments.midloop_pilot.chunk_hf_guidelines
+  python -m experiments.midloop_pilot.chunk_hf_guidelines \\
+      --in staging/hf_guidelines/who_icrc.jsonl \\
+      --out staging/hf_guidelines/chunks
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+HERE = Path(__file__).parent
+DEFAULT_IN = HERE / "staging" / "hf_guidelines" / "who_icrc.jsonl"
+DEFAULT_OUT = HERE / "staging" / "hf_guidelines" / "chunks"
+
+_HEADING_RE = re.compile(r"^(#+)\s+(.+?)\s*$", re.MULTILINE)
+
+# Clinical-action lexicon. A chunk with high density of these terms is
+# likely to contain a protocol that a CHW-assistant pipeline can turn
+# into a (prompt, truth) training pair. Calibrated on a 10-doc sample
+# (see RESULTS_v0 iteration notes).
+_CLIN_VERBS = frozenset([
+    "administer", "administered", "give", "prescribe", "treat", "treatment",
+    "dose", "dosage", "mg", "ml", "injection", "oral", "intravenous",
+    "diagnose", "diagnosis", "assess", "assessment", "refer", "referral",
+    "symptoms", "signs", "fever", "pain", "bleeding", "monitor",
+    "pregnant", "infant", "child", "adult", "dehydration", "shock",
+    "antibiotic", "antimalarial", "vaccine", "immunize",
+])
+_Q_MARKERS = ("if ", "when ", "in case of", "should ", "must ", "do not")
+
+
+def clinical_density(body: str) -> float:
+    """Clinical-action terms per 1000 chars. 0 for non-clinical prose."""
+    lb = body.lower()
+    n_verbs = sum(lb.count(v) for v in _CLIN_VERBS)
+    n_qm = sum(lb.count(q) for q in _Q_MARKERS)
+    return (n_verbs + n_qm) / max(len(body) / 1000.0, 1.0)
+
+
+def _slugify(text: str, limit: int = 60) -> str:
+    s = re.sub(r"[^A-Za-z0-9]+", "-", text.strip().lower())
+    return s.strip("-")[:limit] or "section"
+
+
+def _split_on_headings(text: str, level_re: re.Pattern = None) -> list[tuple[str, str]]:
+    """Split text on top-level `#` headings. Returns [(heading, body), ...]."""
+    if level_re is None:
+        level_re = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+    chunks: list[tuple[str, str]] = []
+    matches = list(level_re.finditer(text))
+    if not matches:
+        return []
+    for i, m in enumerate(matches):
+        heading = m.group(1).strip()
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[start:end].strip()
+        chunks.append((heading, body))
+    return chunks
+
+
+def _has_content(body: str) -> bool:
+    # strip other headings, count non-heading lowercase words
+    stripped = _HEADING_RE.sub("", body)
+    words = re.findall(r"\b[a-z]{3,}\b", stripped)
+    return len(words) >= 20
+
+
+def _resplit_on_subheadings(body: str, min_chars: int, max_chars: int) -> list[tuple[str, str]]:
+    subs = _split_on_headings(body, re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE))
+    good = [
+        (h, b) for (h, b) in subs
+        if min_chars <= len(b) <= max_chars and _has_content(b)
+    ]
+    return good if len(good) >= 2 else []
+
+
+def process_doc(
+    doc: dict, min_chars: int, max_chars: int
+) -> list[dict]:
+    out: list[dict] = []
+    chunks = _split_on_headings(doc["clean_text"])
+    for idx, (heading, body) in enumerate(chunks):
+        n = len(body)
+        if n < min_chars:
+            continue
+        if not _has_content(body):
+            continue
+        if n > max_chars:
+            sub = _resplit_on_subheadings(body, min_chars, max_chars)
+            if not sub:
+                continue
+            for j, (sh, sb) in enumerate(sub):
+                out.append({
+                    "source": doc["source"],
+                    "doc_id": doc["id"],
+                    "url": doc["url"] or "None",
+                    "chunk_idx": idx * 1000 + j,
+                    "heading": f"{heading} :: {sh}",
+                    "body": sb,
+                })
+        else:
+            out.append({
+                "source": doc["source"],
+                "doc_id": doc["id"],
+                "url": doc["url"] or "None",
+                "chunk_idx": idx,
+                "heading": heading,
+                "body": body,
+            })
+    return out
+
+
+_SAFE_SOURCES = frozenset({"who", "icrc", "cdc", "nice"})
+
+
+def write_chunk(out_dir: Path, chunk: dict) -> Path:
+    src = chunk["source"]
+    # Whitelist: `source` becomes a subdir name; reject anything that could
+    # escape out_dir via path traversal (..) or absolute paths.
+    if src not in _SAFE_SOURCES:
+        raise ValueError(f"unsafe chunk source: {src!r} not in {sorted(_SAFE_SOURCES)}")
+    slug = _slugify(chunk["heading"])
+    doc_short = chunk["doc_id"][:10]
+    filename = f"{doc_short}-{chunk['chunk_idx']:04d}-{slug}.md"
+    src_dir = out_dir / src
+    src_dir.mkdir(parents=True, exist_ok=True)
+    path = src_dir / filename
+    body = chunk["body"]
+    header = (
+        f"---\n"
+        f"source: {chunk['source']}\n"
+        f"doc_id: {chunk['doc_id']}\n"
+        f"chunk_idx: {chunk['chunk_idx']}\n"
+        f"heading: {chunk['heading'][:200]}\n"
+        f"url: {chunk['url']}\n"
+        f"chars: {len(body)}\n"
+        f"density: {chunk.get('density', 0.0):.2f}\n"
+        f"---\n\n"
+        f"# {chunk['heading']}\n\n"
+    )
+    path.write_text(header + body + "\n")
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--in", dest="in_path", default=str(DEFAULT_IN))
+    parser.add_argument("--out", dest="out_path", default=str(DEFAULT_OUT))
+    parser.add_argument("--min-chars", type=int, default=400)
+    parser.add_argument("--max-chars", type=int, default=8000)
+    parser.add_argument("--limit-docs", type=int, default=0, help="0=all")
+    parser.add_argument(
+        "--min-density", type=float, default=0.0,
+        help="clinical action density cutoff; >=3 picks clinical, "
+             ">=5 picks protocol-dense (default 0=keep all)",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    in_path = Path(args.in_path)
+    out_path = Path(args.out_path)
+    rows = [json.loads(line) for line in in_path.read_text().splitlines() if line.strip()]
+    if args.limit_docs:
+        rows = rows[: args.limit_docs]
+    print(f"input docs: {len(rows)}")
+
+    all_chunks: list[dict] = []
+    per_source: dict[str, int] = {}
+    dropped_density = 0
+    for doc in rows:
+        cs = process_doc(doc, args.min_chars, args.max_chars)
+        for c in cs:
+            c["density"] = clinical_density(c["body"])
+        if args.min_density > 0:
+            before = len(cs)
+            cs = [c for c in cs if c["density"] >= args.min_density]
+            dropped_density += before - len(cs)
+        all_chunks.extend(cs)
+        per_source[doc["source"]] = per_source.get(doc["source"], 0) + len(cs)
+    if dropped_density:
+        print(f"dropped by density < {args.min_density}: {dropped_density}")
+
+    chars = [len(c["body"]) for c in all_chunks]
+    print(f"chunks produced: {len(all_chunks)}")
+    for s, c in sorted(per_source.items()):
+        print(f"  {s}: {c}")
+    if chars:
+        print(f"chunk chars: min={min(chars)} p50={sorted(chars)[len(chars)//2]} "
+              f"p90={sorted(chars)[int(len(chars)*0.9)]} max={max(chars)}")
+
+    if args.dry_run:
+        # Print first 10 chunk headings to eyeball
+        print("\nFirst 10 chunks (dry-run):")
+        for c in all_chunks[:10]:
+            print(f"  [{c['source']}] {c['heading'][:80]}  ({len(c['body'])} chars)")
+        return
+
+    out_path.mkdir(parents=True, exist_ok=True)
+    for c in all_chunks:
+        write_chunk(out_path, c)
+    print(f"wrote {len(all_chunks)} .md files to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/midloop_pilot/chunk_hf_guidelines.py
+++ b/experiments/midloop_pilot/chunk_hf_guidelines.py
@@ -13,8 +13,8 @@ Filters (conservative; too-small or too-large chunks are dropped):
     protocols (default 8000). Larger chunks are re-split on ``##``
     sub-headings if that produces at least 2 sub-chunks passing the
     size filter; otherwise they are skipped.
-  - content sanity: chunk must contain at least 3 lowercase words
-    after stripping headings, rules out ALL-CAPS banners.
+  - content sanity: chunk must contain at least 20 lowercase words
+    after stripping headings, which rules out ALL-CAPS banners.
 
 Frontmatter per output .md:
 
@@ -193,7 +193,8 @@ def main() -> None:
 
     in_path = Path(args.in_path)
     out_path = Path(args.out_path)
-    rows = [json.loads(line) for line in in_path.read_text().splitlines() if line.strip()]
+    with in_path.open() as f:
+        rows = [json.loads(line) for line in f if line.strip()]
     if args.limit_docs:
         rows = rows[: args.limit_docs]
     print(f"input docs: {len(rows)}")

--- a/experiments/midloop_pilot/merge_datasets.py
+++ b/experiments/midloop_pilot/merge_datasets.py
@@ -1,0 +1,96 @@
+"""Merge the v0 MedLocal dataset with the HF-guidelines expansion.
+
+Produces ``training_data/midloop_v1.jsonl`` whose rows come from both
+sources, with metadata.source distinguishing them. Idempotent --
+safe to re-run (writes to a fresh file).
+
+Schema is identical to v0 (same ``format_for_training`` output), so
+the existing split + prepare + train pipeline works unchanged. The
+only thing that grows is ``metadata.protocol_id`` diversity.
+
+Usage:
+  python -m experiments.midloop_pilot.merge_datasets
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+HERE = Path(__file__).parent
+V0 = HERE / "training_data" / "midloop_v0.jsonl"
+V1_HF = HERE / "scaleup_out_hf" / "midloop_v1_hf.jsonl"
+OUT = HERE / "training_data" / "midloop_v1.jsonl"
+
+
+def _load(path: Path) -> list[dict]:
+    if not path.exists():
+        raise SystemExit(f"missing: {path}")
+    return [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+
+
+def main() -> None:
+    v0 = _load(V0)
+    v1_hf = _load(V1_HF)
+    print(f"v0:    {len(v0)} cases")
+    print(f"v1_hf: {len(v1_hf)} cases")
+
+    # Tag source in metadata so downstream scripts can stratify if they want.
+    for r in v0:
+        r.setdefault("metadata", {}).setdefault("dataset_source", "medlocal_v0")
+    for r in v1_hf:
+        r.setdefault("metadata", {}).setdefault("dataset_source", "hf_guidelines_v1")
+
+    # Collision detection: two sources with the same protocol_id would mix
+    # CHW / HF content under one "protocol" name, silently corrupting the
+    # protocol-level train/test split (no leak but the semantics breaks).
+    v0_pids = {r["metadata"]["protocol_id"] for r in v0}
+    v1_pids = {r["metadata"]["protocol_id"] for r in v1_hf}
+    overlap = v0_pids & v1_pids
+    if overlap:
+        raise SystemExit(
+            f"protocol_id collision between v0 and v1_hf "
+            f"({len(overlap)} ids). Samples: {sorted(overlap)[:5]}"
+        )
+
+    # case_id uniqueness: downstream eval indexes by case_id so duplicates
+    # quietly over-count a test case.
+    case_ids = [r["case_id"] for r in v0 + v1_hf]
+    if len(set(case_ids)) != len(case_ids):
+        from collections import Counter as _C
+        dups = [(k, v) for k, v in _C(case_ids).items() if v > 1]
+        raise SystemExit(
+            f"duplicate case_ids ({len(dups)} collisions). "
+            f"Samples: {dups[:5]}"
+        )
+
+    merged = v0 + v1_hf
+    print(f"merged: {len(merged)} cases")
+
+    # protocol_id distribution in the merged set
+    pids = Counter(r["metadata"]["protocol_id"] for r in merged)
+    print(f"unique protocols: {len(pids)}")
+    sizes = Counter(pids.values())
+    print(f"cases-per-protocol distribution:")
+    for count, n_protos in sorted(sizes.items()):
+        print(f"  {count} cases: {n_protos} protocols")
+
+    # source breakdown
+    src = Counter(r["metadata"].get("dataset_source", "?") for r in merged)
+    print(f"by dataset_source: {dict(src)}")
+
+    # response-token sanity
+    tot_tok = sum(len(r["response_tokens"]) for r in merged)
+    tot_pos = sum(sum(r["intervene_labels"]) for r in merged)
+    print(f"total response tokens: {tot_tok}")
+    print(f"total positive labels: {tot_pos} ({tot_pos/tot_tok*100:.2f}%)")
+
+    with OUT.open("w") as f:
+        for r in merged:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"wrote: {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/midloop_pilot/merge_datasets.py
+++ b/experiments/midloop_pilot/merge_datasets.py
@@ -58,8 +58,7 @@ def main() -> None:
     # quietly over-count a test case.
     case_ids = [r["case_id"] for r in v0 + v1_hf]
     if len(set(case_ids)) != len(case_ids):
-        from collections import Counter as _C
-        dups = [(k, v) for k, v in _C(case_ids).items() if v > 1]
+        dups = [(k, v) for k, v in Counter(case_ids).items() if v > 1]
         raise SystemExit(
             f"duplicate case_ids ({len(dups)} collisions). "
             f"Samples: {dups[:5]}"

--- a/experiments/midloop_pilot/retrain_v1.sh
+++ b/experiments/midloop_pilot/retrain_v1.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# End-to-end retrain for midloop v1.
+#
+# Preconditions:
+#   - scaleup_out_hf/midloop_v1_hf.jsonl exists (output of scaleup_phase1_hf.py)
+#   - training_data/midloop_v0.jsonl exists (original v0)
+#
+# Runs:
+#   1. Merge v0 + v1_hf -> training_data/midloop_v1.jsonl
+#   2. Split (10% protocol-level holdout) -> midloop_v1_{train,test}.jsonl
+#   3. nanoGPT prepare.py on v1 split
+#   4. train_midloop.py with config/train_midloop_v1.py
+#   5. train-vs-val F1 diagnostic on the new ckpt
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."  # engram repo root
+
+NANO=${NANOGPT_REPO:-$HOME/Desktop/Personal/Projects/nanoGPT}
+
+echo "=== step 1/5: merge v0 + v1_hf ==="
+python -m experiments.midloop_pilot.merge_datasets
+
+echo "=== step 2/5: split v1 ==="
+# Count protocols in the merged set to pick a reasonable test_protocols value
+N_PROTO=$(python -c "
+import json
+pids = set()
+with open('experiments/midloop_pilot/training_data/midloop_v1.jsonl') as f:
+    for l in f:
+        pids.add(json.loads(l)['metadata']['protocol_id'])
+print(len(pids))
+")
+# Guardrail: tiny datasets produce meaningless splits. 20 is the smallest
+# we'd try to train on (would yield 2 test protocols at 10%).
+if [ "$N_PROTO" -lt 20 ]; then
+    echo "ERROR: N_PROTO=$N_PROTO too small for a meaningful split (need >= 20)" >&2
+    exit 1
+fi
+N_TEST=$(( (N_PROTO * 10 + 99) / 100 ))  # ceil(10%)
+echo "  total protocols: $N_PROTO, test-protocols: $N_TEST"
+python -m experiments.midloop_pilot.split_train_test \
+  --in experiments/midloop_pilot/training_data/midloop_v1.jsonl \
+  --train experiments/midloop_pilot/training_data/midloop_v1_train.jsonl \
+  --test experiments/midloop_pilot/training_data/midloop_v1_test.jsonl \
+  --test-protocols "$N_TEST"
+
+echo "=== step 3/5: nanoGPT prepare v1 ==="
+(cd "$NANO" && python data/midloop_v1/prepare.py)
+
+echo "=== step 4/5: train v1 ==="
+(cd "$NANO" && python train_midloop.py config/train_midloop_v1.py)
+
+echo "=== step 5/5: train-vs-val diagnostic ==="
+(cd "$NANO" && python eval_midloop_train.py out-midloop-v1/ckpt.pt)
+
+echo "=== done ==="

--- a/experiments/midloop_pilot/retrain_v1.sh
+++ b/experiments/midloop_pilot/retrain_v1.sh
@@ -15,7 +15,10 @@
 set -euo pipefail
 cd "$(dirname "$0")/../.."  # engram repo root
 
-NANO=${NANOGPT_REPO:-$HOME/Desktop/Personal/Projects/nanoGPT}
+# Default: look for nanoGPT as a sibling of the engram checkout.
+# Override with NANOGPT_REPO=... for any other layout.
+ENGRAM_ROOT=$(git rev-parse --show-toplevel)
+NANO=${NANOGPT_REPO:-"$ENGRAM_ROOT/../nanoGPT"}
 
 echo "=== step 1/5: merge v0 + v1_hf ==="
 python -m experiments.midloop_pilot.merge_datasets

--- a/experiments/midloop_pilot/sample_case_gen.py
+++ b/experiments/midloop_pilot/sample_case_gen.py
@@ -1,0 +1,281 @@
+"""Sample case_generator on a handful of HF-guideline chunks with Gemini.
+
+Selects a diverse set of chunks from
+``staging/hf_guidelines/chunks/{who,icrc}/``, runs the structured
+Gemini client (PR #25) through ``CaseGenerator``, and reports:
+
+  - how many chunks produce the requested N cases (pass rate),
+  - per-chunk (prompt, truth) coherence spot-check (first case),
+  - total tokens / wall time (as Gemini SDK exposes them).
+
+Writes full outputs to
+``staging/hf_guidelines/sample_cases.jsonl`` so you can eyeball or
+promote to the production protocols/ dir afterwards.
+
+Usage:
+  GOOGLE_API_KEY=... python -m experiments.midloop_pilot.sample_case_gen
+  python -m experiments.midloop_pilot.sample_case_gen --n-chunks 10 --n-cases 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import sys
+import time
+from pathlib import Path
+
+from merken.training.case_generator import (
+    CaseGenerator,
+    ProtocolClause,
+    default_gemini_client,
+)
+
+HERE = Path(__file__).parent
+CHUNK_ROOT = HERE / "staging" / "hf_guidelines" / "chunks"
+OUT_PATH = HERE / "staging" / "hf_guidelines" / "sample_cases.jsonl"
+REPORT_PATH = HERE / "staging" / "hf_guidelines" / "sample_report.md"
+
+_FRONT_RE = re.compile(r"\A---\n(.*?)\n---\n\n?", re.DOTALL)
+
+
+def parse_chunk(path: Path) -> dict:
+    """Parse frontmatter .md chunk into {source, doc_id, heading, density, body}."""
+    raw = path.read_text()
+    m = _FRONT_RE.match(raw)
+    if not m:
+        raise ValueError(f"no frontmatter: {path}")
+    fm = {}
+    for line in m.group(1).splitlines():
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        fm[k.strip()] = v.strip()
+    body = raw[m.end():].lstrip()
+    # Strip the duplicate "# heading" line the chunker prepended.
+    body = re.sub(r"\A#\s+[^\n]+\n+", "", body)
+    return {
+        "path": str(path),
+        "source": fm.get("source", "unknown"),
+        "doc_id": fm.get("doc_id", ""),
+        "heading": fm.get("heading", ""),
+        "density": float(fm.get("density", 0.0)),
+        "chars": int(fm.get("chars", 0)),
+        "body": body.strip(),
+    }
+
+
+def select_chunks(
+    n: int,
+    source_mix: dict[str, int],
+    min_chars: int,
+    max_chars: int,
+    seed: int,
+    max_per_doc: int = 1,
+) -> list[dict]:
+    """Pick chunks density-first with per-doc diversity cap.
+
+    ``max_per_doc=1`` forces one chunk per source document (the v1
+    selection mode, trades coverage for diversity). Higher values
+    (e.g. 4-8) allow more samples per doc so sections of long
+    guidelines get covered -- useful when the corpus is small and
+    source docs are already topically diverse internally.
+    """
+    if max_per_doc < 1:
+        raise ValueError(f"max_per_doc must be >= 1, got {max_per_doc}")
+    rng = random.Random(seed)
+    all_chunks: list[dict] = []
+    n_failed = 0
+    # sorted() required for cross-filesystem reproducibility; pathlib.glob
+    # order is filesystem-defined (APFS happens to be ordered, ext4 is not).
+    for sub in ("who", "icrc"):
+        sub_dir = CHUNK_ROOT / sub
+        if not sub_dir.exists():
+            continue
+        for p in sorted(sub_dir.glob("*.md")):
+            try:
+                c = parse_chunk(p)
+            except Exception as e:
+                import sys as _sys
+                print(f"warn: skipping {p.name}: {type(e).__name__}: {e}",
+                      file=_sys.stderr)
+                n_failed += 1
+                continue
+            if min_chars <= c["chars"] <= max_chars:
+                all_chunks.append(c)
+    if n_failed:
+        print(f"warn: {n_failed} chunks failed to parse", file=__import__('sys').stderr)
+
+    all_chunks.sort(key=lambda c: -c["density"])
+    picked: list[dict] = []
+    per_doc: dict[str, int] = {}
+    per_src_done = {s: 0 for s in source_mix}
+    for c in all_chunks:
+        if per_doc.get(c["doc_id"], 0) >= max_per_doc:
+            continue
+        if per_src_done.get(c["source"], 0) >= source_mix.get(c["source"], 0):
+            continue
+        picked.append(c)
+        per_doc[c["doc_id"]] = per_doc.get(c["doc_id"], 0) + 1
+        per_src_done[c["source"]] = per_src_done.get(c["source"], 0) + 1
+        if sum(per_src_done.values()) >= n:
+            break
+
+    # Under-fill warning: if the corpus could not supply the requested mix,
+    # surface this instead of silently returning fewer chunks.
+    import sys as _sys
+    for s, target in source_mix.items():
+        got = per_src_done.get(s, 0)
+        if got < target:
+            print(f"warn: requested {target} {s!r} chunks, got {got} "
+                  f"(corpus + max_per_doc={max_per_doc} cap)",
+                  file=_sys.stderr)
+
+    rng.shuffle(picked)
+    return picked
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n-chunks", type=int, default=10)
+    parser.add_argument("--n-cases", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--min-chars", type=int, default=600)
+    parser.add_argument("--max-chars", type=int, default=4000)
+    parser.add_argument("--model", default="gemini-2.5-flash")
+    parser.add_argument("--timeout-s", type=float, default=60.0)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    if not api_key and not args.dry_run:
+        print("ERROR: GOOGLE_API_KEY not set", file=sys.stderr)
+        sys.exit(2)
+
+    # Proportional to full corpus (WHO 4041 / ICRC 1474 = ~73% / 27%)
+    who_target = round(args.n_chunks * 0.7)
+    icrc_target = args.n_chunks - who_target
+    source_mix = {"who": who_target, "icrc": icrc_target}
+
+    chunks = select_chunks(
+        n=args.n_chunks,
+        source_mix=source_mix,
+        min_chars=args.min_chars,
+        max_chars=args.max_chars,
+        seed=args.seed,
+    )
+    print(f"selected {len(chunks)} chunks "
+          f"(who={sum(1 for c in chunks if c['source']=='who')}, "
+          f"icrc={sum(1 for c in chunks if c['source']=='icrc')})")
+    for c in chunks:
+        print(f"  [{c['source']}] density={c['density']:5.2f} "
+              f"chars={c['chars']:4d}  {c['heading'][:70]}")
+
+    if args.dry_run:
+        return
+
+    client = default_gemini_client(
+        api_key=api_key,
+        model=args.model,
+        structured=True,
+        timeout_s=args.timeout_s,
+    )
+    gen = CaseGenerator(client, structured=True)
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+    n_pass = 0
+    n_cases_total = 0
+    t0 = time.time()
+    for i, c in enumerate(chunks):
+        # Build protocol_id that will survive into midloop_v0.jsonl metadata
+        slug = re.sub(r"[^A-Za-z0-9]+", "-", c["heading"][:40].lower()).strip("-")
+        protocol_id = f"{c['source']}-hf-{c['doc_id'][:8]}-{slug}"[:80]
+        clause = ProtocolClause(
+            protocol_id=protocol_id,
+            text=c["body"],
+            metadata={
+                "source": c["source"],
+                "hf_doc_id": c["doc_id"],
+                "heading": c["heading"],
+                "density": c["density"],
+            },
+        )
+        try:
+            t_call = time.time()
+            cases = gen.generate(clause, n=args.n_cases)
+            dt = time.time() - t_call
+            n_pass += 1 if len(cases) >= args.n_cases else 0
+            n_cases_total += len(cases)
+            print(f"  [{i+1}/{len(chunks)}] {protocol_id[:50]}: "
+                  f"{len(cases)}/{args.n_cases} cases in {dt:.1f}s")
+            rows.append({
+                "protocol_id": protocol_id,
+                "source_path": c["path"],
+                "heading": c["heading"],
+                "n_cases": len(cases),
+                "dt_s": round(dt, 2),
+                "cases": [
+                    {"case_id": cs.case_id, "prompt": cs.prompt,
+                     "truth": cs.truth, "metadata": cs.metadata}
+                    for cs in cases
+                ],
+            })
+        except Exception as e:
+            print(f"  [{i+1}/{len(chunks)}] {protocol_id[:50]}: FAIL {e.__class__.__name__}: {e}")
+            rows.append({
+                "protocol_id": protocol_id,
+                "source_path": c["path"],
+                "heading": c["heading"],
+                "n_cases": 0,
+                "error": f"{e.__class__.__name__}: {e}",
+                "cases": [],
+            })
+    total_dt = time.time() - t0
+
+    with OUT_PATH.open("w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+    print(f"\nwrote {OUT_PATH}")
+    print(f"total time: {total_dt:.1f}s")
+    print(f"pass rate (>= {args.n_cases} cases): {n_pass}/{len(chunks)} "
+          f"({n_pass/len(chunks)*100:.0f}%)")
+    print(f"total cases produced: {n_cases_total} "
+          f"(expected {args.n_cases * len(chunks)})")
+
+    # Brief markdown report
+    lines = [
+        "# HF-guidelines case_generator sample",
+        "",
+        f"- n_chunks: {len(chunks)}",
+        f"- n_cases requested per chunk: {args.n_cases}",
+        f"- pass rate: {n_pass}/{len(chunks)} ({n_pass/len(chunks)*100:.0f}%)",
+        f"- total cases produced: {n_cases_total}",
+        f"- total wall time: {total_dt:.1f}s",
+        f"- model: {args.model}",
+        "",
+        "## Per-chunk results",
+        "",
+    ]
+    for r in rows:
+        lines.append(f"### {r['protocol_id']}")
+        lines.append("")
+        lines.append(f"- heading: `{r['heading'][:200]}`")
+        lines.append(f"- cases: {r['n_cases']}")
+        if "error" in r:
+            lines.append(f"- **ERROR**: {r['error']}")
+        elif r["cases"]:
+            c0 = r["cases"][0]
+            lines.append("- first case:")
+            lines.append(f"  - **prompt:** {c0['prompt']}")
+            lines.append(f"  - **truth:** {c0['truth']}")
+        lines.append("")
+    REPORT_PATH.write_text("\n".join(lines))
+    print(f"wrote {REPORT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/midloop_pilot/sample_case_gen.py
+++ b/experiments/midloop_pilot/sample_case_gen.py
@@ -99,15 +99,14 @@ def select_chunks(
             try:
                 c = parse_chunk(p)
             except Exception as e:
-                import sys as _sys
                 print(f"warn: skipping {p.name}: {type(e).__name__}: {e}",
-                      file=_sys.stderr)
+                      file=sys.stderr)
                 n_failed += 1
                 continue
             if min_chars <= c["chars"] <= max_chars:
                 all_chunks.append(c)
     if n_failed:
-        print(f"warn: {n_failed} chunks failed to parse", file=__import__('sys').stderr)
+        print(f"warn: {n_failed} chunks failed to parse", file=sys.stderr)
 
     all_chunks.sort(key=lambda c: -c["density"])
     picked: list[dict] = []
@@ -126,13 +125,12 @@ def select_chunks(
 
     # Under-fill warning: if the corpus could not supply the requested mix,
     # surface this instead of silently returning fewer chunks.
-    import sys as _sys
     for s, target in source_mix.items():
         got = per_src_done.get(s, 0)
         if got < target:
             print(f"warn: requested {target} {s!r} chunks, got {got} "
                   f"(corpus + max_per_doc={max_per_doc} cap)",
-                  file=_sys.stderr)
+                  file=sys.stderr)
 
     rng.shuffle(picked)
     return picked

--- a/experiments/midloop_pilot/scaleup_phase1_hf.py
+++ b/experiments/midloop_pilot/scaleup_phase1_hf.py
@@ -1,0 +1,363 @@
+"""Scale up Phase 1 on HF-guidelines chunks.
+
+Picks N chunks from ``staging/hf_guidelines/chunks/{who,icrc}/`` via
+the sample_case_gen selector, then runs the full Phase 1 pipeline on
+them:
+
+  1. case_generator (Gemini 2.5 Flash, structured-output) -> cases.jsonl
+  2. response_generator (lmstudio gemma-4-e4b-it-mlx)     -> responses.jsonl
+  3. aligner (fastembed BAAI/bge-small-en-v1.5)           -> aligned.jsonl
+  4. format_for_training (boundary labels)                -> midloop_v1_hf.jsonl
+
+Resumable via ``--skip``; each step checks for its output file and
+skips if present (mirror of run_pilot.py).
+
+Output dir defaults to ``scaleup_out_hf/`` under this package. Kept
+separate from ``out/`` and ``scaleup_out/`` so the existing v0
+artifacts stay untouched.
+
+Usage:
+  GOOGLE_API_KEY=... python -m experiments.midloop_pilot.scaleup_phase1_hf \
+      --n-chunks 300 --n-cases 5
+
+  python -m experiments.midloop_pilot.scaleup_phase1_hf --skip cases align
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+# Reuse selection + parsing from the 10-chunk sample script.
+from experiments.midloop_pilot.sample_case_gen import select_chunks
+
+HERE = Path(__file__).parent
+OUT_DIR = HERE / "scaleup_out_hf"
+LMSTUDIO_URL = "http://localhost:1234/v1"
+LMSTUDIO_MODEL = "gemma-4-e4b-it-mlx"
+GEMINI_MODEL = "gemini-2.5-flash"
+GEMINI_TIMEOUT_S = 90.0
+EMBED_MODEL = "BAAI/bge-small-en-v1.5"
+
+
+def step_select(
+    out_dir: Path, n_chunks: int, seed: int, min_chars: int, max_chars: int,
+    max_per_doc: int = 1,
+) -> Path:
+    """Persist the selected chunks as 'protocols.jsonl' so the rest of
+    the pipeline reads the same format run_pilot expects."""
+    path = out_dir / "protocols.jsonl"
+    who_target = round(n_chunks * 0.7)
+    icrc_target = n_chunks - who_target
+    source_mix = {"who": who_target, "icrc": icrc_target}
+    chunks = select_chunks(
+        n=n_chunks, source_mix=source_mix,
+        min_chars=min_chars, max_chars=max_chars, seed=seed,
+        max_per_doc=max_per_doc,
+    )
+    print(f"  selected {len(chunks)} chunks "
+          f"(who={sum(1 for c in chunks if c['source']=='who')}, "
+          f"icrc={sum(1 for c in chunks if c['source']=='icrc')})")
+    if not chunks:
+        raise SystemExit("no chunks selected; did you run chunk_hf_guidelines?")
+    with path.open("w") as f:
+        for c in chunks:
+            slug = re.sub(r"[^A-Za-z0-9]+", "-", c["heading"][:40].lower()).strip("-")
+            protocol_id = f"{c['source']}-hf-{c['doc_id'][:8]}-{slug}"[:80]
+            row = {
+                "protocol_id": protocol_id,
+                "text": c["body"],
+                "metadata": {
+                    "source": f"hf_{c['source']}",
+                    "hf_doc_id": c["doc_id"],
+                    "heading": c["heading"],
+                    "density": c["density"],
+                    "source_path": c["path"],
+                },
+            }
+            f.write(json.dumps(row) + "\n")
+    print(f"  wrote -> {path}")
+    return path
+
+
+def step_cases(protocols_path: Path, out_dir: Path, n_per: int) -> Path:
+    from merken.training.case_generator import (
+        CaseGenerator, ProtocolClause, default_gemini_client,
+    )
+
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        raise SystemExit("GOOGLE_API_KEY required for case generation")
+    client = default_gemini_client(
+        api_key=api_key, model=GEMINI_MODEL, structured=True,
+        timeout_s=GEMINI_TIMEOUT_S,
+    )
+    gen = CaseGenerator(client, structured=True)
+
+    out_path = out_dir / "cases.jsonl"
+    tmp_path = out_dir / "cases.jsonl.tmp"
+    n_protocols = 0
+    n_cases = 0
+    n_failed = 0
+    t0 = time.time()
+    with tmp_path.open("w") as fout:
+        for line in protocols_path.open():
+            row = json.loads(line)
+            n_protocols += 1
+            clause = ProtocolClause(
+                protocol_id=row["protocol_id"],
+                text=row["text"],
+                metadata=row["metadata"],
+            )
+            try:
+                cases = gen.generate(clause, n=n_per)
+            except Exception as e:
+                print(f"    ERR {clause.protocol_id[:50]}: "
+                      f"{type(e).__name__}: {e}", file=sys.stderr)
+                n_failed += 1
+                continue
+            for case in cases:
+                fout.write(json.dumps({
+                    "case_id": case.case_id,
+                    "prompt": case.prompt,
+                    "truth": case.truth,
+                    "metadata": case.metadata,
+                }, ensure_ascii=False) + "\n")
+                n_cases += 1
+            if n_protocols % 10 == 0:
+                print(f"    {n_protocols} protocols / {n_cases} cases / "
+                      f"{n_failed} failed / {time.time()-t0:.0f}s")
+    tmp_path.rename(out_path)
+    print(f"  total: {n_cases} cases from {n_protocols} protocols "
+          f"({n_failed} failed) in {time.time()-t0:.0f}s -> {out_path}")
+    return out_path
+
+
+def step_responses(cases_path: Path, out_dir: Path) -> Path:
+    from merken.training.case_generator import GeneratedCase
+    from merken.training.response_generator import ResponseGenerator
+
+    import requests
+    SYSTEM = (
+        "You are a community health worker assistant in a low-resource "
+        "clinical setting. Respond with ONLY the recommended clinical "
+        "action in 1-3 short sentences. Do NOT use markdown headers, "
+        "bullet lists, tables, code blocks, or extended explanations. "
+        "Do NOT add disclaimers, caveats, or signatures. Be direct, "
+        "specific (drug names + doses + durations), and brief."
+    )
+    session = requests.Session()
+
+    def lmstudio_fn(prompt: str) -> str:
+        resp = session.post(
+            f"{LMSTUDIO_URL}/chat/completions",
+            json={
+                "model": LMSTUDIO_MODEL,
+                "messages": [
+                    {"role": "system", "content": SYSTEM},
+                    {"role": "user", "content": prompt},
+                ],
+                "temperature": 0.0,
+                "max_tokens": 256,
+            },
+            timeout=120,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return (data["choices"][0]["message"]["content"] or "").strip()
+
+    gen = ResponseGenerator(lmstudio_fn)
+
+    out_path = out_dir / "responses.jsonl"
+    tmp_path = out_dir / "responses.jsonl.tmp"
+    n = 0
+    n_failed = 0
+    t0 = time.time()
+    with tmp_path.open("w") as fout:
+        for line in cases_path.open():
+            row = json.loads(line)
+            case = GeneratedCase(
+                case_id=row["case_id"],
+                prompt=row["prompt"],
+                truth=row["truth"],
+                metadata=row.get("metadata", {}),
+            )
+            try:
+                cwr = gen.respond(case)
+            except Exception as e:
+                print(f"    ERR {case.case_id}: "
+                      f"{type(e).__name__}: {e}", file=sys.stderr)
+                n_failed += 1
+                continue
+            fout.write(json.dumps({
+                "case_id": cwr.case_id,
+                "prompt": cwr.prompt,
+                "truth": cwr.truth,
+                "model_response": cwr.model_response,
+                "metadata": cwr.metadata,
+            }, ensure_ascii=False) + "\n")
+            n += 1
+            if n % 50 == 0:
+                print(f"    {n} responses / {n_failed} failed / "
+                      f"{time.time()-t0:.0f}s")
+    tmp_path.rename(out_path)
+    print(f"  total: {n} responses ({n_failed} failed) in "
+          f"{time.time()-t0:.0f}s -> {out_path}")
+    return out_path
+
+
+def step_align(responses_path: Path, out_dir: Path, threshold: float) -> Path:
+    from merken.training.midloop_dataset import (
+        Aligner, Case, default_embed_fn,
+    )
+
+    out_path = out_dir / "aligned.jsonl"
+    tmp_path = out_dir / "aligned.jsonl.tmp"
+    aligner = Aligner(
+        embed_fn=default_embed_fn(model_name=EMBED_MODEL),
+        similarity_threshold=threshold,
+    )
+    n = 0
+    n_int = 0
+    n_div = 0
+    t0 = time.time()
+    with tmp_path.open("w") as fout:
+        for line in responses_path.open():
+            row = json.loads(line)
+            case = Case(
+                truth=row["truth"],
+                model_response=row["model_response"],
+                prompt=row["prompt"],
+                case_id=row["case_id"],
+                metadata=row.get("metadata", {}),
+            )
+            result = aligner.process(case)
+            interventions_out = [
+                {
+                    "model_token_start": r.model_start,
+                    "model_token_end": r.model_end,
+                    "truth_token_start": r.truth_start,
+                    "truth_token_end": r.truth_end,
+                    "truth_text": r.truth_text,
+                    "model_text": r.model_text,
+                    "cosine_sim": r.cosine_sim,
+                }
+                for r in result.interventions
+            ]
+            drops_out = [
+                {
+                    "truth_text": r.truth_text,
+                    "model_text": r.model_text,
+                    "cosine_sim": r.cosine_sim,
+                }
+                for r in result.semantic_drops
+            ]
+            fout.write(json.dumps({
+                "case_id": case.case_id,
+                "prompt": case.prompt,
+                "truth": case.truth,
+                "model_response": case.model_response,
+                "metadata": case.metadata,
+                "n_divergent": len(result.divergent_regions),
+                "n_dropped_semantic": len(result.semantic_drops),
+                "n_interventions": len(result.interventions),
+                "interventions": interventions_out,
+                "semantic_drops": drops_out,
+            }, ensure_ascii=False) + "\n")
+            n += 1
+            n_int += len(result.interventions)
+            n_div += len(result.divergent_regions)
+            if n % 100 == 0:
+                print(f"    {n} aligned / {n_int} interventions / "
+                      f"{time.time()-t0:.0f}s")
+    tmp_path.rename(out_path)
+    print(f"  aligned {n} cases in {time.time()-t0:.0f}s -> {out_path}")
+    print(f"  divergent regions: {n_div}, interventions: {n_int}")
+    return out_path
+
+
+def step_format(aligned_path: Path, out_dir: Path) -> Path:
+    """Convert aligned.jsonl to the training_data format (boundary labels).
+
+    convert_case returns None for empty responses or zero tokenized
+    output. Count these explicitly so silent data loss is visible.
+    """
+    from experiments.midloop_pilot.format_for_training import convert_case
+    out_path = out_dir / "midloop_v1_hf.jsonl"
+    n = 0
+    n_dropped = 0
+    with out_path.open("w") as fout:
+        for line in aligned_path.open():
+            row = json.loads(line)
+            formatted = convert_case(row, labeling="boundary")
+            if formatted is None:
+                n_dropped += 1
+                continue
+            fout.write(json.dumps(formatted, ensure_ascii=False) + "\n")
+            n += 1
+    print(f"  formatted {n} cases (dropped {n_dropped} empty/untokenizable) "
+          f"-> {out_path}")
+    return out_path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n-chunks", type=int, default=300)
+    ap.add_argument("--n-cases", type=int, default=5)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--min-chars", type=int, default=600)
+    ap.add_argument("--max-chars", type=int, default=4000)
+    ap.add_argument("--threshold", type=float, default=0.85)
+    ap.add_argument("--max-per-doc", type=int, default=1,
+                    help="max chunks allowed per source doc; higher = more "
+                         "coverage, lower = more diversity. v1 used 1.")
+    ap.add_argument("--skip", choices=["select", "cases", "responses", "align", "format"],
+                    nargs="*", default=[])
+    args = ap.parse_args()
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"=== scaleup_phase1_hf ===")
+    print(f"out_dir: {OUT_DIR}")
+    print(f"n_chunks: {args.n_chunks}, n_cases per chunk: {args.n_cases}")
+    print(f"threshold: {args.threshold}")
+    print()
+
+    print("step 1/5: select chunks")
+    protocols_path = OUT_DIR / "protocols.jsonl"
+    if "select" not in args.skip or not protocols_path.exists():
+        protocols_path = step_select(
+            OUT_DIR, args.n_chunks, args.seed, args.min_chars, args.max_chars,
+            args.max_per_doc,
+        )
+
+    print("\nstep 2/5: generate cases (Gemini structured)")
+    cases_path = OUT_DIR / "cases.jsonl"
+    if "cases" not in args.skip or not cases_path.exists():
+        cases_path = step_cases(protocols_path, OUT_DIR, args.n_cases)
+
+    print("\nstep 3/5: generate responses (lmstudio gemma)")
+    responses_path = OUT_DIR / "responses.jsonl"
+    if "responses" not in args.skip or not responses_path.exists():
+        responses_path = step_responses(cases_path, OUT_DIR)
+
+    print("\nstep 4/5: align + filter")
+    aligned_path = OUT_DIR / "aligned.jsonl"
+    if "align" not in args.skip or not aligned_path.exists():
+        aligned_path = step_align(responses_path, OUT_DIR, args.threshold)
+
+    print("\nstep 5/5: format for training")
+    training_path = OUT_DIR / "midloop_v1_hf.jsonl"
+    if "format" not in args.skip or not training_path.exists():
+        training_path = step_format(aligned_path, OUT_DIR)
+
+    print(f"\n=== DONE: {training_path} ===")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/midloop_pilot/scaleup_phase1_hf.py
+++ b/experiments/midloop_pilot/scaleup_phase1_hf.py
@@ -9,8 +9,10 @@ them:
   3. aligner (fastembed BAAI/bge-small-en-v1.5)           -> aligned.jsonl
   4. format_for_training (boundary labels)                -> midloop_v1_hf.jsonl
 
-Resumable via ``--skip``; each step checks for its output file and
-skips if present (mirror of run_pilot.py).
+Resumable via ``--skip`` by naming the steps to omit on a rerun
+(for example, ``--skip cases align``). A listed step is only
+skipped when its output file already exists; otherwise it runs
+anyway so an interrupted pipeline can be re-driven safely.
 
 Output dir defaults to ``scaleup_out_hf/`` under this package. Kept
 separate from ``out/`` and ``scaleup_out/`` so the existing v0
@@ -68,13 +70,19 @@ def step_select(
     with path.open("w") as f:
         for c in chunks:
             slug = re.sub(r"[^A-Za-z0-9]+", "-", c["heading"][:40].lower()).strip("-")
-            protocol_id = f"{c['source']}-hf-{c['doc_id'][:8]}-{slug}"[:80]
+            # chunk_idx disambiguates protocol_id when max_per_doc > 1: two
+            # chunks of the same doc share doc_id[:8] and may share the
+            # truncated slug, but have distinct chunk_idx from the chunker.
+            # Parsed from the source filename: <doc[:10]>-<idx:04d>-<slug>.md.
+            chunk_idx = Path(c["path"]).stem.split("-")[1] if c.get("path") else "0000"
+            protocol_id = f"{c['source']}-hf-{c['doc_id'][:8]}-{chunk_idx}-{slug}"[:96]
             row = {
                 "protocol_id": protocol_id,
                 "text": c["body"],
                 "metadata": {
                     "source": f"hf_{c['source']}",
                     "hf_doc_id": c["doc_id"],
+                    "chunk_idx": chunk_idx,
                     "heading": c["heading"],
                     "density": c["density"],
                     "source_path": c["path"],
@@ -169,7 +177,12 @@ def step_responses(cases_path: Path, out_dir: Path) -> Path:
         )
         resp.raise_for_status()
         data = resp.json()
-        return (data["choices"][0]["message"]["content"] or "").strip()
+        choices = data.get("choices") or []
+        if not choices:
+            raise RuntimeError(
+                f"lmstudio returned no choices: {str(data)[:200]}"
+            )
+        return (choices[0].get("message", {}).get("content") or "").strip()
 
     gen = ResponseGenerator(lmstudio_fn)
 

--- a/experiments/midloop_pilot/split_train_test.py
+++ b/experiments/midloop_pilot/split_train_test.py
@@ -1,0 +1,121 @@
+"""Group-based train/test split for midloop_v0 by protocol_id.
+
+Holds out ~10% of protocols ENTIRE (no case-level mixing) so the
+test set contains protocols the model has never seen. This is the
+harder generalization setup required by the Phase 3 plan
+(notes/midloop-training-plan.md) -- stratified-within-protocol
+would leak 4 of every 5 cases from a holdout protocol into train.
+
+Deterministic via --seed (default 42).
+
+Usage:
+  python -m experiments.midloop_pilot.split_train_test
+  python -m experiments.midloop_pilot.split_train_test \
+      --in training_data/midloop_v0.jsonl \
+      --train training_data/midloop_v0_train.jsonl \
+      --test training_data/midloop_v0_test.jsonl \
+      --test-protocols 8 --seed 42
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from collections import defaultdict
+from pathlib import Path
+
+
+def _load(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def _group_by_protocol(rows: list[dict]) -> dict[str, list[dict]]:
+    groups: dict[str, list[dict]] = defaultdict(list)
+    for r in rows:
+        pid = r.get("metadata", {}).get("protocol_id")
+        if not pid:
+            raise ValueError(f"row without protocol_id: case_id={r.get('case_id')}")
+        groups[pid].append(r)
+    return dict(groups)
+
+
+def _write(path: Path, rows: list[dict]) -> None:
+    with path.open("w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def split(
+    in_path: Path,
+    train_path: Path,
+    test_path: Path,
+    test_protocols: int,
+    seed: int,
+) -> tuple[int, int, list[str]]:
+    rows = _load(in_path)
+    groups = _group_by_protocol(rows)
+    protocol_ids = sorted(groups.keys())
+
+    if test_protocols >= len(protocol_ids):
+        raise ValueError(
+            f"test_protocols={test_protocols} >= total protocols={len(protocol_ids)}"
+        )
+
+    rng = random.Random(seed)
+    shuffled = protocol_ids[:]
+    rng.shuffle(shuffled)
+    test_ids = set(shuffled[:test_protocols])
+
+    train_rows = [r for pid in protocol_ids if pid not in test_ids for r in groups[pid]]
+    test_rows = [r for pid in protocol_ids if pid in test_ids for r in groups[pid]]
+
+    _write(train_path, train_rows)
+    _write(test_path, test_rows)
+
+    return len(train_rows), len(test_rows), sorted(test_ids)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--in",
+        dest="in_path",
+        default="experiments/midloop_pilot/training_data/midloop_v0.jsonl",
+    )
+    parser.add_argument(
+        "--train",
+        default="experiments/midloop_pilot/training_data/midloop_v0_train.jsonl",
+    )
+    parser.add_argument(
+        "--test",
+        default="experiments/midloop_pilot/training_data/midloop_v0_test.jsonl",
+    )
+    parser.add_argument("--test-protocols", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    n_train, n_test, test_ids = split(
+        Path(args.in_path),
+        Path(args.train),
+        Path(args.test),
+        args.test_protocols,
+        args.seed,
+    )
+
+    total = n_train + n_test
+    print(f"train: {n_train} cases ({n_train / total * 100:.1f}%)")
+    print(f"test:  {n_test} cases ({n_test / total * 100:.1f}%)")
+    print(f"test protocols ({len(test_ids)}):")
+    for pid in test_ids:
+        print(f"  - {pid}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/midloop_pilot/split_train_test.py
+++ b/experiments/midloop_pilot/split_train_test.py
@@ -1,4 +1,4 @@
-"""Group-based train/test split for midloop_v0 by protocol_id.
+"""Group-based train/test split by protocol_id for any midloop dataset.
 
 Holds out ~10% of protocols ENTIRE (no case-level mixing) so the
 test set contains protocols the model has never seen. This is the
@@ -6,15 +6,23 @@ harder generalization setup required by the Phase 3 plan
 (notes/midloop-training-plan.md) -- stratified-within-protocol
 would leak 4 of every 5 cases from a holdout protocol into train.
 
+Used for both midloop_v0 (77 protocols / 8-proto holdout) and
+midloop_v1 (312 protocols / 32-proto holdout). CLI paths default
+to v0 for back-compat; point --in/--train/--test at the v1 JSONLs
+for the larger corpus.
+
 Deterministic via --seed (default 42).
 
 Usage:
+  # v0 default
   python -m experiments.midloop_pilot.split_train_test
+
+  # v1 (driven by retrain_v1.sh):
   python -m experiments.midloop_pilot.split_train_test \
-      --in training_data/midloop_v0.jsonl \
-      --train training_data/midloop_v0_train.jsonl \
-      --test training_data/midloop_v0_test.jsonl \
-      --test-protocols 8 --seed 42
+      --in training_data/midloop_v1.jsonl \
+      --train training_data/midloop_v1_train.jsonl \
+      --test training_data/midloop_v1_test.jsonl \
+      --test-protocols 32 --seed 42
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Scale corpus 77 -> 312 protocols via epfl-llm/guidelines (WHO+ICRC) chunking
- Capacity bump 4L/4H/128d -> 6L/6H/192d empirically justified by measurement
- v1-6L is the shipping candidate at VAL F1 = **0.442** (v0 baseline was 0.352)
- All knob / head / aligner / regularisation alternatives documented as negative results

## Headline numbers (VAL F1 with threshold sweep)

| variant | params | VAL F1 | train-val gap | verdict |
|---|---:|---:|---:|---|
| v0 (77p, 4L/128d) | 0.9M | 0.352 | +0.272 | memorising |
| v1 (312p, 4L/128d) | 0.9M | 0.359 | +0.072 | gap closed |
| **v1-6L (312p, 6L/192d)** | **2.8M** | **0.442** | +0.291 | **winner** |
| v1-8L (312p, 8L/256d) | 6.5M | 0.453 | +0.464 | saturated (+0.01) |

Shadow bar F1 >= 0.50 now 0.058 away. Only lever left is more data (task #14).

## What ships

Pipeline:
- `chunk_hf_guidelines.py` -- clinical-density chunker for epfl-llm/guidelines
- `sample_case_gen.py` -- chunk selector + Gemini-structured validation
- `scaleup_phase1_hf.py` -- end-to-end Phase 1 pipeline orchestrator
- `merge_datasets.py` -- v0 + v1_hf merge with collision detection
- `split_train_test.py` -- protocol-level group split (zero leakage)
- `retrain_v1.sh` -- end-to-end retrain driver

Docs:
- `RESULTS_v0.md` -- round 1 plateau diagnosis
- `RESULTS_v1.md` -- rounds 2-5, positive + negative results, code review summary

Downstream training infra (`train_midloop.py`, `data/midloop_v{0,1}/prepare.py`, configs, eval scripts) lives in the `nanoGPT` sibling repo and will be tracked there separately.

## Code review already done

Full pass via code-reviewer subagent before this PR. Blocker fix caught: `eval_midloop_train.py` / `eval_midloop_pr.py` in nanoGPT repo had hardcoded `data/midloop_v0` -- produced F1=0.112 instead of 0.442 when run on v1 ckpts (silent tokenizer mismatch, same vocab size, no dimension error). Training-loop metrics in the tables are from the loop's own `evaluate()` (correct) + inline threshold sweeps with explicit paths (correct). The only corrupted artifact was the `retrain_v1.sh` step-5 diagnostic output, which I spotted as inconsistent at the time and verified manually.

Important / minor fixes in this PR (from the review):
- Path-traversal whitelist on chunk source
- Reproducibility: `sorted(glob())`, under-fill warnings
- retrain_v1.sh: `set -euo pipefail` + N_PROTO >= 20 guardrail
- merge_datasets: collision detection on protocol_id + case_id
- scaleup step_format: count/log convert_case=None drops (was silent)
- KEEP IN SYNC headers on duplicated prepare.py (v0 and v1)

## Negative results also documented

Per feedback on documenting positives AND negatives:
- pos_weight sweep [3..18]: plateau 0.32-0.35
- MLP tagging head: equal-or-worse than linear, collapses at pw>=5
- Tighter aligner cos 0.90/0.95: <1% label delta, filter already inactive
- Extended training 1200->2000 iters: VAL flat, gap explodes
- Stronger regularisation: VAL drops 0.44 -> 0.37

## Test plan

- [x] Smoke test: `train_midloop.py --max_iters=50` on v1 -- runs clean, evaluate() produces expected metrics
- [x] `eval_midloop_train.py out-midloop-v1-6L/ckpt.pt` post-fix reports F1=0.442 matching manual sweep
- [x] Split integrity: zero protocol_id overlap, zero case_id overlap between train/test
- [x] Phase 1 pipeline smoke: 10-chunk Gemini sample at 100% pass rate (validated MgSO4 / PLAN C / EFV truths literal-from-chunk)
- [x] Full scale-up: 235 chunks -> 1175 cases in 35min, 0 failures; lmstudio 1175 responses in 18min, 0 failures; aligner 12s
- [ ] No new pytest tests -- research pipeline, documented via RESULTS\_v{0,1}.md