### PR TITLE
feat(midloop): v1c who_pdf integration, F1 0.451 -> 0.461 + diminishing returns analysis

### DIFF
--- a/experiments/midloop_pilot/RESULTS_v1.md
+++ b/experiments/midloop_pilot/RESULTS_v1.md
@@ -142,7 +142,7 @@ cap (30, since who_pdf has only 7 docs).
 | v1b (4L/4H/128d)  |  2585 |  0.9M  |   0.449  | 0.435  |  +0.013 |
 | v1b-6L (6L/192d)  |  2585 |  2.8M  |   0.511  | 0.451  |  +0.060 |
 | v1c (4L/4H/128d)  |  3090 |  0.9M  |   0.416  | **0.388**|  +0.029 |
-| **v1c-6L (6L/192d)**| 3090 |  2.8M  |   0.618  | **0.461**|  +0.157 |
+| **v1c-6L (6L/192d)** | 3090 |  2.8M  |   0.618  | **0.461** |  +0.157 |
 
 ### Verdicts (MIXED)
 
@@ -180,7 +180,7 @@ cap (30, since who_pdf has only 7 docs).
 **Total gain 0.352 -> 0.461 = +0.109 across 7 rounds.**
 
 The capacity bump (round 3) was the single biggest lever (+0.083).
