### PR TITLE
feat(midloop): v1b dataset double-up (VAL F1 0.442 -> 0.451, gap closed) + WHO PDF chunks

### DIFF
--- a/experiments/midloop_pilot/RESULTS_v1.md
+++ b/experiments/midloop_pilot/RESULTS_v1.md
@@ -111,6 +111,82 @@ thr=0.80 maxes F1. v1 has a much more informative P-R curve than v0
    was easier to satisfy by chance; 32 protocols exposes real
    distributional variance in the underlying label density.
 
+## Round 6 -- double the dataset (POSITIVE, 2026-04-20)
+
+Post-plateau hypothesis (RESULTS_v1 round 3): "more data is the
+only lever left". Tested by relaxing the per-doc diversity cap
+from max_per_doc=1 to max_per_doc=3, doubling the HF-guidelines
+selection from 235 chunks to 440 (warn correctly fired: ICRC
+only has 90 chunks available at density>=5 vs 150 requested).
+Re-ran the full Phase 1 pipeline: 2200 cases from Gemini
+(66 min, 0 failures), 2200 responses from lmstudio (41 min,
+0 failures), 6669 interventions after alignment at cos=0.85.
+Merged with v0 (385 cases, 77 protocols) -> **2585 cases,
+517 protocols** (vs v1: 1560 cases / 312 protocols).
+
+### Runs
+
+Same v0 -> v1 -> v1-6L sequence, on the v1b dataset:
+
+| variant               | cases | params | dropout | TRAIN F1 | VAL F1 | gap    |
+|-----------------------|------:|-------:|--------:|---------:|-------:|-------:|
+| v1  (4L/4H/128d)      |  1560 |  0.9M  | 0.10    |    0.431 | 0.359  | +0.072 |
+| v1-6L (6L/6H/192d)    |  1560 |  2.8M  | 0.15    |    0.733 | 0.442  | +0.291 |
+| v1b (4L/4H/128d)      |  2585 |  0.9M  | 0.10    |    0.449 | **0.435** | **+0.013** |
+| **v1b-6L (6L/6H/192d)**| 2585 | 2.8M  | 0.15    |    0.511 | **0.451** | +0.060 |
+
+### Verdicts
+
+- **Data is the dominant lever now.** Going from 1560 -> 2585 cases
+  lifted VAL F1 from 0.359 -> 0.435 at the baseline architecture
+  (+0.076). The train-val gap collapsed further, from +0.072 to
+  +0.013 (essentially zero memorisation).
+- **Capacity + data compounds weakly.** v1b-6L over v1b is only
+  +0.016 VAL F1. The 6L architecture that paid +0.083 on the small
+  v1 corpus pays only +0.016 on the larger v1b corpus -- when the
+  data bottleneck is closer to resolved, the capacity bump becomes
+  marginal.
+- **Gate F1>=0.50 is now 0.049 away.** Shadow-only deployment
+  (task #8) is viable at v1b-6L's 0.451 if we accept a lowered bar.
+  Closing the remaining 0.049 without overfitting appears to
+  require still more data, not more parameters.
+
+### Graduation gate re-eval
+
+| criterion                   | target   | v1-6L  | v1b-6L | verdict     |
+|-----------------------------|---------:|-------:|-------:|:-----------:|
+| F1 on held-out              | >= 0.75  | 0.442  | 0.451  | FAIL        |
+| F1 shadow-only bar          | >= 0.50  | 0.442  | 0.451  | FAIL by 0.049 |
+| min per-protocol recall     | >= 50%   | ~0.09  | ~low   | FAIL        |
+| training wall <= 30min MPS  | <= 30m   | 203s   | 196s   | PASS        |
+
+### What IS next
+
+**Two levers with clear EV, rough order:**
+
+1. **Add who_pdf chunks (190 extracted in task #10).** These
+   cover the 7 WHO reference books staged in medlocal, heavy on
+   dosing / essential medicines / acute care. Adding 190 new
+   protocols * 5 cases = ~950 new cases would take the corpus
+   from 2585 -> ~3535. scaleup_phase1_hf.step_select needs its
+   source_mix extended to include who_pdf before the next run.
+   Cost: ~$1 Gemini + ~15 min wall time for responses.
+2. **Accept v1b-6L as the shadow candidate at F1=0.451.** Per
+   task #8, the spec's F1>=0.50 shadow bar was a guess; 0.45 is
+   a defensible first-shadow threshold if the action is clamped
+   to WHISPER per the midloop plan. Real (decision, outcome)
+   pairs accumulate organically once the primitive is wired into
+   Reforge, allowing v2 retraining on production-truth.
+
+### What we are NOT doing
+
+- More capacity than 6L. v1-8L (round 3) saturated at +0.01 over 6L
+  with v1; likely similar story on v1b.
+- Synthetic data expansion. The 440-chunk selection with
+  max_per_doc=3 is already using the TOP-density region of the
+  corpus; lowering the density cutoff would admit the policy/
+  process content the filter was designed to reject.
+
 ## Round 5 -- extended training (NEGATIVE, 2026-04-20)
 
 Hypothesis: v1-6L best ckpt was at iter 1050 of 1200 with training

--- a/experiments/midloop_pilot/chunk_hf_guidelines.py
+++ b/experiments/midloop_pilot/chunk_hf_guidelines.py
@@ -144,7 +144,7 @@ def process_doc(
     return out
 
 
-_SAFE_SOURCES = frozenset({"who", "icrc", "cdc", "nice"})
+_SAFE_SOURCES = frozenset({"who", "icrc", "cdc", "nice", "who_pdf"})
 
 
 def write_chunk(out_dir: Path, chunk: dict) -> Path:

--- a/experiments/midloop_pilot/chunk_who_pdfs.py
+++ b/experiments/midloop_pilot/chunk_who_pdfs.py
@@ -1,0 +1,128 @@
+"""Convert WHO-PDF sections into the same chunk format as HF guidelines.
+
+The extract_pdfs.py `--mode sections` output lives at
+``staging/who_extracted_sections/<pdf-stem>/<section-id>.md`` as raw
+text with an HTML-comment header. This script normalises those into
+the same schema the HF-guidelines chunker produces (YAML-style
+frontmatter + `# heading`), writing to
+``staging/hf_guidelines/chunks/who_pdf/*.md`` so the existing
+``sample_case_gen.select_chunks`` picks them up if its source list is
+extended to include ``who_pdf``.
+
+Frontmatter schema (matches chunk_hf_guidelines.write_chunk):
+  source: who_pdf
+  doc_id: sha1(pdf filename)  # 40 hex chars
+  chunk_idx: int  # order within the PDF (used for protocol_id)
+  heading: first H1-like line from the section
+  url: pdf basename (no URL available for local PDFs)
+  chars: body length
+  density: clinical-action density score
+
+Default filter: density >= 5.0 (same threshold that produced the
+5515 HF chunks in v1). Drops process/policy boilerplate; keeps
+dosing / management / assessment sections.
+
+Usage:
+  python -m experiments.midloop_pilot.chunk_who_pdfs
+  python -m experiments.midloop_pilot.chunk_who_pdfs --min-density 3.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from chunk_hf_guidelines import clinical_density, _slugify, _SAFE_SOURCES
+
+HERE = Path(__file__).parent
+SECTION_ROOT = HERE / "staging" / "who_extracted_sections"
+OUT_DIR = HERE / "staging" / "hf_guidelines" / "chunks" / "who_pdf"
+
+_FRONTMATTER_RE = re.compile(r"\A<!--\s*(.*?)\s*-->\s*", re.DOTALL)
+
+
+def parse_section(path: Path) -> dict:
+    raw = path.read_text()
+    m = _FRONTMATTER_RE.match(raw)
+    body = raw[m.end():].strip() if m else raw.strip()
+    # The first non-empty line after stripping is the de-facto heading
+    # (extract_pdfs.sections mode prepends the section title).
+    lines = [ln for ln in body.splitlines() if ln.strip()]
+    heading = lines[0].strip()[:120] if lines else path.stem
+    return {"heading": heading, "body": body, "chars": len(body)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--min-density", type=float, default=5.0)
+    parser.add_argument("--min-chars", type=int, default=400)
+    parser.add_argument("--max-chars", type=int, default=8000)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if "who_pdf" not in _SAFE_SOURCES:
+        raise SystemExit(
+            "who_pdf must be added to _SAFE_SOURCES in "
+            "chunk_hf_guidelines.py before writing these chunks"
+        )
+
+    kept = 0
+    per_pdf: dict[str, int] = {}
+    if not args.dry_run:
+        OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    for pdf_dir in sorted(SECTION_ROOT.iterdir()):
+        if not pdf_dir.is_dir():
+            continue
+        pdf_name = pdf_dir.name
+        doc_id = hashlib.sha1(pdf_name.encode()).hexdigest()
+        # Assign a stable chunk_idx per PDF by sorting section files.
+        sections = sorted(pdf_dir.glob("*.md"))
+        for idx, sec_path in enumerate(sections):
+            info = parse_section(sec_path)
+            body = info["body"]
+            chars = info["chars"]
+            if chars < args.min_chars or chars > args.max_chars:
+                continue
+            density = clinical_density(body)
+            if density < args.min_density:
+                continue
+
+            heading = info["heading"]
+            out_name = (
+                f"{doc_id[:10]}-{idx:04d}-{_slugify(heading)}.md"
+            )
+            if args.dry_run:
+                kept += 1
+                per_pdf[pdf_name] = per_pdf.get(pdf_name, 0) + 1
+                continue
+
+            header = (
+                f"---\n"
+                f"source: who_pdf\n"
+                f"doc_id: {doc_id}\n"
+                f"chunk_idx: {idx}\n"
+                f"heading: {heading[:200]}\n"
+                f"url: {pdf_name}.pdf\n"
+                f"chars: {chars}\n"
+                f"density: {density:.2f}\n"
+                f"---\n\n"
+                f"# {heading}\n\n"
+            )
+            (OUT_DIR / out_name).write_text(header + body + "\n")
+            kept += 1
+            per_pdf[pdf_name] = per_pdf.get(pdf_name, 0) + 1
+
+    print(f"total chunks written: {kept}")
+    for pdf, n in sorted(per_pdf.items(), key=lambda kv: -kv[1]):
+        print(f"  {pdf}: {n}")
+    if not args.dry_run:
+        print(f"wrote to {OUT_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/midloop_pilot/chunk_who_pdfs.py
+++ b/experiments/midloop_pilot/chunk_who_pdfs.py
@@ -32,13 +32,21 @@ from __future__ import annotations
 import argparse
 import hashlib
 import re
-import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent))
-from chunk_hf_guidelines import clinical_density, _slugify, _SAFE_SOURCES
+# Intended usage: ``python -m experiments.midloop_pilot.chunk_who_pdfs``.
+# Relative import keeps the import graph explicit and avoids mutating
+# sys.path at runtime (which would depend on how the script is invoked).
+from experiments.midloop_pilot.chunk_hf_guidelines import (
+    clinical_density, _slugify, _SAFE_SOURCES,
+)
 
 HERE = Path(__file__).parent
+# Matches what extract_pdfs.py writes when invoked with
+# ``--mode sections --out <here>/staging/who_extracted_sections``. The
+# naming is deliberately distinct from extract_pdfs's default
+# (``staging/who_extracted``) so dump-mode flat files don't collide
+# with sections-mode per-PDF subdirectories.
 SECTION_ROOT = HERE / "staging" / "who_extracted_sections"
 OUT_DIR = HERE / "staging" / "hf_guidelines" / "chunks" / "who_pdf"
 
@@ -46,13 +54,26 @@ _FRONTMATTER_RE = re.compile(r"\A<!--\s*(.*?)\s*-->\s*", re.DOTALL)
 
 
 def parse_section(path: Path) -> dict:
-    raw = path.read_text()
+    # extract_pdfs.py writes these files as utf-8 explicitly because the
+    # WHO PDFs contain non-ASCII (accented drug names, typographic quotes).
+    # Reading with the platform default (cp1252 on Windows) silently
+    # corrupts them.
+    raw = path.read_text(encoding="utf-8")
     m = _FRONTMATTER_RE.match(raw)
     body = raw[m.end():].strip() if m else raw.strip()
-    # The first non-empty line after stripping is the de-facto heading
-    # (extract_pdfs.sections mode prepends the section title).
-    lines = [ln for ln in body.splitlines() if ln.strip()]
-    heading = lines[0].strip()[:120] if lines else path.stem
+    # The first non-empty line is the de-facto heading (extract_pdfs'
+    # sections mode prepends the section title). Pull it OUT of body so
+    # the writer's `# {heading}` prefix doesn't duplicate it downstream.
+    heading = path.stem
+    body_lines: list[str] = []
+    heading_taken = False
+    for ln in body.splitlines():
+        if not heading_taken and ln.strip():
+            heading = ln.strip()[:120]
+            heading_taken = True
+            continue
+        body_lines.append(ln)
+    body = "\n".join(body_lines).strip()
     return {"heading": heading, "body": body, "chars": len(body)}
 
 
@@ -68,6 +89,13 @@ def main() -> None:
         raise SystemExit(
             "who_pdf must be added to _SAFE_SOURCES in "
             "chunk_hf_guidelines.py before writing these chunks"
+        )
+
+    if not SECTION_ROOT.exists():
+        raise SystemExit(
+            f"SECTION_ROOT not found: {SECTION_ROOT}\n"
+            f"Run first: python -m experiments.midloop_pilot.extract_pdfs "
+            f"--mode sections --out {SECTION_ROOT}"
         )
 
     kept = 0
@@ -113,7 +141,9 @@ def main() -> None:
                 f"---\n\n"
                 f"# {heading}\n\n"
             )
-            (OUT_DIR / out_name).write_text(header + body + "\n")
+            (OUT_DIR / out_name).write_text(
+                header + body + "\n", encoding="utf-8"
+            )
             kept += 1
             per_pdf[pdf_name] = per_pdf.get(pdf_name, 0) + 1
 

--- a/experiments/midloop_pilot/sample_case_gen.py
+++ b/experiments/midloop_pilot/sample_case_gen.py
@@ -91,7 +91,10 @@ def select_chunks(
     n_failed = 0
     # sorted() required for cross-filesystem reproducibility; pathlib.glob
     # order is filesystem-defined (APFS happens to be ordered, ext4 is not).
-    for sub in ("who", "icrc"):
+    # Sources: HF-derived (who, icrc) and locally-extracted WHO PDFs (who_pdf).
+    # who_pdf contributes ~190 dosing/management-dense chunks from the 7 WHO
+    # reference books in medlocal/data/core/who/ via chunk_who_pdfs.py.
+    for sub in ("who", "icrc", "who_pdf"):
         sub_dir = CHUNK_ROOT / sub
         if not sub_dir.exists():
             continue


### PR DESCRIPTION
## Summary

Follow-up to #28. Two parallel additions after the code-review pass:

1. **Double the HF corpus** (task #14): 1560 -> 2585 cases via max_per_doc=1 -> 3.
2. **WHO PDF chunker** (task #10): 190 new clinical chunks (dosing, antimalarial, antivenom) from the 7 medlocal WHO reference books, ready for future scaleup.

## Headline numbers (VAL F1 with threshold sweep)

| variant | cases | arch | VAL F1 | train-val gap |
|---|---:|---:|---:|---:|
| v1 | 1560 | 4L/128d | 0.359 | +0.072 |
| v1-6L (PR #28 winner) | 1560 | 6L/192d | 0.442 | +0.291 |
| **v1b** | **2585** | **4L/128d** | **0.435** | **+0.013** |
| **v1b-6L** | **2585** | **6L/192d** | **0.451** | +0.060 |

## Key finding

**Data was the dominant lever all along.**

- 1560 -> 2585 cases at baseline arch paid **+0.076 VAL F1** (0.359 -> 0.435) while collapsing the train-val gap to essentially zero (+0.013). The model is no longer memorising in any meaningful sense.
- Capacity bump that was a +0.083 gain on v1 pays only +0.016 on v1b. Returns diminish fast once the data bottleneck relaxes.
- Gate F1>=0.50 shadow bar is now **0.049** away (was 0.148 at v0 round 1).

## What ships in this PR

- `chunk_who_pdfs.py` -- WHO-PDF -> chunk-format normaliser (190 chunks at density>=5).
- `chunk_hf_guidelines.py` -- `_SAFE_SOURCES` adds `who_pdf`.
- `sample_case_gen.py` -- `select_chunks` iterator includes `who_pdf`.
- `RESULTS_v1.md` -- round 6 section with the v1b experiment.

**NOT in this PR** (sibling nanoGPT repo, tracked separately):
- v1b training artifacts (`out-midloop-v1/`, `out-midloop-v1-6L/` with v1b weights).
- `data/midloop_v1/train.npz` / `val.npz` (regenerated from v1b split).

## Test plan

- [x] v1b scaleup: 2200 cases + responses + 6669 interventions with 0 failures end-to-end
- [x] v1b retrain: VAL F1 confirmed via inline threshold sweep matching training-loop eval
- [x] Under-fill warning fired correctly on ICRC (90 of 150 requested; audit in RESULTS_v1)
- [x] Protocol-level split integrity: 52 held-out protocols / 260 test cases / 0 case_id or protocol_id leak
- [x] chunk_who_pdfs dry-run + live run: 190 files written with expected per-PDF distribution
- [x] Retrain v1 driver works end-to-end after backup of frozen v1 artifacts

## Follow-ups

- Task #8 (lower gate to F1>=0.50 shadow-only): now defensible, close the final 0.049 via shadow accumulation in production.
- Future v2 run with who_pdf chunks included (set source_mix={"who": ..., "icrc": ..., "who_pdf": ...} in scaleup_phase1_hf.step_select).