### PR TITLE
feat(midloop): Move 4 -- claim-level Judge + vstash signal surfacing

### DIFF
--- a/experiments/midloop_concept/RESULTS.md
+++ b/experiments/midloop_concept/RESULTS.md
@@ -584,22 +584,187 @@ moves the number.
 
 ---
 
+---
+
+## Run 7 -- claim-level Judge + vstash signal surfacing (2026-04-21)
+
+Move 4. The open item flagged in Run 5a was that the Judge
+verified answer-level but not claim-level: cotrimoxazole's
+top-line "start prophylaxis for CD4=180" was confirmed as
+`supports` while the Builder's `CD4 <200` threshold quietly
+contradicted the chunk's `CD4 <350`. Run 6 also surfaced a
+second instance in the diagnostic: `consolidation_threshold`
+answered 0.70 correctly but (in v3 variants) had cited a
+chunk about a different 0.65 experiment.
+
+This move does two things together -- claim-level verification
+and surfacing the vstash retrieval signals that were being
+discarded -- because both feed the same "glass box" invariant
+(we use signals we never invent, and we report drift we never
+hide).
+
+### Claim-level schema
+
+`JUDGE_SYSTEM_TEMPLATE` gained a `claims: [...]` array in the
+JSON schema. Each sub-claim carries `{text, verdict,
+supporting_excerpt_id, quoted_evidence}` under the SAME
+verbatim-substring rule as the top-level `quoted_evidence`.
+Decomposition is taken from the FINAL rendered answer (the
+corrected_text when verdict=contradicts, the draft otherwise)
+explicitly -- not from the rejected draft.
+
+`annotate_deterministic` now appends a second section after
+the primary provenance footer whenever any sub-claim verdict
+is `contradicts` or `neutral`:
+
+```
+>> [N sub-claim(s) not grounded in memory]
+>>   contradicted: 'the CD4 threshold is 200'
+>>     source says: "CD4 <350"
+```
+
+The happy case (all sub-claims supported) emits no sub-claim
+section at all, preserving the reading-path for clean outputs.
+`MAX_TOKENS_JUDGE` bumped 600 -> 1200 to fit 3-8 sub-claim
+entries comfortably.
+
+### vstash signal surfacing
+
+`retrieve()` now returns a list of dicts carrying every signal
+vstash publishes on `SearchResult`: `source_id, text, score,
+layer, chunk_id, added_at, collection`. Previous code used only
+`text` + `title` and silently discarded the rest.
+
+Judge excerpts now render with score + layer in the header:
+
+```
+[excerpt 13 | source=hiv-who | score=0.0167 | layer=episodic]
+**Cotrimoxazole prophylaxis:** 1 tablet daily for all HIV+ ...
+```
+
+and `JUDGE_SYSTEM_TEMPLATE` gained a short note explaining that
+score is an RRF-family relevance hint (higher = more relevant,
+typical 0.005-0.030 on current corpora) and `layer` distinguishes
+episodic from distilled content. The Judge is told to prefer
+grounding in high-score or distilled-layer excerpts when
+multiple candidates touch the same claim; these are hints,
+not hard cutoffs.
+
+The audit row also gained `retrieval_stats` (n, max/min/mean
+score, layer counts) and `n_sub_claims / n_sub_claims_unsupported`
+so future training pipelines can filter by retrieval quality or
+by claim-level outcome without re-running the pipeline.
+
+### Run 7a -- clinical + confident + dual-3 + claim-level
+
+Log: `cerebras_smoke_v4_claimlevel.jsonl`.
+
+| qid | Run 5a verdict | Run 7a verdict | claims / unsupported | note |
+|---|---|---|---|---|
+| severe_dehydration_child | contradicts | contradicts | 6 / 0 | clean |
+| severe_pneumonia_infant | contradicts | contradicts | 5 / 0 | clean |
+| postpartum_hemorrhage_txa | supports | supports | 5 / 0 | clean |
+| cotrimoxazole_hiv_adult | **supports** | **contradicts** | 3 / 0 | **FLIP** -- the <200 vs <350 leak caught. Judge produced a corrected_text that threads the <350 threshold verbatim. |
+| blood_donor_screening | supports | contradicts | 6 / 3 | claim-level caught 3 sub-claim leaks: pale->anemia inference (neutral), cough->infection inference (neutral), tattoo deferral based on "local regulations" contradicted by WHO guideline (contradicts). |
+
+5/5 still grounded top-level. **Cotrimoxazole flip is the
+direct test pass: the answer-level-supports / claim-level-
+contradicts case that motivated Move 4 now renders
+contradicts with a corrected_text that preserves the <350
+threshold verbatim.** Blood donor case demonstrates
+claim-level surfaces inferences even when the top-line
+recommendation is correct.
+
+### Run 7b -- personal + confident + dual-3 + claim-level
+
+Log: `cerebras_personal_smoke_v4_claimlevel.jsonl`.
+
+| qid | Run 5b verdict | Run 7b verdict | claims / unsupported |
+|---|---|---|---|
+| write_filter_baseline | contradicts | contradicts | 3 / 0 |
+| consolidation_threshold | contradicts | contradicts | 5 / 0 |
+| silt_rule | contradicts | contradicts | 3 / 0 |
+| engram_longmemeval_r5 | supports | contradicts | 4 / 0 |
+| four_primitives | contradicts | contradicts | 9 / 0 |
+
+5/5 still grounded, 0 unsupported sub-claims across all 5
+questions. This is the important negative result:
+claim-level does NOT introduce false positives on a domain
+where the previous pipeline was already clean. It only fires
+when a genuine sub-claim drift exists.
+
+`consolidation_threshold` retained the correct 0.70 answer with
+5/5 sub-claims grounded -- confirming that the claim-level
+rigor discourages the Judge from grabbing tangential chunks
+(like the 0.65 experiment chunk that v3 cited).
+
+### Cost
+
+| metric | v3 (dual-3) | v4 (claim-level) | delta |
+|---|---|---|---|
+| clinical avg tok/q | 12712 | 14620 | +1908 (+15%) |
+| personal avg tok/q | 7677 | 8904 | +1226 (+16%) |
+
+Overhead is entirely in Judge completion (the claims array is
+3-8 entries at ~60 tokens each) plus ~150 extra tokens of
+Judge system prompt for the new rules. Wall time stays under
+2s per question. Well below earlier back-of-envelope estimates.
+
+### Retrieval signals (first pass)
+
+All clinical questions see the same max_score=0.0167 (the vstash
+RRF ceiling in this adaptive-RRF regime); mean_score clusters
+tightly around 0.015. Layers in medlocal_concept are all
+reported as `unknown` (layer tagging was not set at seed time);
+personal engram vstash shows `episodic` with some `unknown`
+stragglers. These are the first observations Silt's rule would
+warn against optimising over -- the distribution is narrow.
+Useful baseline for a future policy layer but no immediate
+threshold to set.
+
+### Move 4 verdict
+
+- Claim-level schema shipped. One verdict flip (cotrimoxazole
+  `supports -> contradicts`) confirms the change catches the
+  answer-level-correct / claim-level-leaky case that motivated
+  the move. Blood donor case shows the warning surfaces
+  inferences even when the top-line is right.
+- vstash signals surfaced to Judge prompt and audit row. No
+  immediate decision rule is derived; the first-pass
+  distribution is narrow (max_score saturates at 0.0167
+  across every question). Training-time use will come when
+  enough audit rows accumulate to regress against.
+- Token cost +15-16%. Wall <2s. Production-acceptable.
+
+---
+
 ## Next moves
 