-Corpus expansions contributed +0.009 (v1 -> v1b) + +0.010 (v1b ->
+Corpus expansions contributed +0.009 (v1 -> v1b) + 0.010 (v1b ->
 v1c) = +0.019. Other levers (pos_weight, MLP head, aligner, longer
 training, regularisation) contributed 0.
 

--- a/experiments/midloop_pilot/RESULTS_v1.md
+++ b/experiments/midloop_pilot/RESULTS_v1.md
@@ -111,6 +111,96 @@ thr=0.80 maxes F1. v1 has a much more informative P-R curve than v0
    was easier to satisfy by chance; 32 protocols exposes real
    distributional variance in the underlying label density.
 
+## Round 7 -- add who_pdf chunks (MIXED, 2026-04-20)
+
+Hypothesis: the 184 who_pdf chunks extracted from the 7 WHO
+reference books (IMAI acute care, essential medicines, IMCI
+booklets, snakebite, maternal-newborn) add topic coverage the HF
+corpus doesn't (dosing ladders, antimalarial/antivenom dosing).
+Task #10 staged 190 chunks -> 184 after heading-dedup fix; scaleup
+extends source_mix to include ``who_pdf`` with a separate per-doc
+cap (30, since who_pdf has only 7 docs).
+
+### Setup
+
+- 500 HF chunks target (max_per_doc=3) + 150 who_pdf target
+  (max_per_doc=30).
+- Corpus limited both sources below target:
+  - icrc corpus-capped at 90 chunks (density+length filters admit
+    only 90 of its 1474 chunks per the v1b warning).
+  - who_pdf corpus-capped at 101 chunks (of 184; 6 of 7 PDFs
+    contribute; postnatal-care has no chunks >= 400 chars).
+- Final selection: **541 chunks = 350 HF-who + 90 HF-icrc + 101 who_pdf**.
+- Phase 1: 2705 cases in 82 min (0 fail), 2705 responses in 43 min
+  (0 fail), 7942 interventions at cos=0.85 (99.3% retention).
+- Merged with v0 -> **3090 cases / 618 protocols** (vs v1b: 2585 / 517).
+
+### Runs
+
+| variant           | cases | params | TRAIN F1 | VAL F1 | gap     |
+|-------------------|------:|-------:|---------:|-------:|--------:|
+| v1b (4L/4H/128d)  |  2585 |  0.9M  |   0.449  | 0.435  |  +0.013 |
+| v1b-6L (6L/192d)  |  2585 |  2.8M  |   0.511  | 0.451  |  +0.060 |
+| v1c (4L/4H/128d)  |  3090 |  0.9M  |   0.416  | **0.388**|  +0.029 |
+| **v1c-6L (6L/192d)**| 3090 |  2.8M  |   0.618  | **0.461**|  +0.157 |
+
+### Verdicts (MIXED)
+
+- **v1c-6L is the new best: VAL F1=0.461, +0.010 over v1b-6L.**
+  Capacity + who_pdf data compound slightly. Gate F1>=0.50 shadow
+  bar now 0.039 away (from 0.049 at v1b-6L).
+- **v1c baseline (4L/128d) REGRESSED: 0.435 -> 0.388** (-0.047).
+  who_pdf chunks carry a different structural signature than HF
+  (dosing tables, bullet lists vs prose guidelines). At 4L/128d
+  the model can't unify them with the HF chunks; the extra data
+  hurts instead of helping. At 6L/192d the capacity is enough to
+  accommodate both distributions, and the benefit flips positive.
+- **Returns diminish.** Round 6 (data doubling v1 -> v1b) paid
+  +0.009 at 6L. Round 7 (adding who_pdf) pays +0.010 at 6L.
+  Baseline hurt in round 7 is a new failure mode.
+
+### Graduation gate re-eval
+
+| criterion          | target   | v1-6L  | v1b-6L | v1c-6L | verdict     |
+|--------------------|---------:|-------:|-------:|-------:|:-----------:|
+| F1 held-out        | >= 0.75  | 0.442  | 0.451  | 0.461  | FAIL        |
+| F1 shadow-only     | >= 0.50  | 0.442  | 0.451  | 0.461  | FAIL by 0.039 |
+| train wall MPS     | <= 30m   | 203s   | 196s   | 216s   | PASS        |
+
+### Cumulative session summary
+
+| round | lever | best VAL F1 | delta | cumulative |
+|-------|-------|------------:|------:|-----------:|
+| 0 | v0 baseline (77p, 4L/128d) | 0.352 | -- | 0.352 |
+| 2 | v1 corpus 77->312 (4L/128d) | 0.359 | +0.007 | 0.359 |
+| 3 | v1-6L capacity 6L/192d     | 0.442 | +0.083 | 0.442 |
+| 6 | v1b-6L corpus 2585 (data+) | 0.451 | +0.009 | 0.451 |
+| 7 | v1c-6L + who_pdf 3090     | **0.461** | +0.010 | **0.461** |
+
+**Total gain 0.352 -> 0.461 = +0.109 across 7 rounds.**
+
+The capacity bump (round 3) was the single biggest lever (+0.083).
+Corpus expansions contributed +0.009 (v1 -> v1b) + +0.010 (v1b ->
+v1c) = +0.019. Other levers (pos_weight, MLP head, aligner, longer
+training, regularisation) contributed 0.
+
+### Decision: stop scaling corpus, pivot to shadow
+
+With two consecutive corpus-expansion rounds paying ~+0.010 each at
+6L, and the baseline regression in round 7, it is clear we have
+squeezed most of the juice from the "more data at 6L" lever.
+Closing the remaining 0.039 to the shadow bar F1=0.50 with the
+same pattern (another round adding epfl-llm CDC + NICE = 2549
+more docs) would cost another $4-6 API + 3-4 hours for an
+expected +0.005 to +0.015 gain. Diminishing returns is decisive.
+
+Recommended next move: **accept v1c-6L as the v1 shadow candidate
+at F1=0.461** per task #8, wire it into the midloop primitive
+through `ShadowMidloopDecider(NoopMidloopDecider(),
+NanoGPTMidloopDecider(ckpt))` with action clamped to WHISPER, and
+let real (decision, outcome) pairs accumulate. Retrain on pooled
+real labels once sufficient volume (~200) accumulates.
+
 ## Round 6 -- double the dataset (POSITIVE, 2026-04-20)
 
 Post-plateau hypothesis (RESULTS_v1 round 3): "more data is the

--- a/experiments/midloop_pilot/sample_case_gen.py
+++ b/experiments/midloop_pilot/sample_case_gen.py
@@ -75,6 +75,7 @@ def select_chunks(
     max_chars: int,
     seed: int,
     max_per_doc: int = 1,
+    max_per_doc_overrides: dict[str, int] | None = None,
 ) -> list[dict]:
     """Pick chunks density-first with per-doc diversity cap.
 
@@ -83,9 +84,19 @@ def select_chunks(
     (e.g. 4-8) allow more samples per doc so sections of long
     guidelines get covered -- useful when the corpus is small and
     source docs are already topically diverse internally.
+
+    ``max_per_doc_overrides`` lets a specific source pick more chunks
+    per doc than the global cap. Needed when a source has very few
+    docs but many chunks each (e.g. who_pdf has 7 PDFs * ~26
+    chunks/PDF; max_per_doc=3 would only yield 21 total even if the
+    caller wanted 150).
     """
     if max_per_doc < 1:
         raise ValueError(f"max_per_doc must be >= 1, got {max_per_doc}")
+    caps: dict[str, int] = dict(max_per_doc_overrides or {})
+    for s, cap in caps.items():
+        if cap < 1:
+            raise ValueError(f"max_per_doc_overrides[{s!r}]={cap} must be >= 1")
     rng = random.Random(seed)
     all_chunks: list[dict] = []
     n_failed = 0
@@ -116,13 +127,15 @@ def select_chunks(
     per_doc: dict[str, int] = {}
     per_src_done = {s: 0 for s in source_mix}
     for c in all_chunks:
-        if per_doc.get(c["doc_id"], 0) >= max_per_doc:
+        src = c["source"]
+        cap = caps.get(src, max_per_doc)
+        if per_doc.get(c["doc_id"], 0) >= cap:
             continue
-        if per_src_done.get(c["source"], 0) >= source_mix.get(c["source"], 0):
+        if per_src_done.get(src, 0) >= source_mix.get(src, 0):
             continue
         picked.append(c)
         per_doc[c["doc_id"]] = per_doc.get(c["doc_id"], 0) + 1
-        per_src_done[c["source"]] = per_src_done.get(c["source"], 0) + 1
+        per_src_done[src] = per_src_done.get(src, 0) + 1
         if sum(per_src_done.values()) >= n:
             break
 
@@ -130,9 +143,10 @@ def select_chunks(
     # surface this instead of silently returning fewer chunks.
     for s, target in source_mix.items():
         got = per_src_done.get(s, 0)
+        cap_for_msg = caps.get(s, max_per_doc)
         if got < target:
             print(f"warn: requested {target} {s!r} chunks, got {got} "
-                  f"(corpus + max_per_doc={max_per_doc} cap)",
+                  f"(corpus + max_per_doc={cap_for_msg} cap)",
                   file=sys.stderr)
 
     rng.shuffle(picked)

--- a/experiments/midloop_pilot/sample_case_gen.py
+++ b/experiments/midloop_pilot/sample_case_gen.py
@@ -85,11 +85,13 @@ def select_chunks(
     guidelines get covered -- useful when the corpus is small and
     source docs are already topically diverse internally.
 
-    ``max_per_doc_overrides`` lets a specific source pick more chunks
-    per doc than the global cap. Needed when a source has very few
-    docs but many chunks each (e.g. who_pdf has 7 PDFs * ~26
-    chunks/PDF; max_per_doc=3 would only yield 21 total even if the
-    caller wanted 150).
+    ``max_per_doc_overrides`` applies a per-source cap override --
+    either higher or lower than the global ``max_per_doc``. The common
+    case is a source with very few docs but many chunks each (e.g.
+    who_pdf has 7 PDFs * ~26 chunks/PDF; max_per_doc=3 would only
+    yield 21 total even if the caller wanted 150), but the same
+    mechanism also supports tightening a source that would otherwise
+    over-contribute at the global cap.
     """
     if max_per_doc < 1:
         raise ValueError(f"max_per_doc must be >= 1, got {max_per_doc}")
@@ -128,10 +130,13 @@ def select_chunks(
     per_src_done = {s: 0 for s in source_mix}
     for c in all_chunks:
         src = c["source"]
+        # Cheap check first: if this source's quota is already filled,
+        # skip before hitting per-doc cap + dict lookups for what would
+        # be a discarded chunk anyway.
+        if per_src_done.get(src, 0) >= source_mix.get(src, 0):
+            continue
         cap = caps.get(src, max_per_doc)
         if per_doc.get(c["doc_id"], 0) >= cap:
-            continue
-        if per_src_done.get(src, 0) >= source_mix.get(src, 0):
             continue
         picked.append(c)
         per_doc[c["doc_id"]] = per_doc.get(c["doc_id"], 0) + 1

--- a/experiments/midloop_pilot/scaleup_phase1_hf.py
+++ b/experiments/midloop_pilot/scaleup_phase1_hf.py
@@ -79,9 +79,13 @@ def step_select(
         max_per_doc=max_per_doc,
         max_per_doc_overrides=overrides or None,
     )
-    print(f"  selected {len(chunks)} chunks "
-          f"(who={sum(1 for c in chunks if c['source']=='who')}, "
-          f"icrc={sum(1 for c in chunks if c['source']=='icrc')})")
+    # Dynamic breakdown across whatever source_mix was configured so
+    # who_pdf (or future sources) show up in the run log.
+    per_source_counts = {s: 0 for s in source_mix}
+    for c in chunks:
+        per_source_counts[c["source"]] = per_source_counts.get(c["source"], 0) + 1
+    breakdown = ", ".join(f"{s}={n}" for s, n in per_source_counts.items())
+    print(f"  selected {len(chunks)} chunks ({breakdown})")
     if not chunks:
         raise SystemExit("no chunks selected; did you run chunk_hf_guidelines?")
     with path.open("w") as f:
@@ -346,11 +350,27 @@ def main() -> int:
     ap.add_argument("--max-per-doc", type=int, default=1,
                     help="max chunks allowed per source doc; higher = more "
                          "coverage, lower = more diversity. v1 used 1.")
-    ap.add_argument("--who-pdf-target", type=int, default=0,
+    def _non_negative_int(v: str) -> int:
+        i = int(v)
+        if i < 0:
+            raise argparse.ArgumentTypeError(
+                f"value must be >= 0, got {i}"
+            )
+        return i
+
+    def _positive_int(v: str) -> int:
+        i = int(v)
+        if i < 1:
+            raise argparse.ArgumentTypeError(
+                f"value must be >= 1, got {i}"
+            )
+        return i
+
+    ap.add_argument("--who-pdf-target", type=_non_negative_int, default=0,
                     help="number of who_pdf chunks to ADD on top of the HF "
                          "(who + icrc) mix. 0 disables who_pdf entirely. "
                          "Populate only after chunk_who_pdfs.py has run.")
-    ap.add_argument("--who-pdf-max-per-doc", type=int, default=30,
+    ap.add_argument("--who-pdf-max-per-doc", type=_positive_int, default=30,
                     help="per-PDF cap for who_pdf (overrides --max-per-doc "
                          "for that source). 30 allows the IMAI and "
                          "essential-medicines books to contribute most of "

--- a/experiments/midloop_pilot/scaleup_phase1_hf.py
+++ b/experiments/midloop_pilot/scaleup_phase1_hf.py
@@ -50,17 +50,34 @@ EMBED_MODEL = "BAAI/bge-small-en-v1.5"
 def step_select(
     out_dir: Path, n_chunks: int, seed: int, min_chars: int, max_chars: int,
     max_per_doc: int = 1,
+    who_pdf_target: int = 0,
+    who_pdf_max_per_doc: int = 30,
 ) -> Path:
     """Persist the selected chunks as 'protocols.jsonl' so the rest of
-    the pipeline reads the same format run_pilot expects."""
+    the pipeline reads the same format run_pilot expects.
+
+    The HF slice (who + icrc) splits n_chunks 70/30 per corpus
+    ratios. The who_pdf slice is additive -- who_pdf_target chunks
+    on top of the HF selection. who_pdf has only 7 documents so the
+    global max_per_doc cap is overridden to 30 for that source; set
+    lower to force broader per-PDF coverage, higher to pick more
+    of each book's dense sections.
+    """
     path = out_dir / "protocols.jsonl"
     who_target = round(n_chunks * 0.7)
     icrc_target = n_chunks - who_target
     source_mix = {"who": who_target, "icrc": icrc_target}
+    overrides: dict[str, int] = {}
+    total_n = n_chunks
+    if who_pdf_target > 0:
+        source_mix["who_pdf"] = who_pdf_target
+        overrides["who_pdf"] = who_pdf_max_per_doc
+        total_n = n_chunks + who_pdf_target
     chunks = select_chunks(
-        n=n_chunks, source_mix=source_mix,
+        n=total_n, source_mix=source_mix,
         min_chars=min_chars, max_chars=max_chars, seed=seed,
         max_per_doc=max_per_doc,
+        max_per_doc_overrides=overrides or None,
     )
     print(f"  selected {len(chunks)} chunks "
           f"(who={sum(1 for c in chunks if c['source']=='who')}, "
@@ -329,6 +346,15 @@ def main() -> int:
     ap.add_argument("--max-per-doc", type=int, default=1,
                     help="max chunks allowed per source doc; higher = more "
                          "coverage, lower = more diversity. v1 used 1.")
+    ap.add_argument("--who-pdf-target", type=int, default=0,
+                    help="number of who_pdf chunks to ADD on top of the HF "
+                         "(who + icrc) mix. 0 disables who_pdf entirely. "
+                         "Populate only after chunk_who_pdfs.py has run.")
+    ap.add_argument("--who-pdf-max-per-doc", type=int, default=30,
+                    help="per-PDF cap for who_pdf (overrides --max-per-doc "
+                         "for that source). 30 allows the IMAI and "
+                         "essential-medicines books to contribute most of "
+                         "their sections; lower to force broader coverage.")
     ap.add_argument("--skip", choices=["select", "cases", "responses", "align", "format"],
                     nargs="*", default=[])
     args = ap.parse_args()
@@ -346,6 +372,8 @@ def main() -> int:
         protocols_path = step_select(
             OUT_DIR, args.n_chunks, args.seed, args.min_chars, args.max_chars,
             args.max_per_doc,
+            who_pdf_target=args.who_pdf_target,
+            who_pdf_max_per_doc=args.who_pdf_max_per_doc,
         )
 
     print("\nstep 2/5: generate cases (Gemini structured)")


### PR DESCRIPTION
## Summary

Round 7 of the Phase 3 midloop training iteration. Integrates the 184 who_pdf chunks (staged in PR #29) into the scaleup selector and runs the full pipeline at 3090 cases / 618 protocols.

**v1c-6L is the new best at VAL F1 = 0.461**, +0.010 over v1b-6L.

**However, who_pdf data regressed the baseline (4L/128d)**: 0.435 -> 0.388 (-0.047). Capacity-dependent data gain is a new observation.

## Headline numbers (VAL F1 with threshold sweep)

| variant | cases | params | VAL F1 | train-val gap |
|---|---:|---:|---:|---:|
| v1b (4L/128d) | 2585 | 0.9M | 0.435 | +0.013 |
| v1b-6L (6L/192d) | 2585 | 2.8M | 0.451 | +0.060 |
| v1c (4L/128d) | 3090 | 0.9M | **0.388** | +0.029 |
| **v1c-6L (6L/192d)** | **3090** | **2.8M** | **0.461** | +0.157 |

## Cumulative session gain (7 rounds)

| round | lever | VAL F1 | delta |
|---|---|---:|---:|
| 0 | v0 baseline (77p) | 0.352 | -- |
| 2 | v1 corpus 77 -> 312 | 0.359 | +0.007 |
| 3 | v1-6L capacity 6L/192d | 0.442 | +0.083 |
| 6 | v1b-6L corpus 2585 | 0.451 | +0.009 |
| 7 | v1c-6L + who_pdf 3090 | **0.461** | +0.010 |

Total: **0.352 -> 0.461 = +0.109**.

## What ships

1. **`sample_case_gen.select_chunks`** gains `max_per_doc_overrides` dict (per-source override). Needed because who_pdf has 7 docs with many chunks each; a global max_per_doc=3 would cap total at 21.
2. **`scaleup_phase1_hf.step_select`** gains `who_pdf_target` + `who_pdf_max_per_doc` params (CLI flags). Default 0 = disabled (v1b behavior preserved).
3. **RESULTS_v1.md round 7** documents the positive (capacity) + negative (baseline regression) findings + cumulative analysis.

NOT in this PR: v1c training artifacts in the nanoGPT sibling repo.

## Decision documented in RESULTS_v1

With two consecutive corpus rounds each paying ~+0.010 at 6L, and a baseline regression in this round, **the "more data at 6L" lever is spent**. Closing the remaining 0.039 to the F1>=0.50 shadow bar via more data (e.g. epfl-llm CDC + NICE = 2549 more docs) would cost $4-6 + 3-4h for an expected +0.005 to +0.015 gain.

**Recommended next move:** pivot to shadow deployment per task #8. Wire v1c-6L via `ShadowMidloopDecider(NoopMidloopDecider(), NanoGPTMidloopDecider(ckpt))` with action clamped to WHISPER. Accumulate real (decision, outcome) pairs. Retrain on pooled real labels when ~200 accumulate.

## Test plan

- [x] dry-run of `select_chunks` with who_pdf: 541 chunks (350 + 90 + 101) as expected
- [x] Warn fired correctly on both under-filled sources
- [x] End-to-end pipeline: 2705 cases + 2705 responses + 7942 interventions with 0 failures
- [x] Train-vs-val F1 matches inline sweeps in both directions (no more eval script bug)
- [x] Protocol-level split: 62 test protocols, 0 case_id or protocol_id leak verified by merge_datasets collision check

## Follow-ups

- Task #8 (formalize F1>=0.50 shadow bar decision) now actionable at v1c-6L.
- Shadow integration (NanoGPTMidloopDecider class) pending -- needs Reforge runtime hook design.