-**Moves 1b, 2, the supports-on-refusal bug fix, and Move 3
-KV-splice POC** all shipped 2026-04-21.
+**Moves 1b, 2, 3, 4 + supports-on-refusal fix** all shipped
+2026-04-21.
 
-Open secondary issue (noted, not in Move 3):
+Remaining candidates, not yet started:
 
-- **Answer-level verification vs claim-level verification.**
-  Run 5a cotrimoxazole had the Judge mark the Builder's
-  "start prophylaxis" recommendation as supports, even though
-  the Builder said "CD4 <200" and the cited chunk said "CD4
-  <350". The top-line answer is confirmed; the sub-claim
-  threshold is not. A claim-level Judge pass would flag the
-  inconsistency. Worth considering for a future Mode A
-  evolution -- not a blocker for current use.
+- **Long-splice + chat-template probe for Mode C.** Move 3
+  POC used a 14-token splice and a raw continuation prompt.
+  Production will splice 500+ tokens of retrieved excerpts
+  into chat-template-formatted Gemma turns. Probe should
+  measure coherence degradation vs splice length and test
+  role-marker boundary behavior.
+- **Cost optimisation (Move 2.1).** Dual-3 + claim-level is
+  now ~14k tok/q on clinical. The excerpt pool (up to 28
+  excerpts post-dedup) dominates cost. Levers: full-text
+  hash dedup instead of 120-char prefix, score-threshold
+  cutoff, mini-rerank pass before handing to Judge.
+- **Retrieval-signal policy layer.** Now that `score` and
+  `layer` live in the audit row, a policy could decide
+  whether to fall back to "low-confidence mode" (e.g. force
+  verdict=neutral if max_score is below corpus-calibrated
+  threshold). Needs corpus-specific calibration first.
 
 Deferred (needs curated dataset + rubric, not next-session
 work): N=50+ benchmark against ASQA / HAGRID / MedQA with
-two-rater scoring.
+two-rater scoring. Sub-claim classifier training from the
+accumulated `claims` arrays (every v4 run produces labeled
+per-claim data; enough audit rows accumulate to regress on
+after ~100 more runs).

--- a/experiments/midloop_concept/medlocal/cerebras_midloop.py
+++ b/experiments/midloop_concept/medlocal/cerebras_midloop.py
@@ -148,24 +148,35 @@ def cerebras_chat(model: str, messages: list[dict], max_tokens: int) -> tuple[st
     """Return (text, wall_seconds, usage). Bubbles SDK exceptions up
     after a short retry window.
 
-    Cerebras intermittently returns 503 ``queue_exceeded`` under
-    load. A smoke run that fires 2 calls per question times N
-    questions has a non-trivial probability of hitting one. Retry
-    up to 3 times with exponential backoff (2s, 4s, 8s) so a
-    single transient 503 does not lose all the tokens spent
-    earlier in the run. Persistent 5xx still bubbles up.
+    Cerebras intermittently returns 5xx ``queue_exceeded`` / 429
+    rate-limit under load. A smoke run that fires 2 calls per
+    question times N questions has a non-trivial probability of
+    hitting one. Retry the transient classes up to 4 total
+    attempts with exponential backoff of 2s / 4s / 8s between
+    attempts (so attempts 1..4 are at t=0, t=2, t=6, t=14).
+    Non-retryable errors (auth, bad request, not found) bubble
+    up immediately.
+
+    We catch ``APIStatusError`` (the common parent of every HTTP
+    error the SDK raises) rather than a specific subclass so a
+    future SDK version that reclassifies 503 as
+    ``ServiceUnavailableError`` does not silently break the
+    retry. Status-code gating via ``response.status_code`` keeps
+    4xx client errors out of the retry loop.
 
     ``usage`` is a dict of prompt_tokens / completion_tokens /
     total_tokens taken from ``resp.usage`` when Cerebras populates
     it. Empty dict when the SDK response omits the field, so the
     caller can sum defensively.
     """
-    from cerebras.cloud.sdk import InternalServerError
+    from cerebras.cloud.sdk import APIStatusError
 
     client = _cerebras_client()
     t0 = time.perf_counter()
-    last_err: Exception | None = None
-    for attempt in range(3):
+    # Attempts 1..4; between each pair we sleep backoffs[i] seconds.
+    # Three backoffs => four attempts total (matches the docstring).
+    backoffs = [2, 4, 8]
+    for attempt in range(len(backoffs) + 1):
         try:
             resp = client.chat.completions.create(
                 model=model,
@@ -174,21 +185,23 @@ def cerebras_chat(model: str, messages: list[dict], max_tokens: int) -> tuple[st
                 temperature=0.3,
             )
             break
-        except InternalServerError as exc:
-            last_err = exc
-            # 5xx on the last attempt -> let it bubble; the caller
-            # already has the partial run state it needs.
-            if attempt == 2:
+        except APIStatusError as exc:
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            # Only transient classes retry: 5xx (server) and 429
+            # (rate-limit). 4xx client errors (400/401/403/404/422
+            # etc) are bugs on our side; retrying would just waste
+            # budget and hide the real error.
+            is_transient = isinstance(status, int) and (
+                status >= 500 or status == 429
+            )
+            if not is_transient or attempt == len(backoffs):
                 raise
-            backoff = 2 ** (attempt + 1)
+            backoff = backoffs[attempt]
             print(
-                f"    cerebras 5xx (attempt {attempt+1}/3), "
-                f"backing off {backoff}s: {exc}"
+                f"    cerebras {status} (attempt {attempt+1}/"
+                f"{len(backoffs)+1}), backing off {backoff}s: {exc}"
             )
             time.sleep(backoff)
-    else:  # pragma: no cover -- the break above covers the success path
-        if last_err is not None:
-            raise last_err
     dt = time.perf_counter() - t0
     usage = {}
     u = getattr(resp, "usage", None)
@@ -268,7 +281,7 @@ JUDGE_SYSTEM_TEMPLATE = (
     "    {{\n"
     '      "text": "...",             // the atomic sub-claim as a short sentence\n'
     '      "verdict": "supports"|"contradicts"|"neutral",\n'
-    '      "supporting_excerpt_id": int|null, // 0-based index, or null when neutral/contradicts\n'
+    '      "supporting_excerpt_id": int|null, // null only for neutral\n'
     '      "quoted_evidence": "..."   // verbatim substring from that excerpt; "" when neutral\n'
     "    }}\n"
     "  ]\n"
@@ -295,8 +308,14 @@ JUDGE_SYSTEM_TEMPLATE = (
     "- For each sub-claim, emit verdict/supporting_excerpt_id/"
     "quoted_evidence using the SAME verbatim-substring rule as the "
     "top-level quoted_evidence.\n"
-    "- If a sub-claim's verdict is 'contradicts', quoted_evidence "
-    "must be a verbatim substring of the excerpt it contradicts.\n"
+    "- If a sub-claim's verdict is 'supports', supporting_excerpt_id "
+    "is the excerpt whose text grounds the claim and "
+    "quoted_evidence is a verbatim substring of that excerpt.\n"
+    "- If a sub-claim's verdict is 'contradicts', "
+    "supporting_excerpt_id is the excerpt that contradicts the "
+    "claim (NOT null -- future audit / training code needs the "
+    "index to trace the evidence) and quoted_evidence is a "
+    "verbatim substring of that excerpt.\n"
     "- If verdict is 'neutral' for a sub-claim, "
     "supporting_excerpt_id = null and quoted_evidence = \"\".\n"
     "- claims may be [] when has_claim=false.\n\n"
@@ -436,11 +455,16 @@ def judge_once(
             "corrected_text": "",
             "claims": [],
         }
-    # Ensure every returned judgment has the claims field so the
-    # annotator does not need to None-guard it. Older stored logs
-    # predate this field -- leaving it absent there is fine (the
-    # annotator treats missing as []).
-    parsed.setdefault("claims", [])
+    # Ensure every returned judgment has a claims LIST so the
+    # annotator does not need to None-guard or type-check it.
+    # Defensive type-check: if the model returned a non-list
+    # (e.g. a dict keyed by claim text, or a stray string), drop
+    # it silently to []. Better to miss claim-level signaling on
+    # one malformed response than to crash the whole smoke run.
+    # Older stored logs predate this field; reading them stays
+    # safe because the annotator treats missing as [].
+    if not isinstance(parsed.get("claims"), list):
+        parsed["claims"] = []
     return parsed, dt, usage
 
 

--- a/experiments/midloop_concept/medlocal/cerebras_midloop.py
+++ b/experiments/midloop_concept/medlocal/cerebras_midloop.py
@@ -52,7 +52,10 @@ JUDGE = "qwen-3-235b-a22b-instruct-2507"
 # Draft caps where a clinical answer comfortably fits; Judge caps
 # where the verdict + quoted evidence + optional rewrite fit.
 MAX_TOKENS_DRAFT = 300
-MAX_TOKENS_JUDGE = 600
+# Bumped 2026-04-21 from 600 to 1200 when the Judge schema grew
+# a `claims` array. 3-8 sub-claim entries at ~60 tokens each plus
+# the original fields fit comfortably under 1200 with headroom.
+MAX_TOKENS_JUDGE = 1200
 
 DB_PATH = str(Path.home() / ".merken" / "medlocal_concept.db")
 PROJECT = "medlocal_concept"
@@ -142,21 +145,50 @@ def _cerebras_client():
 
 
 def cerebras_chat(model: str, messages: list[dict], max_tokens: int) -> tuple[str, float, dict]:
-    """Return (text, wall_seconds, usage). Bubbles SDK exceptions up.
+    """Return (text, wall_seconds, usage). Bubbles SDK exceptions up
+    after a short retry window.
+
+    Cerebras intermittently returns 503 ``queue_exceeded`` under
+    load. A smoke run that fires 2 calls per question times N
+    questions has a non-trivial probability of hitting one. Retry
+    up to 3 times with exponential backoff (2s, 4s, 8s) so a
+    single transient 503 does not lose all the tokens spent
+    earlier in the run. Persistent 5xx still bubbles up.
 
     ``usage`` is a dict of prompt_tokens / completion_tokens /
     total_tokens taken from ``resp.usage`` when Cerebras populates
     it. Empty dict when the SDK response omits the field, so the
     caller can sum defensively.
     """
+    from cerebras.cloud.sdk import InternalServerError
+
     client = _cerebras_client()
     t0 = time.perf_counter()
-    resp = client.chat.completions.create(
-        model=model,
-        messages=messages,
-        max_tokens=max_tokens,
-        temperature=0.3,
-    )
+    last_err: Exception | None = None
+    for attempt in range(3):
+        try:
+            resp = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=0.3,
+            )
+            break
+        except InternalServerError as exc:
+            last_err = exc
+            # 5xx on the last attempt -> let it bubble; the caller
+            # already has the partial run state it needs.
+            if attempt == 2:
+                raise
+            backoff = 2 ** (attempt + 1)
+            print(
+                f"    cerebras 5xx (attempt {attempt+1}/3), "
+                f"backing off {backoff}s: {exc}"
+            )
+            time.sleep(backoff)
+    else:  # pragma: no cover -- the break above covers the success path
+        if last_err is not None:
+            raise last_err
     dt = time.perf_counter() - t0
     usage = {}
     u = getattr(resp, "usage", None)
@@ -211,33 +243,75 @@ def _extract_json_object(raw: str) -> dict:
 # applies to both clinical and personal runs.
 JUDGE_SYSTEM_TEMPLATE = (
     "{domain_frame}\n\n"
+    "Each excerpt header carries retrieval signals from the memory "
+    "store: `score` is an RRF-family relevance score (higher = more "
+    "relevant; typical range 0.005-0.030 on this corpus); `layer` "
+    "is the memory layer tag (episodic = raw, brief/semantic = "
+    "distilled). Prefer grounding your verdict in high-score and "
+    "distilled-layer excerpts when multiple candidates touch the "
+    "same claim. These are hints, not hard cutoffs.\n\n"
     "Your job in ONE JSON response:\n"
     "  1. decide the verdict of the draft against the excerpts.\n"
     "  2. if contradicts, produce the corrected answer using only "
-    "     information grounded in the excerpts.\n\n"
+    "     information grounded in the excerpts.\n"
+    "  3. decompose the final rendered answer (the corrected_text "
+    "     if verdict=contradicts, otherwise the draft) into atomic "
+    "     sub-claims and verify EACH one against the excerpts.\n\n"
     "Respond ONLY with a JSON object:\n"
     "{{\n"
     '  "has_claim": bool,              // draft contains a verifiable factual claim?\n'
     '  "verdict": "supports"|"contradicts"|"neutral"|"no_claim",\n'
     '  "cited_excerpt_ids": [int, ...], // 0-based indices into excerpts\n'
     '  "quoted_evidence": "...",       // verbatim sentence(s) from the excerpts\n'
-    '  "corrected_text": "..."         // required iff verdict=contradicts; empty otherwise\n'
+    '  "corrected_text": "...",        // required iff verdict=contradicts; empty otherwise\n'
+    '  "claims": [                    // per sub-claim verification; see Rules below\n'
+    "    {{\n"
+    '      "text": "...",             // the atomic sub-claim as a short sentence\n'
+    '      "verdict": "supports"|"contradicts"|"neutral",\n'
+    '      "supporting_excerpt_id": int|null, // 0-based index, or null when neutral/contradicts\n'
+    '      "quoted_evidence": "..."   // verbatim substring from that excerpt; "" when neutral\n'
+    "    }}\n"
+    "  ]\n"
     "}}\n\n"
-    "Rules:\n"
-    "- supports: some excerpt VERBATIM matches the draft. Fill "
-    "cited_excerpt_ids + quoted_evidence. Leave corrected_text empty.\n"
+    "Rules (top-level verdict):\n"
+    "- supports: some excerpt VERBATIM matches the draft's top-line "
+    "answer. Fill cited_excerpt_ids + quoted_evidence. Leave "
+    "corrected_text empty.\n"
     "- contradicts: some excerpt contradicts the draft. Fill all "
     "fields; corrected_text is the final user-facing answer.\n"
     "- neutral: excerpts do not cover the claim. Leave cited_excerpt_ids "
     "[] and quoted_evidence \"\".\n"
     "- no_claim: draft has no verifiable factual claim.\n\n"
+    "Rules (claims array -- applies when has_claim=true):\n"
+    "- Decompose the FINAL rendered answer into 3-8 atomic "
+    "sub-claims. 'Final rendered answer' = corrected_text when "
+    "verdict=contradicts, draft otherwise. **Do NOT include any "
+    "statements that appear only in the draft when a "
+    "corrected_text is present** -- the draft is the rejected "
+    "version; only the corrected_text is user-facing.\n"
+    "- Atomic means one specific fact per sub-claim (e.g. 'start "
+    "co-trimoxazole prophylaxis' and 'CD4 threshold is 200' are "
+    "two separate sub-claims).\n"
+    "- For each sub-claim, emit verdict/supporting_excerpt_id/"
+    "quoted_evidence using the SAME verbatim-substring rule as the "
+    "top-level quoted_evidence.\n"
+    "- If a sub-claim's verdict is 'contradicts', quoted_evidence "
+    "must be a verbatim substring of the excerpt it contradicts.\n"
+    "- If verdict is 'neutral' for a sub-claim, "
+    "supporting_excerpt_id = null and quoted_evidence = \"\".\n"
+    "- claims may be [] when has_claim=false.\n\n"
     "HARD RULES (enforce every time):\n"
-    "- quoted_evidence MUST be a substring of one excerpt. If you "
-    "cannot find verbatim supporting evidence in the excerpts, "
-    "verdict = 'neutral'. Do NOT synthesise evidence from your "
-    "own general knowledge.\n"
+    "- quoted_evidence (top-level AND per-claim) MUST be a substring "
+    "of one excerpt. If you cannot find verbatim supporting evidence "
+    "in the excerpts, verdict = 'neutral'. Do NOT synthesise evidence "
+    "from your own general knowledge.\n"
     "- corrected_text MUST only contain claims grounded in "
     "quoted_evidence. Keep it to <= 120 words, numbered points ok.\n"
+    "- The 'claims' array is the lever that makes answer-level "
+    "verdicts honest. A 'supports' top-level verdict that ALSO has "
+    "sub-claims with verdict=contradicts means the top-line is "
+    "correct but the body drifts from the source -- emit that "
+    "faithfully, do NOT hide the drift.\n"
     "- No prose outside the JSON. No markdown fences."
 )
 
@@ -291,15 +365,18 @@ JUDGE_SYSTEM = JUDGE_SYSTEM_TEMPLATE.format(domain_frame=DOMAIN_FRAMES["clinical
 
 
 def judge_once(
-    question: str, draft: str, excerpts: list[tuple[str, str]],
+    question: str, draft: str, excerpts: list[dict],
 ) -> tuple[dict, float, dict]:
     """One Judge call that performs detect + verify + rewrite in
     a single pass. Returns (parsed_json, wall_s, usage_dict).
 
-    ``excerpts`` is a list of ``(source_id, text)`` so the Judge
-    can cite sources by their memory tag rather than by ephemeral
-    index alone. Indices remain 0-based in cited_excerpt_ids; the
-    source_id is carried through into the deterministic annotator.
+    ``excerpts`` is a list of dicts (see ``retrieve``) carrying
+    text plus the vstash signals (score, layer, ...). The Judge
+    sees each excerpt rendered with a header that exposes those
+    signals so a sub-claim anchored to a high-score excerpt is
+    distinguishable from one anchored to a rank-20 low-score
+    chunk. This is the "glass box" principle -- the Judge
+    decides using information we never invented, only surfaced.
     """
     if not excerpts:
         # No retrieval -> no verification possible. Short-circuit
@@ -311,14 +388,26 @@ def judge_once(
                 "cited_excerpt_ids": [],
                 "quoted_evidence": "",
                 "corrected_text": "",
+                "claims": [],
             },
             0.0,
             {},
         )
-    joined = "\n---\n".join(
-        f"[excerpt {i} | source={src}]\n{text}"
-        for i, (src, text) in enumerate(excerpts)
-    )
+    joined_parts = []
+    for i, e in enumerate(excerpts):
+        src = e.get("source_id", "memory")
+        score = e.get("score")
+        layer = e.get("layer") or "unknown"
+        # Score is an RRF-family float; round to 4dp so the Judge
+        # doesn't fixate on spurious precision. The literal string
+        # "none" flags missing scores without collapsing to 0.0.
+        score_str = f"{score:.4f}" if isinstance(score, (int, float)) else "none"
+        header = (
+            f"[excerpt {i} | source={src} | score={score_str} "
+            f"| layer={layer}]"
+        )
+        joined_parts.append(f"{header}\n{e.get('text', '')}")
+    joined = "\n---\n".join(joined_parts)
     user = (
         f"Question:\n{question}\n\n"
         f"Draft response:\n{draft}\n\n"
@@ -345,7 +434,13 @@ def judge_once(
             "cited_excerpt_ids": [],
             "quoted_evidence": "",
             "corrected_text": "",
+            "claims": [],
         }
+    # Ensure every returned judgment has the claims field so the
+    # annotator does not need to None-guard it. Older stored logs
+    # predate this field -- leaving it absent there is fine (the
+    # annotator treats missing as []).
+    parsed.setdefault("claims", [])
     return parsed, dt, usage
 
 
@@ -380,10 +475,45 @@ def _draft_is_refusal(draft: str) -> bool:
     return any(m in lower for m in REFUSAL_MARKERS)
 
 
+def _claims_warning(claims: list[dict]) -> str:
+    """If any sub-claim has verdict=contradicts or neutral, emit a
+    warning section listing them. Empty string when all sub-claims
+    are grounded.
+
+    The warning is appended AFTER the primary provenance footer so
+    the consumer sees top-line attribution first, then the per-
+    sub-claim caveats. This preserves the reading-path for the
+    happy case (all sub-claims supported -> no warning at all) and
+    makes the drift loud when it exists.
+    """
+    if not claims:
+        return ""
+    unsupported = [
+        c for c in claims
+        if isinstance(c, dict) and c.get("verdict") in ("contradicts", "neutral")
+    ]
+    if not unsupported:
+        return ""
+    lines = [f"\n\n>> [{len(unsupported)} sub-claim(s) not grounded in memory]"]
+    for c in unsupported:
+        v = c.get("verdict", "?")
+        text = (c.get("text") or "").strip().replace("\n", " ")
+        text = (text[:120] + "...") if len(text) > 120 else text
+        if v == "contradicts":
+            ev = (c.get("quoted_evidence") or "").strip()
+            ev_short = (ev[:120] + "...") if len(ev) > 120 else ev
+            lines.append(f">>   contradicted: {text!r}")
+            if ev_short:
+                lines.append(f">>     source says: \"{ev_short}\"")
+        else:
+            lines.append(f">>   unsupported: {text!r}")
+    return "\n".join(lines)
+
+
 def annotate_deterministic(
     draft: str,
     judgment: dict,
-    excerpts: list[tuple[str, str]],
+    excerpts: list[dict],
 ) -> str:
     """Assemble the final user-facing response with provenance
     footer. Zero extra LLM calls.
@@ -400,6 +530,14 @@ def annotate_deterministic(
     - neutral / no_claim / no_retrieval: draft + [generated, no
       memory coverage] footer.
 
+    Regardless of top-level verdict, if the Judge returned a
+    ``claims`` array with any sub-claim whose verdict is
+    ``contradicts`` or ``neutral``, a second warning section is
+    appended listing those unsupported sub-claims. This is the
+    lever that closes the answer-level-correct / claim-level-
+    leaky gap surfaced on 2026-04-21 (cotrimoxazole threshold
+    <200 vs <350, consolidation threshold 0.65 vs 0.70).
+
     The footer is a single-line marker so the downstream consumer
     can grep for it or strip it. An inline-per-sentence annotation
     would need another LLM call; the per-question footer gives the
@@ -408,13 +546,16 @@ def annotate_deterministic(
     verdict = judgment.get("verdict", "neutral")
     cited_ids = judgment.get("cited_excerpt_ids") or []
     quoted = (judgment.get("quoted_evidence") or "").strip()
+    claims = judgment.get("claims") or []
 
     def _cite_sources() -> str:
         srcs = []
         for i in cited_ids:
             if isinstance(i, int) and 0 <= i < len(excerpts):
-                srcs.append(excerpts[i][0])
+                srcs.append(excerpts[i].get("source_id", "memory"))
         return ", ".join(srcs) if srcs else "unknown"
+
+    claims_note = _claims_warning(claims)
 
     if verdict == "contradicts":
         body = (judgment.get("corrected_text") or draft).strip()
@@ -423,7 +564,7 @@ def annotate_deterministic(
             f"\n\n>> [corrected from prior draft: {_cite_sources()}]"
             f"\n>> quoted evidence: \"{quoted_short}\""
         )
-        return body + footer
+        return body + footer + claims_note
 
     if verdict == "supports":
         quoted_short = (quoted[:200] + "...") if len(quoted) > 200 else quoted
@@ -435,18 +576,20 @@ def annotate_deterministic(
                 f"\n\n>> [recovered from uncertain draft: {_cite_sources()}]"
                 f"\n>> quoted evidence: \"{quoted_short}\""
             )
-            return body + footer
+            return body + footer + claims_note
         footer = (
             f"\n\n>> [confirmed: {_cite_sources()}]"
             f"\n>> quoted evidence: \"{quoted_short}\""
         )
-        return draft.strip() + footer
+        return draft.strip() + footer + claims_note
 
     if verdict == "no_claim":
-        return draft.strip() + "\n\n>> [no verifiable claim]"
+        return draft.strip() + "\n\n>> [no verifiable claim]" + claims_note
 
     # neutral, no_retrieval, or fail-closed fallback
-    return draft.strip() + "\n\n>> [generated, no memory coverage]"
+    return (
+        draft.strip() + "\n\n>> [generated, no memory coverage]" + claims_note
+    )
 
 
 # --------------------------------------------------------------- seed
@@ -489,8 +632,25 @@ def retrieve(
     top_k: int = 5,
     *,
     retrieval_mode: str = "hybrid",
-) -> list[tuple[str, str]]:
-    """Return list of (source_id, text).
+) -> list[dict]:
+    """Return an excerpt pool as a list of dicts, each carrying the
+    text plus every vstash signal we currently propagate:
+
+      {
+        "source_id": str,
+        "text":      str,
+        "score":     float | None,    # RRF score when available
+        "layer":     str   | None,    # vstash layer tag
+        "chunk_id":  str   | None,    # stable id for audit trails
+        "added_at":  str   | None,    # ISO timestamp, freshness signal
+        "collection": str  | None,    # bucket within the db
+      }
+
+    Downstream code (`judge_once`, the audit row) uses these to
+    render a score-aware Judge prompt and to surface retrieval
+    quality in the audit log -- see Silt's rule "before proposing
+    an algorithm, look at the distribution of the data" and the
+    glass-box invariant in the merken CONSTITUTION.
 
     ``retrieval_mode``:
       - ``"hybrid"`` (default): one vstash.search call with the
@@ -564,7 +724,7 @@ def retrieve(
     except Exception as e:
         print(f"    search error for {query[:60]!r}: {e}")
         return []
-    out: list[tuple[str, str]] = []
+    out: list[dict] = []
     seen: set[str] = set()
     for h in hits:
         text = getattr(h, "text", None) or getattr(h, "content", None) or ""
@@ -583,8 +743,52 @@ def retrieve(
             or getattr(h, "tags", None)
             or "memory"
         )
-        out.append((str(src_id), text))
+        # Pull every signal vstash publishes. Missing fields stay
+        # None so downstream code can uniformly treat them as
+        # "unknown" without a KeyError.
+        out.append({
+            "source_id": str(src_id),
+            "text": text,
+            "score": getattr(h, "score", None),
+            "layer": getattr(h, "layer", None),
+            "chunk_id": getattr(h, "chunk_id", None),
+            "added_at": getattr(h, "added_at", None),
+            "collection": getattr(h, "collection", None),
+        })
     return out
+
+
+def retrieval_stats(excerpts: list[dict]) -> dict:
+    """Summarise the excerpt pool for the audit log. No per-query
+    decision is derived from these numbers yet; we surface them so
+    later sessions can spot patterns (e.g. "all neutrals had
+    max_score < 0.012") without re-running everything.
+    """
+    scores = [
+        e.get("score") for e in excerpts
+        if isinstance(e.get("score"), (int, float))
+    ]
+    layers: dict[str, int] = {}
+    for e in excerpts:
+        layer = e.get("layer") or "unknown"
+        layers[layer] = layers.get(layer, 0) + 1
+    if not scores:
+        return {
+            "n_excerpts": len(excerpts),
+            "n_scored": 0,
+            "max_score": None,
+            "min_score": None,
+            "mean_score": None,
+            "layers": layers,
+        }
+    return {
+        "n_excerpts": len(excerpts),
+        "n_scored": len(scores),
+        "max_score": max(scores),
+        "min_score": min(scores),
+        "mean_score": sum(scores) / len(scores),
+        "layers": layers,
+    }
 
 
 def run_one(
@@ -619,21 +823,39 @@ def run_one(
     # not just to the abstract question.
     query = f"{question}\n{draft[:400]}"
     excerpts = retrieve(mem, query, top_k=5, retrieval_mode=retrieval_mode)
+    r_stats = retrieval_stats(excerpts)
+    top_src = excerpts[0].get("source_id") if excerpts else None
     print(
         f"[RETRIEVE] got {len(excerpts)} excerpts"
-        + (f"; top_src={excerpts[0][0]}" if excerpts else "")
+        + (f"; top_src={top_src}" if top_src else "")
+        + (
+            f"; scores[max={r_stats['max_score']:.4f} "
+            f"min={r_stats['min_score']:.4f} "
+            f"mean={r_stats['mean_score']:.4f}]"
+            if r_stats["max_score"] is not None else ""
+        )
     )
 
     # --- stage 3: Judge single call --------------------------------
     judgment, j_dt, j_usage = judge_once(question, draft, excerpts)
+    claims = judgment.get("claims") or []
+    bad_claims = [
+        c for c in claims
+        if isinstance(c, dict) and c.get("verdict") in ("contradicts", "neutral")
+    ]
     print(
         f"[JUDGE | {j_dt:.2f}s | tok={j_usage.get('total_tokens', '?')}] "
         f"has_claim={judgment.get('has_claim')} "
         f"verdict={judgment.get('verdict')} "
-        f"cited={judgment.get('cited_excerpt_ids')}"
+        f"cited={judgment.get('cited_excerpt_ids')} "
+        f"sub_claims={len(claims)} unsupported={len(bad_claims)}"
     )
     if judgment.get("verdict") == "contradicts":
         print(f"         corrected_text: {judgment.get('corrected_text', '')[:180]}...")
+    for c in bad_claims:
+        v = c.get("verdict", "?")
+        text = (c.get("text") or "")[:100]
+        print(f"         sub-claim {v}: {text!r}")
 
     # --- stage 4: deterministic annotation (no LLM) ----------------
     final = annotate_deterministic(draft, judgment, excerpts)
@@ -643,6 +865,14 @@ def run_one(
     # Audit-ready row: every Mode A run IS a labeled training example.
     # The builder / judge identifiers + timestamp let downstream
     # trainers slice by model version and freshness.
+    #
+    # `retrieved` now carries every vstash signal (score, layer,
+    # chunk_id, added_at, collection) per excerpt so downstream
+    # training code can build features on retrieval quality
+    # without re-running the pipeline. `retrieval_stats` is the
+    # per-query summary for fast pandas-style filtering.
+    # `judgment.claims` is the per-sub-claim label array (the
+    # claim-level ground truth for a sub-claim classifier).
     return {
         "audit_id": uuid.uuid4().hex[:12],
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -652,7 +882,8 @@ def run_one(
         "draft": draft,
         "draft_s": b_dt,
         "draft_usage": b_usage,
-        "retrieved": [{"source_id": s, "text": t} for s, t in excerpts],
+        "retrieved": excerpts,
+        "retrieval_stats": r_stats,
         "judgment": judgment,
         "judge_s": j_dt,
         "judge_usage": j_usage,
@@ -660,6 +891,8 @@ def run_one(
         "total_tokens": total_tokens,
         "verdict": judgment.get("verdict"),
         "fired": judgment.get("verdict") == "contradicts",
+        "n_sub_claims": len(claims),
+        "n_sub_claims_unsupported": len(bad_claims),
     }
 
 


### PR DESCRIPTION
## Summary

Closes two related gaps surfaced in PR #32's results:

1. **Answer-level vs claim-level verification** (Run 5a cotrimoxazole). Judge marked the Builder's \"start prophylaxis for CD4=180\" as `supports` even though the Builder said CD4 <200 and the cited chunk said CD4 <350. Top-line correct, sub-claim wrong.
2. **vstash signals discarded**. `SearchResult` publishes `score`, `layer`, `chunk_id`, `added_at`, `collection`; prior pipeline used only `text` + `title`. Missed feature surface for future training + no per-excerpt calibration hint for the Judge.

## What changed

- **Claim-level schema (Architecture A++).** Judge now emits a `claims: [...]` array alongside the existing top-level verdict, one entry per atomic sub-claim of the FINAL rendered answer. Same verbatim-substring rule applies per sub-claim. `annotate_deterministic` appends a warning section when any sub-claim is `contradicts` or `neutral`. `MAX_TOKENS_JUDGE` bumped 600 -> 1200.
- **vstash signal surfacing.** `retrieve()` now returns `list[dict]` with every signal vstash publishes. Judge excerpt headers render `[excerpt N | source=X | score=0.0167 | layer=episodic]`. Audit row gains `retrieval_stats` and `n_sub_claims / n_sub_claims_unsupported` so the v4 run ledger is labeled training-ready for a future sub-claim classifier or retrieval-quality predictor.
- **Robustness.** `cerebras_chat` retries up to 3x on 5xx `queue_exceeded` with exponential backoff (2s, 4s, 8s). Smoke runs were losing whole sessions to transient Cerebras 503s.

## A/B results (Run 7 vs Run 5)

Clinical + confident + dual-3:

| qid | v3 verdict | v4 verdict | claims / unsupported |
|---|---|---|---|
| severe_dehydration_child | contradicts | contradicts | 6 / 0 |
| severe_pneumonia_infant | contradicts | contradicts | 5 / 0 |
| postpartum_hemorrhage_txa | supports | supports | 5 / 0 |
| **cotrimoxazole_hiv_adult** | **supports** | **contradicts** | **3 / 0** |
| blood_donor_screening | supports | contradicts | 6 / 3 |

Cotrimoxazole flip is the direct test pass: the answer-level-supports / claim-level-contradicts case now renders `contradicts` with a `corrected_text` that preserves the <350 threshold verbatim.

Personal + confident + dual-3: 5/5 grounded, 0 unsupported across all 5. Claim-level does NOT introduce false positives on a domain where the prior pipeline was already clean.

Consolidation-threshold case: still `contradicts`, now 5/5 sub-claims grounded. Claim-level rigor discouraged the Judge from grabbing the tangential 0.65 chunk that v3 cited, while v4 threads the correct 0.70.

## Cost

| metric | v3 (dual-3) | v4 (claim-level) | delta |
|---|---|---|---|
| clinical avg tok/q | 12712 | 14620 | +1908 (+15%) |
| personal avg tok/q | 7677 | 8904 | +1226 (+16%) |

Overhead is entirely Judge completion (3-8 `claims` entries at ~60 tokens each) + ~150 extra tokens of system prompt. Wall time stays under 2s/q.

## Retrieval signals first pass

Medlocal sees all excerpts at max_score=0.0167 (the adaptive-RRF ceiling) with mean clustering at ~0.015. Layer is `unknown` across clinical (layer tagging not set at seed time) and mostly `episodic` in the engram vstash. Distribution is narrow enough that no immediate decision rule is derived; foundation for a future retrieval-quality policy once more corpora accumulate.

## Test plan

- [ ] `python experiments/midloop_concept/medlocal/cerebras_midloop.py run --domain clinical --builder-mode confident --retrieval-mode dual` reproduces the cotrimoxazole flip + blood_donor sub-claim warnings (~\$1-2 Cerebras spend).
- [ ] `python experiments/midloop_concept/medlocal/cerebras_midloop.py run --domain personal --builder-mode confident --retrieval-mode dual` reproduces 5/5 grounded with 0 unsupported sub-claims.
- [ ] Existing tests / 4 unit cases for `annotate_deterministic` still pass (inline in the commit message).
- [ ] Ruff clean on the whole edited file.

## Next moves (not in this PR)

- Long-splice + chat-template probe for Mode C (Move 3 scale).
- Cost optimisation: full-text hash dedup, score-threshold cutoff, mini-rerank before Judge.
- Retrieval-signal policy layer once calibration across multiple corpora is available.