### PR TITLE
feat(longmemeval): honest Mode A answer-quality eval (N=49) -- TIE with RAG

### DIFF
--- a/experiments/midloop_concept/medlocal/cerebras_midloop.py
+++ b/experiments/midloop_concept/medlocal/cerebras_midloop.py
@@ -754,7 +754,26 @@ def retrieve(
         text = getattr(h, "text", None) or getattr(h, "content", None) or ""
         if not text:
             continue
-        key = text[:120]
+        # Dedup key. Previously ``text[:120]`` which collides on
+        # conversational haystacks (LongMemEval turns like
+        # ``"user: hi, how are you"`` / ``"user: hi, how are you
+        # doing today?"`` share the same 120-char prefix), silently
+        # dropping distinct excerpts. Fix 2026-04-21: prefer
+        # vstash's ``chunk_id`` (the authoritative per-chunk id)
+        # when it's on the SearchResult; fall back to the full-
+        # content tuple (source_id + full text) so we never alias
+        # two different rows on any prefix.
+        chunk_id = getattr(h, "chunk_id", None)
+        if chunk_id is not None:
+            key = f"chunk:{chunk_id}"
+        else:
+            src_raw = (
+                getattr(h, "title", None)
+                or getattr(h, "document_title", None)
+                or getattr(h, "tags", None)
+                or ""
+            )
+            key = f"hash:{src_raw}::{text}"
         if key in seen:
             continue
         seen.add(key)

--- a/experiments/midloop_concept/medlocal/cerebras_midloop.py
+++ b/experiments/midloop_concept/medlocal/cerebras_midloop.py
@@ -35,6 +35,7 @@ side report to stdout + a structured JSON log at
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import sys
@@ -773,13 +774,24 @@ def retrieve(
         if chunk_id is not None:
             key = f"chunk:{chunk_id}"
         else:
+            # Fallback when vstash does not publish chunk_id on this
+            # SearchResult: digest the (source, text) pair so the
+            # dedup set stays bounded in memory regardless of
+            # excerpt length. Full-content concat was O(total_text)
+            # per key and labelled "hash:" without actually hashing
+            # (bot review flagged both issues). blake2s over the
+            # composed bytes is ~microseconds and 32 bytes per key.
             src_raw = (
                 getattr(h, "title", None)
                 or getattr(h, "document_title", None)
                 or getattr(h, "tags", None)
                 or ""
             )
-            key = f"hash:{src_raw}::{text}"
+            digest = hashlib.blake2s(
+                f"{src_raw}::{text}".encode("utf-8", "replace"),
+                digest_size=16,
+            ).hexdigest()
+            key = f"hash:{digest}"
         if key in seen:
             continue
         seen.add(key)

--- a/experiments/midloop_concept/medlocal/cerebras_midloop.py
+++ b/experiments/midloop_concept/medlocal/cerebras_midloop.py
@@ -144,7 +144,13 @@ def _cerebras_client():
     return Cerebras()
 
 
-def cerebras_chat(model: str, messages: list[dict], max_tokens: int) -> tuple[str, float, dict]:
+def cerebras_chat(
+    model: str,
+    messages: list[dict],
+    max_tokens: int,
+    *,
+    temperature: float = 0.3,
+) -> tuple[str, float, dict]:
     """Return (text, wall_seconds, usage). Bubbles SDK exceptions up
     after a short retry window.
 
@@ -182,7 +188,7 @@ def cerebras_chat(model: str, messages: list[dict], max_tokens: int) -> tuple[st
                 model=model,
                 messages=messages,
                 max_tokens=max_tokens,
-                temperature=0.3,
+                temperature=temperature,
             )
             break
         except APIStatusError as exc:

--- a/experiments/retrieval/longmemeval/RESULTS.md
+++ b/experiments/retrieval/longmemeval/RESULTS.md
@@ -143,9 +143,178 @@ with a strikethrough and a link to the correction. We do not silently
 edit history. See `notes/prior-art.md` for the cautionary tale that
 pinned this rule down.
 
-The n ≤ 10 numbers above are **absolute positioning only** — they
+The n <= 10 numbers above are **absolute positioning only** -- they
 cannot support any claim of the form "merken matches X" or "merken
-beats Y." Claims like that require n ≥ 50 with a non-degenerate CI
+beats Y." Claims like that require n >= 50 with a non-degenerate CI
 on the same `longmemeval_s_cleaned` split against the same metric.
 Until such a row exists in this table, the claim does not get made
 anywhere in the repo.
+
+---
+
+## Mode A answer-quality eval (not R@k)
+
+Different question. The table above measures whether retrieval
+surfaces a chunk from the answer session (R@k). `mode_a_eval.py`
+adds a layer: **did we actually give the user a correct answer?**
+That means running a Builder on each question, optionally with
+retrieved chunks, and scoring the final answer against the ground
+truth with an LLM-as-judge. See
+`experiments/retrieval/longmemeval/mode_a_eval.py`.
+
+Three conditions per question:
+
+- **control** -- Builder alone (llama3.1-8b), confident-mode system
+  prompt, no retrieval.
+- **rag** -- Builder with top-5 retrieved chunks (3-way dual
+  retrieval, same as Mode A) inlined into the user prompt. No
+  Judge.
+- **mode_a** -- full Mode A v4 pipeline (draft + dual-3 retrieval
+  + claim-level Judge + deterministic annotator + provenance
+  footer).
+
+Oracle: Gemini 2.5 Flash scores `(question, ground_truth, answer)`
+triples as `supports | partial | contradicts | neutral`. Correct =
+`supports + partial`. Different model family from the
+Builder/Judge on purpose, to avoid intra-family bias.
+
+### Run 1 (2026-04-21) -- N=49 / seed 42 / longmemeval_s
+
+Commit: `ccf6ce2` base (Mode A v4, PR #33 merged) + this branch's
+eval harness. One question hit an `APIConnectionError` from
+Cerebras and was logged as an error row rather than breaking the
+loop (per-question try/except working as intended).
+
+#### Headline
+
+| condition | correct | supports | partial | contradicts | neutral | avg_tok | avg_s |
+|---|---|---|---|---|---|---|---|
+| control | **8.2%** (4/49) | 1 | 3 | 3 | 42 | 288 | 0.7 |
+| rag | **71.4%** (35/49) | 30 | 5 | 9 | 5 | 2210 | 1.4 |
+| mode_a | **71.4%** (35/49) | 33 | 2 | 7 | 7 | 8759 | 5.3 |
+
+**RAG and Mode A tie on top-line correctness.** Mode A is NOT
+better than naive RAG on these 49 questions. Mode A costs ~4x
+the tokens and ~4x the wall time for equal correctness.
+
+Mode A telemetry:
+- **Grounded (verbatim `quoted_evidence` present): 40/49 = 81.6%.**
+  This is the value Mode A buys over RAG -- every answer with a
+  cite-able source trail.
+- Claim-level leak (>=1 unsupported sub-claim): 5/49 = 10.2%.
+- Sub-claims total: 125, of which 14 = 11.2% are unsupported.
+- Judge top-level verdict distribution: contradicts 40 / no_claim
+  5 / neutral 4. Mode A overrode the Builder draft in 82% of
+  cases.
+
+#### By question_type
+
+| type | n | control | rag | mode_a | delta (mode_a - rag) |
+|---|---|---|---|---|---|
+| knowledge-update | 7 | 0% | 57% | **71%** | **+14pp** |
+| multi-session | 17 | 12% | 65% | 65% | 0 |
+| single-session-assistant | 3 | 0% | 100% | 100% | 0 |
+| single-session-preference | 2 | 100% | 50% | 50% | 0 (n=2, noise) |
+| single-session-user | 9 | 0% | 100% | 100% | 0 |
+| temporal-reasoning | 11 | 0% | 64% | 55% | **-9pp** |
+
+**Mode A wins on `knowledge-update`** (facts that evolve across
+sessions, where the later assertion corrects the earlier one).
+The Judge / claim-level rigor picks the right chunk instead of
+averaging across contradictory ones.
+
+**Mode A loses on `temporal-reasoning`** (questions that need
+arithmetic or time-window reasoning). The Judge refuses when it
+should have answered, or the Builder's arithmetic fails and Mode
+A doesn't catch it.
+
+Trivial lookups (`single-session-*`) are 100% for both -- they
+are solved at the retrieval layer.
+
+#### RAG vs Mode A disagreements (4 wins each; cases visible in log)
+
+Mode A wins the cases that need **aggregation across multiple
+chunks**:
+- "money raised for charity total" (GT $3,750): RAG listed items,
+  Mode A summed them.
+- "rollercoasters across events July-October" (GT 10): RAG
+  enumerated without totaling, Mode A aggregated.
+- "engineers I lead (before / now)" (GT 4 / 5): RAG got cut off
+  mid-sentence, Mode A produced a clean both-numbers answer.
+- "book discount %" (GT 20%): RAG said "not mentioned", Mode A
+  retrieved it correctly.
+
+RAG wins the cases where **Mode A over-refuses or mis-aggregates**:
+- "how many projects led" (GT 2): RAG guessed "at least one",
+  Mode A refused entirely ("I don't have information...").
+- "total $ from markets" (GT $495): Mode A summed but got $595.
+  The Judge's arithmetic produced a wrong corrected_text.
+- "sports event 2 weeks ago": RAG got partial credit, Mode A
+  refused. Temporal reasoning weakness.
+
+#### Caveats (code-reviewer pass before the run flagged these)
+
+1. **Same dedup bug on both conditions.** `retrieve()` in this
+   run used a 120-char prefix as dedup key. Conversational turns
+   with identical prefixes (`"user: "`, `"assistant: "`) alias and
+   drop distinct excerpts. Both RAG and Mode A hit this
+   identically, so the A/B is still fair, but the absolute
+   numbers under-represent what a bug-free retrieval could
+   deliver. Fix landed on the same branch for Run 2.
+2. **Control uses `confident` builder mode.** The Builder is told
+   not to hedge. Refusals still dominate (42/49 = 86% control
+   neutral) because the model genuinely lacks the personal
+   information. But on the 7 non-refusal controls, the confident
+   prompt pushes toward confabulation -- which the oracle scores
+   as `contradicts`. Mostly this makes control look worse.
+3. **RAG uses question-only query; Mode A uses question + draft
+   query.** Two retrieval pools differ. Mode A's draft expansion
+   can fetch chunks RAG would miss (knowledge-update advantage)
+   OR noisy chunks RAG would skip.
+4. **RAG truncates each excerpt to 800 chars** before inlining;
+   Mode A's Judge sees the full excerpt text. If an answer lives
+   past char 800 in a long chunk, RAG misses it. At N=49 this did
+   not dominate the comparison but is a source of residual bias.
+
+#### What this supports (conservative)
+
+- Mode A at v4 **does not improve top-line correctness** over a
+  naive inlined-context RAG baseline on LongMemEval_s at N=49.
+- Mode A **does improve auditability**: 81.6% of answers carry
+  a verbatim source quote; all answers carry the source_id and
+  claim-level decomposition in the audit row.
+- Mode A **has a real edge on `knowledge-update` questions**
+  (+14pp over RAG) and a real weakness on `temporal-reasoning`
+  (-9pp).
+
+#### What this does NOT support
+
+- That Mode A is production-ready as a drop-in replacement for
+  RAG. Same correctness at 4x cost is a negative trade unless
+  the auditability / grounded-source property is worth the
+  premium.
+- That the 4x token cost buys nothing -- it buys the grounded
+  evidence trail, which is invisible in "did the oracle say
+  supports?" but central to the "verifiable truth with source"
+  thesis.
+- That temporal-reasoning regressions are unfixable -- the
+  Judge's arithmetic behavior and over-refusal rate are both
+  tunable.
+
+### Next moves (surfaced by this run)
+
+- **Rerun with dedup fix (Run 2)**, same seed, same N. Measure
+  whether both conditions move together (expected) or whether
+  Mode A recovers ground vs RAG (less expected but possible).
+- **Tune Judge for temporal questions.** The `-9pp` on
+  temporal-reasoning comes mostly from over-refusal. A prompt
+  that lets the Judge emit `contradicts` when arithmetic can
+  be inferred from excerpts (rather than demanding a verbatim
+  quote for the computed answer) would likely recover several
+  points.
+- **Token-cost levers.** 4x is steep. Cost profiling on the v1
+  audit rows: excerpts dominate the Judge input. Score-threshold
+  cutoff + hash-dedup (the latter already shipped) should cut
+  ~20-30%.
+- **Graduate to N=100 or N=500** once the cost and Judge tuning
+  stabilise. Current N=49 gives a direction but CIs are wide.

--- a/experiments/retrieval/longmemeval/analyze_mode_a_eval.py
+++ b/experiments/retrieval/longmemeval/analyze_mode_a_eval.py
@@ -143,7 +143,13 @@ def mode_a_specifics(rows: list[dict]) -> str:
         jud = ma.get("judgment", {})
         if (jud.get("quoted_evidence") or "").strip():
             grounded += 1
-        claims = jud.get("claims") or []
+        # Defensive: a malformed model response could emit
+        # non-dict items inside ``claims`` (e.g. a bare string).
+        # Skip anything that isn't a dict rather than crashing on
+        # ``.get`` below -- keeps the analyser robust across old /
+        # stored logs with slightly different shapes.
+        raw_claims = jud.get("claims") or []
+        claims = [c for c in raw_claims if isinstance(c, dict)]
         bad = sum(1 for c in claims if c.get("verdict") in ("contradicts", "neutral"))
         if bad > 0:
             with_leak += 1

--- a/experiments/retrieval/longmemeval/analyze_mode_a_eval.py
+++ b/experiments/retrieval/longmemeval/analyze_mode_a_eval.py
@@ -1,0 +1,206 @@
+"""Post-hoc analyser for ``mode_a_eval.py`` runs.
+
+The eval script prints a top-line summary but the audit JSONL has
+far more signal (per-question-type breakdown, token economics,
+disagreement cases where conditions diverge, claim-level specifics).
+This script produces a RESULTS.md-ready report without re-running
+anything -- it is pure JSONL read + pandas-style aggregation.
+
+Run:
+  python -m experiments.retrieval.longmemeval.analyze_mode_a_eval \\
+      experiments/retrieval/longmemeval/mode_a_eval_runs/n50_seed42.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+VERDICTS = ("supports", "partial", "contradicts", "neutral")
+CONDITIONS = ("control", "rag", "mode_a")
+
+
+def _correct(v: str) -> bool:
+    return v in ("supports", "partial")
+
+
+def _load(path: Path) -> list[dict]:
+    rows = []
+    for line in path.read_text().splitlines():
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        if "error" in r:
+            # Skip error rows from the summary; they're logged for
+            # debugging but do not count toward correct-rate.
+            continue
+        rows.append(r)
+    return rows
+
+
+def headline_table(rows: list[dict]) -> str:
+    n = len(rows)
+    lines = [f"## Headline (N={n})\n"]
+    header = (
+        "| condition | correct | supports | partial | contradicts | "
+        "neutral | avg_tok | avg_s |"
+    )
+    sep = "|---|---|---|---|---|---|---|---|"
+    lines.extend([header, sep])
+    for cond in CONDITIONS:
+        verdicts = [r["conditions"][cond]["oracle"]["verdict"] for r in rows]
+        toks = [int(r["conditions"][cond].get("total_tokens") or 0) for r in rows]
+        walls = [float(r["conditions"][cond].get("_total_s") or 0) for r in rows]
+        s = verdicts.count("supports")
+        p = verdicts.count("partial")
+        c = verdicts.count("contradicts")
+        nt = verdicts.count("neutral")
+        lines.append(
+            f"| {cond} | {(s+p)/n*100:.1f}% ({s+p}/{n}) | {s} | {p} | "
+            f"{c} | {nt} | {sum(toks)//n} | {sum(walls)/n:.1f}s |"
+        )
+    return "\n".join(lines)
+
+
+def by_question_type(rows: list[dict]) -> str:
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for r in rows:
+        grouped[r.get("question_type") or "unknown"].append(r)
+    lines = ["\n## Correct rate by question_type\n"]
+    lines.append("| question_type | n | control | rag | mode_a |")
+    lines.append("|---|---|---|---|---|")
+    for qt, qrows in sorted(grouped.items()):
+        n = len(qrows)
+        pcts = {}
+        for cond in CONDITIONS:
+            ok = sum(1 for r in qrows if _correct(r["conditions"][cond]["oracle"]["verdict"]))
+            pcts[cond] = f"{ok/n*100:.0f}% ({ok}/{n})"
+        lines.append(f"| {qt} | {n} | {pcts['control']} | {pcts['rag']} | {pcts['mode_a']} |")
+    return "\n".join(lines)
+
+
+def disagreements(rows: list[dict]) -> str:
+    """Find the cases where mode_a and rag disagreed on correctness.
+    Those are the interesting cells of the confusion matrix.
+    """
+    win_for_mode_a: list[dict] = []
+    win_for_rag: list[dict] = []
+    for r in rows:
+        rag_ok = _correct(r["conditions"]["rag"]["oracle"]["verdict"])
+        ma_ok = _correct(r["conditions"]["mode_a"]["oracle"]["verdict"])
+        if ma_ok and not rag_ok:
+            win_for_mode_a.append(r)
+        elif rag_ok and not ma_ok:
+            win_for_rag.append(r)
+
+    lines = [
+        f"\n## RAG vs Mode A disagreements (out of {len(rows)})\n",
+        f"- Mode A correct, RAG wrong: {len(win_for_mode_a)}",
+        f"- RAG correct, Mode A wrong: {len(win_for_rag)}",
+    ]
+    if win_for_mode_a:
+        lines.append("\n### Mode A wins (where the Judge layer mattered)\n")
+        for r in win_for_mode_a[:10]:
+            qid = r["question_id"]
+            qt = r.get("question_type") or "?"
+            ma = r["conditions"]["mode_a"]
+            rag = r["conditions"]["rag"]
+            rag_v = rag["oracle"]["verdict"]
+            ma_v = ma["oracle"]["verdict"]
+            lines.append(f"- **{qid}** ({qt}): RAG={rag_v}, Mode A={ma_v}")
+            lines.append(f"  - Q: {r['question'][:140]!r}")
+            lines.append(f"  - GT: {r['ground_truth'][:140]!r}")
+            lines.append(f"  - RAG answer: {rag['answer'][:140]!r}")
+            lines.append(f"  - Mode A final (trimmed): {ma['answer'][:140]!r}")
+    if win_for_rag:
+        lines.append("\n### RAG wins (where Mode A over-corrected or refused)\n")
+        for r in win_for_rag[:10]:
+            qid = r["question_id"]
+            qt = r.get("question_type") or "?"
+            ma = r["conditions"]["mode_a"]
+            rag = r["conditions"]["rag"]
+            rag_v = rag["oracle"]["verdict"]
+            ma_v = ma["oracle"]["verdict"]
+            lines.append(f"- **{qid}** ({qt}): RAG={rag_v}, Mode A={ma_v}")
+            lines.append(f"  - Q: {r['question'][:140]!r}")
+            lines.append(f"  - GT: {r['ground_truth'][:140]!r}")
+            lines.append(f"  - RAG answer: {rag['answer'][:140]!r}")
+            lines.append(f"  - Mode A final (trimmed): {ma['answer'][:140]!r}")
+    return "\n".join(lines)
+
+
+def mode_a_specifics(rows: list[dict]) -> str:
+    n = len(rows)
+    grounded = 0
+    with_leak = 0
+    total_claims = 0
+    unsupported_claims = 0
+    judge_verdicts: Counter = Counter()
+    for r in rows:
+        ma = r["conditions"]["mode_a"]
+        jud = ma.get("judgment", {})
+        if (jud.get("quoted_evidence") or "").strip():
+            grounded += 1
+        claims = jud.get("claims") or []
+        bad = sum(1 for c in claims if c.get("verdict") in ("contradicts", "neutral"))
+        if bad > 0:
+            with_leak += 1
+        total_claims += len(claims)
+        unsupported_claims += bad
+        judge_verdicts[jud.get("verdict", "unknown")] += 1
+    lines = ["\n## Mode A telemetry\n"]
+    lines.append(f"- grounded (quoted_evidence present): {grounded}/{n} ({grounded/n*100:.1f}%)")
+    lines.append(
+        f"- claim-level leak (>=1 unsupported sub-claim): "
+        f"{with_leak}/{n} ({with_leak/n*100:.1f}%)"
+    )
+    lines.append(f"- total sub-claims: {total_claims}")
+    lines.append(
+        f"- unsupported sub-claims: {unsupported_claims} "
+        f"({unsupported_claims/max(total_claims,1)*100:.1f}% of all sub-claims)"
+    )
+    lines.append("- Judge top-level verdict distribution:")
+    for v, c in judge_verdicts.most_common():
+        lines.append(f"  - {v}: {c}")
+    return "\n".join(lines)
+
+
+def cost_table(rows: list[dict]) -> str:
+    n = len(rows)
+    lines = ["\n## Cost per question\n"]
+    lines.append("| condition | avg_tokens | avg_wall_s | notes |")
+    lines.append("|---|---|---|---|")
+    for cond in CONDITIONS:
+        toks = [int(r["conditions"][cond].get("total_tokens") or 0) for r in rows]
+        walls = [float(r["conditions"][cond].get("_total_s") or 0) for r in rows]
+        avg_tok = sum(toks) // max(n, 1)
+        avg_wall = sum(walls) / max(n, 1)
+        lines.append(f"| {cond} | {avg_tok} | {avg_wall:.1f}s | |")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("path", type=Path, help="JSONL from mode_a_eval.py")
+    args = p.parse_args()
+
+    rows = _load(args.path)
+    if not rows:
+        print("no completed rows; nothing to analyse")
+        return 1
+
+    report = "\n".join([
+        headline_table(rows),
+        by_question_type(rows),
+        mode_a_specifics(rows),
+        cost_table(rows),
+        disagreements(rows),
+    ])
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/retrieval/longmemeval/analyze_mode_a_eval.py
+++ b/experiments/retrieval/longmemeval/analyze_mode_a_eval.py
@@ -19,7 +19,7 @@ from collections import Counter, defaultdict
 from pathlib import Path
 
 VERDICTS = ("supports", "partial", "contradicts", "neutral")
-CONDITIONS = ("control", "rag", "mode_a")
+CONDITIONS = ("control", "rag", "rag_specific", "rag_specific_cite", "mode_a")
 
 
 def _correct(v: str) -> bool:

--- a/experiments/retrieval/longmemeval/grids/rag_baseline_sweep.yml
+++ b/experiments/retrieval/longmemeval/grids/rag_baseline_sweep.yml
@@ -1,0 +1,42 @@
+# Temperature + top_k sweep on the RAG BASELINE prompt (not
+# rag_specific, which over-prescribed and regressed -20pp in
+# Run 3). The baseline system prompt is:
+#
+#   "Answer the user question using the provided context.
+#    Quote specific numbers or names from the context when
+#    they appear. Keep the answer under 150 words. Do not hedge."
+#
+# Production candidate shape is likely:
+#   - RAG baseline prompt
+#   - temperature 0.0 for determinism
+#   - top_k tuned for the corpus
+#   - cite_footer True for the grounded property
+#
+# Grid: 3 temperatures x 3 top_k = 9 conditions, ~$0.15 on
+# Cerebras + Gemini at N=50.
+#
+#   python -m experiments.retrieval.longmemeval.mode_a_eval \
+#     --grid experiments/retrieval/longmemeval/grids/rag_baseline_sweep.yml \
+#     --subset longmemeval_s --n 50 --seed 42 \
+#     --out experiments/retrieval/longmemeval/mode_a_eval_grids
+
+conditions:
+  # Temperature sweep at top_k=5 (matches Run 1-3 baseline)
+  - {name: rag_t00_k5,     kind: rag, temperature: 0.0, top_k: 5,
+     retrieval_mode: dual, system_prompt: rag_baseline, cite_footer: true}
+  - {name: rag_t01_k5,     kind: rag, temperature: 0.1, top_k: 5,
+     retrieval_mode: dual, system_prompt: rag_baseline, cite_footer: true}
+  - {name: rag_t03_k5,     kind: rag, temperature: 0.3, top_k: 5,
+     retrieval_mode: dual, system_prompt: rag_baseline, cite_footer: true}
+
+  # top_k sweep at temp=0.0 (the stable ceiling)
+  - {name: rag_t00_k1,     kind: rag, temperature: 0.0, top_k: 1,
+     retrieval_mode: dual, system_prompt: rag_baseline, cite_footer: true}
+  - {name: rag_t00_k3,     kind: rag, temperature: 0.0, top_k: 3,
+     retrieval_mode: dual, system_prompt: rag_baseline, cite_footer: true}
+  - {name: rag_t00_k10,    kind: rag, temperature: 0.0, top_k: 10,
+     retrieval_mode: dual, system_prompt: rag_baseline, cite_footer: true}
+
+  # control anchor for reference
+  - {name: control_t00,    kind: control, temperature: 0.0,
+     system_prompt: confident, max_tokens: 300}

--- a/experiments/retrieval/longmemeval/grids/temperature_sweep.yml
+++ b/experiments/retrieval/longmemeval/grids/temperature_sweep.yml
@@ -1,0 +1,37 @@
+# Temperature sweep on the rag_specific production candidate.
+# Same retrieval, same prompt; only temperature varies. Run
+# at N=50 seed 42 to match the legacy comparison.
+#
+# Hypothesis: temp=0.0 gives a stable ceiling (no cross-run
+# variance), temp=0.1 is a middle ground, temp=0.3 is today's
+# default and the source of the Run 1 vs Run 2 flips.
+#
+#   python -m experiments.retrieval.longmemeval.mode_a_eval \
+#     --grid experiments/retrieval/longmemeval/grids/temperature_sweep.yml \
+#     --subset longmemeval_s --n 50 --seed 42 \
+#     --out experiments/retrieval/longmemeval/mode_a_eval_grids
+
+conditions:
+  - name: rag_specific_t00
+    kind: rag
+    temperature: 0.0
+    top_k: 5
+    retrieval_mode: dual
+    system_prompt: rag_specific
+    cite_footer: true
+
+  - name: rag_specific_t01
+    kind: rag
+    temperature: 0.1
+    top_k: 5
+    retrieval_mode: dual
+    system_prompt: rag_specific
+    cite_footer: true
+
+  - name: rag_specific_t03
+    kind: rag
+    temperature: 0.3
+    top_k: 5
+    retrieval_mode: dual
+    system_prompt: rag_specific
+    cite_footer: true

--- a/experiments/retrieval/longmemeval/grids/topk_sweep.yml
+++ b/experiments/retrieval/longmemeval/grids/topk_sweep.yml
@@ -1,0 +1,48 @@
+# Retrieval budget sweep. How many excerpts should the RAG
+# prompt see? Cerebras cost is linear in prompt tokens, so
+# top_k=1 is cheapest but starves the model; top_k=10 is
+# richer but noisy (more distractors). Sweep at fixed temp=0.0
+# + rag_specific prompt so the only variable is retrieval
+# budget.
+#
+# Hypothesis: top_k=3 is the knee -- top_k=1 misses synthesis
+# cases, top_k=10 hurts on ambiguous queries where the pool is
+# saturated with near-misses.
+#
+#   python -m experiments.retrieval.longmemeval.mode_a_eval \
+#     --grid experiments/retrieval/longmemeval/grids/topk_sweep.yml \
+#     --subset longmemeval_s --n 50 --seed 42 \
+#     --out experiments/retrieval/longmemeval/mode_a_eval_grids
+
+conditions:
+  - name: rag_t00_k1
+    kind: rag
+    temperature: 0.0
+    top_k: 1
+    retrieval_mode: dual
+    system_prompt: rag_specific
+    cite_footer: true
+
+  - name: rag_t00_k3
+    kind: rag
+    temperature: 0.0
+    top_k: 3
+    retrieval_mode: dual
+    system_prompt: rag_specific
+    cite_footer: true
+
+  - name: rag_t00_k5
+    kind: rag
+    temperature: 0.0
+    top_k: 5
+    retrieval_mode: dual
+    system_prompt: rag_specific
+    cite_footer: true
+
+  - name: rag_t00_k10
+    kind: rag
+    temperature: 0.0
+    top_k: 10
+    retrieval_mode: dual
+    system_prompt: rag_specific
+    cite_footer: true

--- a/experiments/retrieval/longmemeval/mode_a_eval.py
+++ b/experiments/retrieval/longmemeval/mode_a_eval.py
@@ -1,0 +1,598 @@
+"""Honest Mode A answer-quality eval on LongMemEval.
+
+The existing runner (``runner.py``) measures R@k -- did retrieval
+surface a chunk from the answer session. That is one piece of the
+Mode A pipeline (``retrieve()``) and tells us whether the substrate
+is finding the right chunk, not whether the final user-facing
+answer is correct.
+
+This script extends the eval to answer quality across three
+conditions per question:
+
+  1. ``control`` -- Builder only, no context. Baseline for
+     "what does the small model know unaided?"
+  2. ``rag`` -- Builder + top-k chunks from the SAME dual-3
+     retrieval Mode A uses, inlined into the user prompt. Baseline
+     for "what does the substrate buy us without a Judge?"
+  3. ``mode_a`` -- the full Mode A v4 pipeline: draft + dual-3 +
+     claim-level Judge + deterministic annotator.
+
+Scoring: Gemini 2.5 Flash as LLM-as-judge on
+``(question, ground_truth, candidate)`` triples. The oracle
+model is deliberately a different family (Google) from the
+Builder/Judge (Cerebras) to avoid intra-family bias.
+
+Metrics per condition:
+- ``correct_rate = (supports + partial) / total``
+- Mode A extras: ``grounded_rate`` (fraction with verbatim
+  ``quoted_evidence``), ``claims_unsupported_rate`` (fraction
+  with >= 1 ``contradicts``/``neutral`` sub-claim).
+- ``avg_tokens``, ``avg_wall_s``.
+
+Cost profile (N=50):
+- ~150 Builder calls (cheap, Cerebras).
+- ~50 Judge calls (Mode A only; Cerebras).
+- ~150 oracle calls (Gemini 2.5 Flash; cents).
+- Ingestion is local vstash (no API cost).
+- Budget estimate: ~\\$5-15 total.
+
+Run:
+  python -m experiments.retrieval.longmemeval.mode_a_eval \\
+      --subset longmemeval_s --n 3 --seed 42    # preview
+  python -m experiments.retrieval.longmemeval.mode_a_eval \\
+      --subset longmemeval_s --n 50 --seed 42   # full
+
+Output: one JSONL row per (question, condition) plus a printed
+summary table. Each row carries everything needed to reconstruct
+the decision later -- retrieval pool with signals, Judge
+verdict + claims, oracle verdict, wall + tokens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import vstash
+
+# We mutate the module-level JUDGE_SYSTEM before calling judge_once
+# so the Judge sees the "personal" frame that matches the
+# conversational LongMemEval haystacks. The alternative of adding
+# a new DOMAIN_FRAMES entry is saved for when we actually have a
+# different-enough domain.
+from experiments.midloop_concept.medlocal import cerebras_midloop as _mod
+
+# Reuse the validated Mode A pipeline parts. cerebras_midloop is the
+# authoritative implementation; we import its helpers rather than
+# duplicating them so a future change to (say) the Judge prompt
+# reaches this eval automatically.
+from experiments.midloop_concept.medlocal.cerebras_midloop import (
+    BUILDER,
+    BUILDER_MODES,
+    DOMAIN_FRAMES,
+    JUDGE_SYSTEM_TEMPLATE,
+    MAX_TOKENS_DRAFT,
+    annotate_deterministic,
+    cerebras_chat,
+    judge_once,
+    retrieval_stats,
+    retrieve,
+)
+from experiments.retrieval.longmemeval.dataset import (
+    Conversation,
+    load_longmemeval,
+)
+
+# Reuse runner._format_turn so ingestion is bit-identical to the R@k
+# benchmark -- in particular it strips tiktoken special tokens
+# (<|endoftext|> etc) that crash vstash's chunk_text on some
+# LongMemEval haystacks. Without this shared helper our rows would
+# not be comparable to the published R@k numbers AND we would lose
+# full questions to ingest crashes (caught by the code-reviewer
+# pass before the N=50 run).
+from experiments.retrieval.longmemeval.runner import (
+    _format_turn as _format_turn_from_runner,
+)
+
+ORACLE_MODEL = "gemini-2.5-flash"
+TOP_K = 5
+
+# Oracle prompt. Short, strict JSON, zero chain-of-thought so the
+# scoring is as close to deterministic as possible. Four-way verdict
+# (supports / partial / contradicts / neutral) maps cleanly to
+# correctness: supports+partial = correct enough, contradicts+neutral
+# = incorrect or evasive.
+ORACLE_PROMPT = """You are a strict grader scoring answer quality.
+
+Question:
+{question}
+
+Ground-truth answer:
+{ground_truth}
+
+Candidate answer:
+{candidate}
+
+Score the candidate against the ground truth with ONE of:
+- "supports"     : the candidate answers the question and agrees with the ground truth
+- "partial"      : partially correct (right on the main point, imprecise on a detail)
+- "contradicts"  : the candidate answers the question but disagrees with the ground truth
+- "neutral"      : the candidate does not actually answer the question (refusal, off-topic, empty)
+
+Respond ONLY with a JSON object:
+{{"verdict": "supports"|"partial"|"contradicts"|"neutral", "rationale": "<one sentence>"}}
+No prose outside the JSON. No markdown fences.
+"""
+
+# Builder system prompt for the RAG baseline. Keeps the Builder
+# confident about the injected context so the RAG-only branch
+# actually uses the retrieved chunks rather than hedging them away.
+RAG_BUILDER_SYSTEM = (
+    "Answer the user question using the provided context. "
+    "Quote specific numbers or names from the context when they "
+    "appear. Keep the answer under 150 words. Do not hedge."
+)
+
+
+# --------------------------------------------------------------------- oracle
+
+
+def _oracle_client():
+    # Lazy import so `--help` works without google-genai. The repo
+    # already uses gemini elsewhere; same env var fallback chain.
+    from google import genai
+
+    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not key:
+        raise SystemExit("GEMINI_API_KEY or GOOGLE_API_KEY required")
+    return genai.Client(api_key=key)
+
+
+def _parse_oracle_json(raw: str) -> dict:
+    """Same pattern as cerebras_midloop's _extract_json_object --
+    tolerate markdown fences and trailing prose by finding the
+    outermost {...} and parsing it.
+    """
+    text = raw.strip()
+    m = re.match(r"```(?:json)?\s*", text)
+    if m:
+        text = text[m.end():]
+        if text.endswith("```"):
+            text = text[:-3]
+        text = text.strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1:
+        return {"verdict": "neutral", "rationale": "oracle_parse_failure", "raw": raw[:200]}
+    try:
+        return json.loads(text[start:end + 1])
+    except json.JSONDecodeError:
+        return {"verdict": "neutral", "rationale": "oracle_parse_failure", "raw": raw[:200]}
+
+
+def oracle_score(client, question: str, ground_truth: str, candidate: str) -> dict:
+    """Return {verdict, rationale, wall_s}. Failures default to
+    ``neutral`` so an oracle outage does not silently inflate any
+    condition's correct_rate.
+    """
+    prompt = ORACLE_PROMPT.format(
+        question=question[:1500],
+        ground_truth=ground_truth[:2000],
+        candidate=candidate[:2000],
+    )
+    t0 = time.perf_counter()
+    try:
+        resp = client.models.generate_content(model=ORACLE_MODEL, contents=prompt)
+    except Exception as exc:  # noqa: BLE001 -- fail-closed deliberately
+        return {
+            "verdict": "neutral",
+            "rationale": f"oracle_error: {exc}",
+            "wall_s": time.perf_counter() - t0,
+        }
+    parsed = _parse_oracle_json(resp.text or "")
+    parsed["wall_s"] = time.perf_counter() - t0
+    return parsed
+
+
+# --------------------------------------------------------------------- ingestion
+
+
+def _ingest(mem: vstash.Memory, conv: Conversation) -> int:
+    """Ingest every turn of every session as a separate memory
+    item, using ``runner._format_turn`` so the ingested shape
+    (including the special-token strip) matches the R@k benchmark.
+    Title encodes session_id so downstream code can trace hits
+    back to the answer session. Returns number of items ingested.
+    """
+    n = 0
+    for sid, turns in conv.haystack_sessions.items():
+        for i, turn in enumerate(turns):
+            mem.remember(
+                _format_turn_from_runner(turn),
+                title=f"{conv.question_id}::{sid}::{i}",
+                collection="default",
+            )
+            n += 1
+    return n
+
+
+# --------------------------------------------------------------------- conditions
+
+
+def run_control(question: str) -> dict:
+    """Builder-only baseline. No retrieval, no context."""
+    t0 = time.perf_counter()
+    draft, dt, usage = cerebras_chat(
+        BUILDER,
+        [
+            {"role": "system", "content": BUILDER_MODES["confident"] or ""},
+            {"role": "user", "content": question},
+        ],
+        MAX_TOKENS_DRAFT,
+    )
+    return {
+        "answer": draft,
+        "wall_s": dt,
+        "total_tokens": usage.get("total_tokens", 0) or 0,
+        "builder_usage": usage,
+        "_total_s": time.perf_counter() - t0,
+    }
+
+
+def run_rag(mem: vstash.Memory, question: str) -> dict:
+    """Naive RAG: same dual-3 retrieval Mode A uses, but the
+    Builder sees the chunks directly and produces the final
+    answer. No Judge, no claim-level. This is what people
+    usually mean by "RAG".
+    """
+    t0 = time.perf_counter()
+    excerpts = retrieve(mem, question, top_k=TOP_K, retrieval_mode="dual")
+    stats = retrieval_stats(excerpts)
+    # Truncate each excerpt so the RAG prompt stays within the
+    # Builder's effective context. Same cap Mode A uses in its
+    # draft step (ballpark).
+    joined = "\n\n---\n\n".join(
+        f"[source={e['source_id']}]\n{e['text'][:800]}"
+        for e in excerpts
+    )
+    user = f"Context:\n{joined}\n\nQuestion: {question}"
+    answer, dt, usage = cerebras_chat(
+        BUILDER,
+        [
+            {"role": "system", "content": RAG_BUILDER_SYSTEM},
+            {"role": "user", "content": user},
+        ],
+        MAX_TOKENS_DRAFT,
+    )
+    return {
+        "answer": answer,
+        "retrieved": excerpts,
+        "retrieval_stats": stats,
+        "wall_s": dt,
+        "total_tokens": usage.get("total_tokens", 0) or 0,
+        "builder_usage": usage,
+        "_total_s": time.perf_counter() - t0,
+    }
+
+
+def run_mode_a(mem: vstash.Memory, question: str) -> dict:
+    """Full Mode A v4. Replicates cerebras_midloop.run_one but
+    returns the raw components so we can build a uniform audit row
+    across conditions. Using the personal domain frame because
+    LongMemEval haystacks are conversational project memory, not
+    clinical guidelines.
+    """
+    t0 = time.perf_counter()
+
+    # Builder draft (confident mode, matches the smoke runs).
+    b_sys = BUILDER_MODES["confident"]
+    draft, b_dt, b_usage = cerebras_chat(
+        BUILDER,
+        [
+            {"role": "system", "content": b_sys},
+            {"role": "user", "content": question},
+        ],
+        MAX_TOKENS_DRAFT,
+    )
+
+    # Retrieval (3-way dual by default).
+    query = f"{question}\n{draft[:400]}"
+    excerpts = retrieve(mem, query, top_k=TOP_K, retrieval_mode="dual")
+    stats = retrieval_stats(excerpts)
+
+    # Point the Judge at the personal domain frame for this eval.
+    # Mutated once globally per call; the Judge prompt is idempotent
+    # across runs so setting it every iteration is cheap.
+    _mod.JUDGE_SYSTEM = JUDGE_SYSTEM_TEMPLATE.format(
+        domain_frame=DOMAIN_FRAMES["personal"]
+    )
+    judgment, j_dt, j_usage = judge_once(question, draft, excerpts)
+
+    final = annotate_deterministic(draft, judgment, excerpts)
+
+    claims = judgment.get("claims") or []
+    bad_claims = [
+        c for c in claims
+        if isinstance(c, dict) and c.get("verdict") in ("contradicts", "neutral")
+    ]
+    total_tokens = (b_usage.get("total_tokens", 0) or 0) + (j_usage.get("total_tokens", 0) or 0)
+    return {
+        "answer": final,
+        "draft": draft,
+        "retrieved": excerpts,
+        "retrieval_stats": stats,
+        "judgment": judgment,
+        "builder_usage": b_usage,
+        "judge_usage": j_usage,
+        "draft_s": b_dt,
+        "judge_s": j_dt,
+        "total_tokens": total_tokens,
+        "n_sub_claims": len(claims),
+        "n_sub_claims_unsupported": len(bad_claims),
+        "_total_s": time.perf_counter() - t0,
+    }
+
+
+# --------------------------------------------------------------------- eval loop
+
+
+@dataclass
+class EvalConfig:
+    subset: str
+    n: int
+    seed: int
+    out_path: Path
+    top_k: int = TOP_K
+    keep_dbs: bool = False
+
+
+def run_eval(cfg: EvalConfig) -> list[dict]:
+    print(f"[config] subset={cfg.subset} n={cfg.n} seed={cfg.seed} out={cfg.out_path}")
+    conversations = load_longmemeval(subset=cfg.subset)
+    print(f"[dataset] loaded {len(conversations)} conversations")
+
+    rnd = random.Random(cfg.seed)
+    sampled = rnd.sample(conversations, min(cfg.n, len(conversations)))
+    print(f"[dataset] sampled {len(sampled)} for eval")
+
+    oracle = _oracle_client()
+    rows: list[dict] = []
+
+    tmp_root = Path.home() / ".merken" / f"longmemeval_mode_a_{cfg.seed}"
+    tmp_root.mkdir(parents=True, exist_ok=True)
+
+    cfg.out_path.parent.mkdir(parents=True, exist_ok=True)
+    fout = cfg.out_path.open("w")
+
+    try:
+        for i, conv in enumerate(sampled):
+            # Some LongMemEval answers are numbers (int/float). The
+            # Conversation dataclass annotates ``answer: str`` but the
+            # loader just passes through whatever is in the JSON.
+            # Coerce here so both the debug print and the oracle prompt
+            # (via ground_truth[:2000]) work uniformly. The coerced
+            # string is what ships to the oracle and into the audit,
+            # so the comparison is faithful.
+            gt_text = str(conv.answer) if conv.answer is not None else ""
+            print(
+                f"\n{'='*72}\n[{i+1}/{len(sampled)}] qid={conv.question_id} "
+                f"type={conv.question_type}\n{'='*72}"
+            )
+            print(f"Q: {conv.question[:200]}")
+            print(f"GT: {gt_text[:200]}")
+
+            # Fresh DB per question so haystacks don't pollute each
+            # other. Project tag is the qid so vstash internal
+            # filtering stays predictable.
+            db_path = tmp_root / f"{conv.question_id}.db"
+            if db_path.exists():
+                db_path.unlink()
+            mem = vstash.Memory(
+                db=str(db_path),
+                project=conv.question_id,
+                collection="default",
+            )
+            # Wrap per-question body so a single Cerebras 5xx /
+            # Gemini hiccup / ingest crash does NOT abort the
+            # remaining rows after we've already paid oracle budget
+            # on earlier ones. A failed question writes a stub row
+            # with the error so the summary can still account for
+            # it and a resume-from-log is possible.
+            try:
+                t_ingest = time.perf_counter()
+                n_ingested = _ingest(mem, conv)
+                ingest_s = time.perf_counter() - t_ingest
+                print(f"[ingest] {n_ingested} turns in {ingest_s:.1f}s")
+
+                # Three conditions, same question, same mem for the
+                # two that need retrieval.
+                print("[control]")
+                r_control = run_control(conv.question)
+                print(f"  answer: {r_control['answer'][:180]!r}")
+
+                print("[rag]")
+                r_rag = run_rag(mem, conv.question)
+                print(f"  answer: {r_rag['answer'][:180]!r}")
+
+                print("[mode_a]")
+                r_mode_a = run_mode_a(mem, conv.question)
+                v = r_mode_a["judgment"].get("verdict")
+                n_claims = r_mode_a["n_sub_claims"]
+                n_bad = r_mode_a["n_sub_claims_unsupported"]
+                print(
+                    f"  verdict={v} sub_claims={n_claims} unsupported={n_bad}"
+                )
+
+                # Oracle each answer against the ground truth.
+                print("[oracle]")
+                o_control = oracle_score(
+                    oracle, conv.question, gt_text, r_control["answer"]
+                )
+                o_rag = oracle_score(
+                    oracle, conv.question, gt_text, r_rag["answer"]
+                )
+                o_mode_a = oracle_score(
+                    oracle, conv.question, gt_text, r_mode_a["answer"]
+                )
+                print(
+                    f"  control={o_control['verdict']:10s} "
+                    f"rag={o_rag['verdict']:10s} "
+                    f"mode_a={o_mode_a['verdict']:10s}"
+                )
+
+                audit = {
+                    "audit_id": uuid.uuid4().hex[:12],
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "question_id": conv.question_id,
+                    "question_type": conv.question_type,
+                    "question": conv.question,
+                    "ground_truth": gt_text,
+                    "answer_session_ids": conv.answer_session_ids,
+                    "n_sessions_ingested": n_ingested,
+                    "ingest_s": ingest_s,
+                    "conditions": {
+                        "control": {**r_control, "oracle": o_control},
+                        "rag": {**r_rag, "oracle": o_rag},
+                        "mode_a": {**r_mode_a, "oracle": o_mode_a},
+                    },
+                }
+                fout.write(json.dumps(audit, default=str) + "\n")
+                fout.flush()
+                rows.append(audit)
+            except Exception as exc:  # noqa: BLE001 -- deliberate catch-all
+                print(f"[error] question {conv.question_id} failed: {exc!r}")
+                err_row = {
+                    "audit_id": uuid.uuid4().hex[:12],
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "question_id": conv.question_id,
+                    "question_type": conv.question_type,
+                    "question": conv.question,
+                    "ground_truth": gt_text,
+                    "error": repr(exc),
+                }
+                fout.write(json.dumps(err_row, default=str) + "\n")
+                fout.flush()
+                # Do NOT append to rows -- the summary counts
+                # completed questions only. The stub row in the log
+                # is enough for later debugging.
+            finally:
+                mem.close()
+                if not cfg.keep_dbs and db_path.exists():
+                    db_path.unlink()
+    finally:
+        fout.close()
+
+    return rows
+
+
+# --------------------------------------------------------------------- summary
+
+
+def _correct(v: str) -> bool:
+    return v in ("supports", "partial")
+
+
+def summarize(rows: list[dict]) -> None:
+    n = len(rows)
+    if n == 0:
+        print("no rows -- nothing to summarise")
+        return
+
+    conditions = ["control", "rag", "mode_a"]
+    print("\n" + "=" * 72)
+    print("SUMMARY")
+    print("=" * 72)
+    print(f"  n questions: {n}")
+    print()
+    print(f"  {'condition':10s}  "
+          f"{'correct':>8s}  {'supports':>9s}  {'partial':>8s}  "
+          f"{'contradicts':>12s}  {'neutral':>8s}  "
+          f"{'avg_tok':>8s}  {'avg_s':>6s}")
+    for cond in conditions:
+        verdicts = [r["conditions"][cond]["oracle"]["verdict"] for r in rows]
+        tok = [int(r["conditions"][cond].get("total_tokens") or 0) for r in rows]
+        wall = [float(r["conditions"][cond].get("_total_s") or 0) for r in rows]
+        supports = verdicts.count("supports")
+        partial = verdicts.count("partial")
+        contradicts = verdicts.count("contradicts")
+        neutral = verdicts.count("neutral")
+        correct = supports + partial
+        print(
+            f"  {cond:10s}  "
+            f"{correct/n*100:6.1f}%  {supports:>9d}  {partial:>8d}  "
+            f"{contradicts:>12d}  {neutral:>8d}  "
+            f"{sum(tok)//n:>8d}  {sum(wall)/n:>5.1f}s"
+        )
+
+    print()
+    mode_a_rows = [r["conditions"]["mode_a"] for r in rows]
+    grounded = sum(
+        1 for r in mode_a_rows
+        if (r.get("judgment", {}).get("quoted_evidence") or "").strip()
+    )
+    with_bad = sum(
+        1 for r in mode_a_rows
+        if (r.get("n_sub_claims_unsupported") or 0) > 0
+    )
+    print(
+        f"  mode_a grounded (has quoted_evidence): "
+        f"{grounded}/{n} ({grounded/n*100:.1f}%)"
+    )
+    print(
+        f"  mode_a claim-level leaks (>=1 unsupported sub-claim): "
+        f"{with_bad}/{n} ({with_bad/n*100:.1f}%)"
+    )
+
+
+# --------------------------------------------------------------------- cli
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--subset", default="longmemeval_s",
+                   help="LongMemEval subset (default longmemeval_s)")
+    p.add_argument("--n", type=int, default=3,
+                   help="number of questions to sample (default 3 for preview)")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=Path("experiments/retrieval/longmemeval/mode_a_eval_runs"),
+        help="directory for audit logs; filename includes n+seed",
+    )
+    p.add_argument(
+        "--keep-dbs", action="store_true",
+        help="keep per-question vstash dbs after the run (default: cleanup)",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    out_dir = args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"n{args.n}_seed{args.seed}.jsonl"
+    cfg = EvalConfig(
+        subset=args.subset,
+        n=args.n,
+        seed=args.seed,
+        out_path=out_path,
+        keep_dbs=args.keep_dbs,
+    )
+    rows = run_eval(cfg)
+    summarize(rows)
+    print(f"\nlog: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/retrieval/longmemeval/mode_a_eval.py
+++ b/experiments/retrieval/longmemeval/mode_a_eval.py
@@ -58,9 +58,11 @@ import re
 import sys
 import time
 import uuid
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import vstash
 
@@ -141,6 +143,41 @@ RAG_BUILDER_SYSTEM = (
     "Quote specific numbers or names from the context when they "
     "appear. Keep the answer under 150 words. Do not hedge."
 )
+
+# Builder system prompt for the `rag_specific` baseline. Targets the
+# failure patterns surfaced in N=49 Run 1:
+#   - aggregation mistakes ("total $ from markets" got $595 instead
+#     of $495 because Mode A/Builder summed wrong)
+#   - knowledge-update misses (prefer older fact over newer one)
+#   - hallucination when the context is ambiguous ("how many
+#     projects" -> Builder guessed instead of abstaining)
+#   - no citation trail (RAG has no auditability, unlike Mode A)
+# The rules are explicit instructions the cheap Builder actually
+# follows; they cost ~80 tokens of system prompt.
+RAG_SPECIFIC_SYSTEM = (
+    "Answer the user question using ONLY the provided context "
+    "excerpts. Follow these rules strictly:\n\n"
+    "1. If the question asks for a TOTAL, COUNT, or SUM, enumerate "
+    "each relevant numeric value across excerpts first, then "
+    "compute the total. Show the enumeration inline when it helps.\n"
+    "2. If multiple excerpts make conflicting claims about the same "
+    "fact (e.g. earlier said X, later said Y), PREFER the most "
+    "recent. Excerpts appear in retrieval order, not time order; "
+    "use any session_id / timestamp hints to pick the later one.\n"
+    "3. If the answer is NOT clearly in the excerpts, respond "
+    "exactly 'not found in memory' rather than guessing.\n"
+    "4. Cite sources: after any specific factual claim, add "
+    "[excerpt N] where N is the 0-based excerpt index you used.\n"
+    "5. Quote specific numbers, names, and dates verbatim from "
+    "the excerpts -- do not paraphrase numerals.\n"
+    "6. Keep the answer under 200 words. Do not hedge outside of "
+    "rule 3."
+)
+
+# Matches [excerpt N] / [excerpt N, M] / [excerpt N | M] citations
+# in the rag_specific output. Used by the _cite variant's
+# deterministic footer renderer.
+_EXCERPT_CITE_RE = re.compile(r"\[excerpt\s+([0-9,\s|]+)\]", re.IGNORECASE)
 
 
 # --------------------------------------------------------------------- oracle
@@ -248,6 +285,51 @@ def run_control(question: str) -> dict:
     }
 
 
+def _render_excerpt_block(excerpts: list[dict]) -> str:
+    """Shared context block used by every RAG-family condition so
+    the retrieval payload is identical and only the system prompt
+    varies.
+    """
+    return "\n\n---\n\n".join(
+        f"[excerpt {i} | source={e['source_id']}]\n{e['text'][:800]}"
+        for i, e in enumerate(excerpts)
+    )
+
+
+def _cite_footer_from_rag(answer: str, excerpts: list[dict]) -> tuple[str, bool, list[int]]:
+    """Parse ``[excerpt N]`` markers from a rag_specific answer and
+    build a deterministic provenance footer listing the cited
+    sources + the verbatim text snippet from each. Returns
+    ``(footer, grounded_bool, cited_indices)``.
+
+    ``grounded`` is True iff at least one citation resolves to a
+    valid excerpt index. Invalid indices are silently dropped so a
+    model that writes ``[excerpt 99]`` does not hallucinate a
+    cite.
+    """
+    cited: list[int] = []
+    for m in _EXCERPT_CITE_RE.finditer(answer):
+        for part in re.split(r"[,|]", m.group(1)):
+            part = part.strip()
+            if not part.isdigit():
+                continue
+            idx = int(part)
+            if 0 <= idx < len(excerpts) and idx not in cited:
+                cited.append(idx)
+    if not cited:
+        return ("\n\n>> [no excerpt citations in answer]", False, [])
+
+    lines = [f"\n\n>> [rag_specific grounded in {len(cited)} excerpt(s)]"]
+    for idx in cited:
+        e = excerpts[idx]
+        src = e.get("source_id", "memory")
+        snippet = (e.get("text") or "").strip().replace("\n", " ")
+        snippet = (snippet[:160] + "...") if len(snippet) > 160 else snippet
+        lines.append(f">>   [excerpt {idx} | source={src}]")
+        lines.append(f">>     {snippet!r}")
+    return ("\n".join(lines), True, cited)
+
+
 def run_rag(mem: vstash.Memory, question: str) -> dict:
     """Naive RAG: same dual-3 retrieval Mode A uses, but the
     Builder sees the chunks directly and produces the final
@@ -282,6 +364,61 @@ def run_rag(mem: vstash.Memory, question: str) -> dict:
         "builder_usage": usage,
         "_total_s": time.perf_counter() - t0,
     }
+
+
+def run_rag_specific(mem: vstash.Memory, question: str) -> dict:
+    """RAG with a prompt engineered for the three failure modes
+    seen in the Run 1 RAG baseline: aggregation math, knowledge-
+    update recency, and over-confident hallucination when context
+    is ambiguous. Same retrieval as RAG; only the system prompt
+    differs. Excerpt headers use the ``[excerpt N | source=X]``
+    format so the model's ``[excerpt N]`` citations are index-
+    stable for the ``_cite`` variant's deterministic footer.
+    """
+    t0 = time.perf_counter()
+    excerpts = retrieve(mem, question, top_k=TOP_K, retrieval_mode="dual")
+    stats = retrieval_stats(excerpts)
+    user = f"Context:\n{_render_excerpt_block(excerpts)}\n\nQuestion: {question}"
+    answer, dt, usage = cerebras_chat(
+        BUILDER,
+        [
+            {"role": "system", "content": RAG_SPECIFIC_SYSTEM},
+            {"role": "user", "content": user},
+        ],
+        MAX_TOKENS_DRAFT,
+    )
+    return {
+        "answer": answer,
+        "retrieved": excerpts,
+        "retrieval_stats": stats,
+        "wall_s": dt,
+        "total_tokens": usage.get("total_tokens", 0) or 0,
+        "builder_usage": usage,
+        "_total_s": time.perf_counter() - t0,
+    }
+
+
+def attach_cite_footer(r_rag_specific: dict) -> dict:
+    """Add a deterministic provenance footer to an existing
+    ``rag_specific`` result. Returns a NEW dict (does not mutate
+    the input) so the oracle sees the same underlying answer + a
+    footer; we are isolating the footer's effect rather than
+    re-running the Builder.
+
+    This is the key test: if the Builder cited excerpts and the
+    footer resolves them to source_id + verbatim snippet
+    deterministically, we get Mode A's grounded property without
+    Mode A's Judge call.
+    """
+    answer = r_rag_specific["answer"]
+    excerpts = r_rag_specific["retrieved"]
+    footer, grounded, cited_ids = _cite_footer_from_rag(answer, excerpts)
+    out = dict(r_rag_specific)
+    out["answer"] = answer + footer
+    out["grounded"] = grounded
+    out["cited_excerpt_ids"] = cited_ids
+    # Token / wall numbers are identical -- the footer is free.
+    return out
 
 
 def run_mode_a(mem: vstash.Memory, question: str) -> dict:
@@ -342,6 +479,147 @@ def run_mode_a(mem: vstash.Memory, question: str) -> dict:
     }
 
 
+# --------------------------------------------------------------------- grid
+
+
+# Prompts addressable by a short key in a grid config. New entries
+# go here; the grid YAML references them by name.
+SYSTEM_PROMPT_REGISTRY: dict[str, str] = {
+    "confident": BUILDER_MODES["confident"] or "",
+    "rag_baseline": RAG_BUILDER_SYSTEM,
+    "rag_specific": RAG_SPECIFIC_SYSTEM,
+}
+
+
+@dataclass
+class Condition:
+    """One row of a grid run. ``kind`` picks the factory; the rest
+    are kind-specific knobs. Unused knobs for a kind are silently
+    ignored so a shared YAML schema can describe every condition
+    without a discriminated union.
+    """
+
+    name: str
+    kind: str  # 'control' | 'rag' | 'rag_specific' | 'mode_a'
+    temperature: float = 0.3
+    top_k: int = TOP_K
+    retrieval_mode: str = "dual"
+    system_prompt: str = "rag_baseline"   # key in SYSTEM_PROMPT_REGISTRY
+    excerpt_truncation: int = 800          # chars per excerpt in the prompt
+    max_tokens: int = MAX_TOKENS_DRAFT
+    cite_footer: bool = False              # append deterministic footer?
+    extra: dict = field(default_factory=dict)
+
+
+def _resolve_system_prompt(key: str) -> str:
+    if key not in SYSTEM_PROMPT_REGISTRY:
+        raise KeyError(
+            f"unknown system_prompt key {key!r}; known: "
+            f"{sorted(SYSTEM_PROMPT_REGISTRY)}"
+        )
+    return SYSTEM_PROMPT_REGISTRY[key]
+
+
+def _run_control_cfg(mem: vstash.Memory, question: str, c: Condition) -> dict:
+    t0 = time.perf_counter()
+    draft, dt, usage = cerebras_chat(
+        BUILDER,
+        [
+            {"role": "system", "content": _resolve_system_prompt(c.system_prompt)},
+            {"role": "user", "content": question},
+        ],
+        c.max_tokens,
+        temperature=c.temperature,
+    )
+    return {
+        "answer": draft,
+        "wall_s": dt,
+        "total_tokens": usage.get("total_tokens", 0) or 0,
+        "builder_usage": usage,
+        "_total_s": time.perf_counter() - t0,
+    }
+
+
+def _run_rag_cfg(mem: vstash.Memory, question: str, c: Condition) -> dict:
+    t0 = time.perf_counter()
+    excerpts = retrieve(mem, question, top_k=c.top_k, retrieval_mode=c.retrieval_mode)
+    stats = retrieval_stats(excerpts)
+    joined = "\n\n---\n\n".join(
+        f"[excerpt {i} | source={e['source_id']}]\n{e['text'][:c.excerpt_truncation]}"
+        for i, e in enumerate(excerpts)
+    )
+    user = f"Context:\n{joined}\n\nQuestion: {question}"
+    answer, dt, usage = cerebras_chat(
+        BUILDER,
+        [
+            {"role": "system", "content": _resolve_system_prompt(c.system_prompt)},
+            {"role": "user", "content": user},
+        ],
+        c.max_tokens,
+        temperature=c.temperature,
+    )
+    result: dict = {
+        "answer": answer,
+        "retrieved": excerpts,
+        "retrieval_stats": stats,
+        "wall_s": dt,
+        "total_tokens": usage.get("total_tokens", 0) or 0,
+        "builder_usage": usage,
+        "_total_s": time.perf_counter() - t0,
+    }
+    if c.cite_footer:
+        footer, grounded, cited_ids = _cite_footer_from_rag(answer, excerpts)
+        result["answer"] = answer + footer
+        result["grounded"] = grounded
+        result["cited_excerpt_ids"] = cited_ids
+    return result
+
+
+def _run_mode_a_cfg(mem: vstash.Memory, question: str, c: Condition) -> dict:
+    # Mode A's internal calls still read temperature from the global
+    # default (0.3) for now. Threading temperature into run_mode_a
+    # is a follow-up; for the grid's first pass we test temperature
+    # on RAG variants, which is where the production shape lives.
+    _ = c  # kind="mode_a" uses the existing hard-coded pipeline
+    return run_mode_a(mem, question)
+
+
+CONDITION_KINDS: dict[str, Callable[[vstash.Memory, str, Condition], dict]] = {
+    "control": _run_control_cfg,
+    "rag": _run_rag_cfg,
+    "mode_a": _run_mode_a_cfg,
+}
+
+
+def run_condition(mem: vstash.Memory, question: str, c: Condition) -> dict:
+    if c.kind not in CONDITION_KINDS:
+        raise KeyError(
+            f"unknown condition kind {c.kind!r}; known: {sorted(CONDITION_KINDS)}"
+        )
+    return CONDITION_KINDS[c.kind](mem, question, c)
+
+
+def load_grid(path: Path) -> list[Condition]:
+    """Load a YAML grid spec. Schema:
+
+    ``conditions:`` list of dicts, each with ``name`` and ``kind``
+    plus optional overrides. Unknown keys become ``extra``.
+    """
+    import yaml  # lazy -- only needed in grid mode
+
+    data = yaml.safe_load(path.read_text())
+    raw = data.get("conditions") or data  # tolerate bare list
+    out: list[Condition] = []
+    known = {f.name for f in Condition.__dataclass_fields__.values()}
+    for row in raw:
+        kwargs = {k: v for k, v in row.items() if k in known}
+        extra = {k: v for k, v in row.items() if k not in known}
+        if extra:
+            kwargs["extra"] = extra
+        out.append(Condition(**kwargs))
+    return out
+
+
 # --------------------------------------------------------------------- eval loop
 
 
@@ -353,6 +631,7 @@ class EvalConfig:
     out_path: Path
     top_k: int = TOP_K
     keep_dbs: bool = False
+    grid: list[Condition] | None = None  # None => legacy 5-condition mode
 
 
 def run_eval(cfg: EvalConfig) -> list[dict]:
@@ -413,8 +692,8 @@ def run_eval(cfg: EvalConfig) -> list[dict]:
                 ingest_s = time.perf_counter() - t_ingest
                 print(f"[ingest] {n_ingested} turns in {ingest_s:.1f}s")
 
-                # Three conditions, same question, same mem for the
-                # two that need retrieval.
+                # Five conditions, same question, same mem for the
+                # four that need retrieval.
                 print("[control]")
                 r_control = run_control(conv.question)
                 print(f"  answer: {r_control['answer'][:180]!r}")
@@ -422,6 +701,20 @@ def run_eval(cfg: EvalConfig) -> list[dict]:
                 print("[rag]")
                 r_rag = run_rag(mem, conv.question)
                 print(f"  answer: {r_rag['answer'][:180]!r}")
+
+                print("[rag_specific]")
+                r_rag_specific = run_rag_specific(mem, conv.question)
+                print(f"  answer: {r_rag_specific['answer'][:180]!r}")
+
+                # Same answer, same excerpts, footer appended
+                # deterministically -- no new LLM call.
+                print("[rag_specific_cite]")
+                r_rag_cite = attach_cite_footer(r_rag_specific)
+                n_cites = len(r_rag_cite.get("cited_excerpt_ids") or [])
+                print(
+                    f"  grounded={r_rag_cite.get('grounded')} "
+                    f"cites={n_cites}"
+                )
 
                 print("[mode_a]")
                 r_mode_a = run_mode_a(mem, conv.question)
@@ -440,12 +733,20 @@ def run_eval(cfg: EvalConfig) -> list[dict]:
                 o_rag = oracle_score(
                     oracle, conv.question, gt_text, r_rag["answer"]
                 )
+                o_rag_specific = oracle_score(
+                    oracle, conv.question, gt_text, r_rag_specific["answer"]
+                )
+                o_rag_cite = oracle_score(
+                    oracle, conv.question, gt_text, r_rag_cite["answer"]
+                )
                 o_mode_a = oracle_score(
                     oracle, conv.question, gt_text, r_mode_a["answer"]
                 )
                 print(
                     f"  control={o_control['verdict']:10s} "
                     f"rag={o_rag['verdict']:10s} "
+                    f"rag_spec={o_rag_specific['verdict']:10s} "
+                    f"rag_cite={o_rag_cite['verdict']:10s} "
                     f"mode_a={o_mode_a['verdict']:10s}"
                 )
 
@@ -462,6 +763,8 @@ def run_eval(cfg: EvalConfig) -> list[dict]:
                     "conditions": {
                         "control": {**r_control, "oracle": o_control},
                         "rag": {**r_rag, "oracle": o_rag},
+                        "rag_specific": {**r_rag_specific, "oracle": o_rag_specific},
+                        "rag_specific_cite": {**r_rag_cite, "oracle": o_rag_cite},
                         "mode_a": {**r_mode_a, "oracle": o_mode_a},
                     },
                 }
@@ -494,6 +797,125 @@ def run_eval(cfg: EvalConfig) -> list[dict]:
     return rows
 
 
+def run_grid_eval(cfg: EvalConfig) -> list[dict]:
+    """Grid-mode eval. Same per-question loop as ``run_eval`` but
+    each condition is parameter-driven (top_k, temperature,
+    system_prompt, etc.). Ingestion is shared per question so
+    adding another condition is only the cost of one more Builder
+    (and optionally Judge) call per question.
+    """
+    assert cfg.grid, "run_grid_eval called with no grid config"
+    print(
+        f"[grid] subset={cfg.subset} n={cfg.n} seed={cfg.seed} "
+        f"conditions={len(cfg.grid)} out={cfg.out_path}"
+    )
+    for c in cfg.grid:
+        print(
+            f"  - {c.name:30s} kind={c.kind:8s} "
+            f"temp={c.temperature} top_k={c.top_k} "
+            f"sys={c.system_prompt} cite={c.cite_footer}"
+        )
+    conversations = load_longmemeval(subset=cfg.subset)
+    rnd = random.Random(cfg.seed)
+    sampled = rnd.sample(conversations, min(cfg.n, len(conversations)))
+    oracle = _oracle_client()
+
+    tmp_root = Path.home() / ".merken" / f"longmemeval_mode_a_{cfg.seed}"
+    tmp_root.mkdir(parents=True, exist_ok=True)
+
+    cfg.out_path.parent.mkdir(parents=True, exist_ok=True)
+    fout = cfg.out_path.open("w")
+    rows: list[dict] = []
+
+    try:
+        for i, conv in enumerate(sampled):
+            gt_text = str(conv.answer) if conv.answer is not None else ""
+            print(
+                f"\n{'='*72}\n[{i+1}/{len(sampled)}] qid={conv.question_id} "
+                f"type={conv.question_type}\n{'='*72}"
+            )
+            print(f"Q: {conv.question[:200]}")
+            print(f"GT: {gt_text[:200]}")
+
+            db_path = tmp_root / f"{conv.question_id}.db"
+            if db_path.exists():
+                db_path.unlink()
+            mem = vstash.Memory(
+                db=str(db_path),
+                project=conv.question_id,
+                collection="default",
+            )
+            try:
+                t_ingest = time.perf_counter()
+                n_ingested = _ingest(mem, conv)
+                ingest_s = time.perf_counter() - t_ingest
+                print(f"[ingest] {n_ingested} turns in {ingest_s:.1f}s")
+
+                per_cond: dict[str, Any] = {}
+                for c in cfg.grid:
+                    print(f"[{c.name}]")
+                    try:
+                        r = run_condition(mem, conv.question, c)
+                    except Exception as exc:  # noqa: BLE001
+                        print(f"  error: {exc!r}")
+                        per_cond[c.name] = {"error": repr(exc)}
+                        continue
+                    o = oracle_score(
+                        oracle, conv.question, gt_text, r["answer"]
+                    )
+                    r["oracle"] = o
+                    r["_condition_spec"] = {
+                        "kind": c.kind,
+                        "temperature": c.temperature,
+                        "top_k": c.top_k,
+                        "retrieval_mode": c.retrieval_mode,
+                        "system_prompt": c.system_prompt,
+                        "cite_footer": c.cite_footer,
+                        "max_tokens": c.max_tokens,
+                    }
+                    per_cond[c.name] = r
+                    print(
+                        f"  oracle={o.get('verdict'):10s} "
+                        f"tok={r.get('total_tokens',0)} "
+                        f"wall={r.get('_total_s', 0):.1f}s"
+                    )
+
+                audit = {
+                    "audit_id": uuid.uuid4().hex[:12],
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "question_id": conv.question_id,
+                    "question_type": conv.question_type,
+                    "question": conv.question,
+                    "ground_truth": gt_text,
+                    "answer_session_ids": conv.answer_session_ids,
+                    "n_sessions_ingested": n_ingested,
+                    "ingest_s": ingest_s,
+                    "conditions": per_cond,
+                }
+                fout.write(json.dumps(audit, default=str) + "\n")
+                fout.flush()
+                rows.append(audit)
+            except Exception as exc:  # noqa: BLE001
+                print(f"[error] qid={conv.question_id}: {exc!r}")
+                fout.write(json.dumps(
+                    {
+                        "audit_id": uuid.uuid4().hex[:12],
+                        "question_id": conv.question_id,
+                        "error": repr(exc),
+                    },
+                    default=str,
+                ) + "\n")
+                fout.flush()
+            finally:
+                mem.close()
+                if not cfg.keep_dbs and db_path.exists():
+                    db_path.unlink()
+    finally:
+        fout.close()
+
+    return rows
+
+
 # --------------------------------------------------------------------- summary
 
 
@@ -507,7 +929,12 @@ def summarize(rows: list[dict]) -> None:
         print("no rows -- nothing to summarise")
         return
 
-    conditions = ["control", "rag", "mode_a"]
+    # Legacy 5-condition layout for backward compat. Grid runs
+    # summarise differently -- see summarize_grid below.
+    first = rows[0].get("conditions", {})
+    conditions = list(first) if first else [
+        "control", "rag", "rag_specific", "rag_specific_cite", "mode_a"
+    ]
     print("\n" + "=" * 72)
     print("SUMMARY")
     print("=" * 72)
@@ -534,23 +961,26 @@ def summarize(rows: list[dict]) -> None:
         )
 
     print()
-    mode_a_rows = [r["conditions"]["mode_a"] for r in rows]
-    grounded = sum(
-        1 for r in mode_a_rows
-        if (r.get("judgment", {}).get("quoted_evidence") or "").strip()
-    )
-    with_bad = sum(
-        1 for r in mode_a_rows
-        if (r.get("n_sub_claims_unsupported") or 0) > 0
-    )
-    print(
-        f"  mode_a grounded (has quoted_evidence): "
-        f"{grounded}/{n} ({grounded/n*100:.1f}%)"
-    )
-    print(
-        f"  mode_a claim-level leaks (>=1 unsupported sub-claim): "
-        f"{with_bad}/{n} ({with_bad/n*100:.1f}%)"
-    )
+    # Mode A telemetry is only meaningful when the legacy
+    # condition key "mode_a" is present in the rows.
+    if rows and "mode_a" in rows[0].get("conditions", {}):
+        mode_a_rows = [r["conditions"]["mode_a"] for r in rows]
+        grounded = sum(
+            1 for r in mode_a_rows
+            if (r.get("judgment", {}).get("quoted_evidence") or "").strip()
+        )
+        with_bad = sum(
+            1 for r in mode_a_rows
+            if (r.get("n_sub_claims_unsupported") or 0) > 0
+        )
+        print(
+            f"  mode_a grounded (has quoted_evidence): "
+            f"{grounded}/{n} ({grounded/n*100:.1f}%)"
+        )
+        print(
+            f"  mode_a claim-level leaks (>=1 unsupported sub-claim): "
+            f"{with_bad}/{n} ({with_bad/n*100:.1f}%)"
+        )
 
 
 # --------------------------------------------------------------------- cli
@@ -573,6 +1003,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--keep-dbs", action="store_true",
         help="keep per-question vstash dbs after the run (default: cleanup)",
     )
+    p.add_argument(
+        "--grid",
+        type=Path,
+        default=None,
+        help=(
+            "path to a YAML grid spec. When set, runs a configurable "
+            "multi-condition eval instead of the legacy 5-condition "
+            "layout. See grids/ for example specs."
+        ),
+    )
     return p.parse_args(argv)
 
 
@@ -580,15 +1020,22 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     out_dir = args.out
     out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"n{args.n}_seed{args.seed}.jsonl"
+    if args.grid:
+        grid = load_grid(args.grid)
+        tag = args.grid.stem
+        out_path = out_dir / f"grid-{tag}_n{args.n}_seed{args.seed}.jsonl"
+    else:
+        grid = None
+        out_path = out_dir / f"n{args.n}_seed{args.seed}.jsonl"
     cfg = EvalConfig(
         subset=args.subset,
         n=args.n,
         seed=args.seed,
         out_path=out_path,
         keep_dbs=args.keep_dbs,
+        grid=grid,
     )
-    rows = run_eval(cfg)
+    rows = run_grid_eval(cfg) if grid else run_eval(cfg)
     summarize(rows)
     print(f"\nlog: {out_path}")
     return 0

--- a/experiments/retrieval/longmemeval/mode_a_eval.py
+++ b/experiments/retrieval/longmemeval/mode_a_eval.py
@@ -446,13 +446,21 @@ def run_mode_a(mem: vstash.Memory, question: str) -> dict:
     excerpts = retrieve(mem, query, top_k=TOP_K, retrieval_mode="dual")
     stats = retrieval_stats(excerpts)
 
-    # Point the Judge at the personal domain frame for this eval.
-    # Mutated once globally per call; the Judge prompt is idempotent
-    # across runs so setting it every iteration is cheap.
-    _mod.JUDGE_SYSTEM = JUDGE_SYSTEM_TEMPLATE.format(
-        domain_frame=DOMAIN_FRAMES["personal"]
-    )
-    judgment, j_dt, j_usage = judge_once(question, draft, excerpts)
+    # Point the Judge at the personal domain frame for this eval,
+    # then RESTORE whatever the original module-level JUDGE_SYSTEM
+    # was after the call. Previously we left the global mutated,
+    # which could silently change the Judge prompt for any other
+    # process importing cerebras_midloop after this eval. The
+    # module is single-threaded-safe but this eliminates the
+    # cross-test contamination failure mode flagged by bot review.
+    _prior = _mod.JUDGE_SYSTEM
+    try:
+        _mod.JUDGE_SYSTEM = JUDGE_SYSTEM_TEMPLATE.format(
+            domain_frame=DOMAIN_FRAMES["personal"]
+        )
+        judgment, j_dt, j_usage = judge_once(question, draft, excerpts)
+    finally:
+        _mod.JUDGE_SYSTEM = _prior
 
     final = annotate_deterministic(draft, judgment, excerpts)
 
@@ -629,8 +637,11 @@ class EvalConfig:
     n: int
     seed: int
     out_path: Path
-    top_k: int = TOP_K
     keep_dbs: bool = False
+    # In legacy mode top_k is hardcoded to TOP_K (5) in each run_*
+    # helper. In grid mode each Condition carries its own top_k.
+    # A top-level cfg.top_k would be misleading (the runs ignore it)
+    # so it is intentionally not exposed here.
     grid: list[Condition] | None = None  # None => legacy 5-condition mode
 
 

--- a/notes/mode-c-continuous-decider.md
+++ b/notes/mode-c-continuous-decider.md
@@ -1,0 +1,200 @@
+# Mode C as the production shape, with a continuous streaming decider
+
+Short memo distilling what clarified at end of 2026-04-21 while
+running N=50 honest evals. We spent ~3 hours discovering that Mode
+A is not the production shape and that Mode C is not simply "Mode
+A but local". This note fixes the architecture so the next session
+does not re-derive it.
+
+## What the N=50 evals revealed (not what we planned to learn)
+
+1. **Mode A v4 is dominated by naive RAG on answer correctness.**
+   Three consecutive N=50 runs on LongMemEval_s, same seed:
+   RAG baseline 71% / 70% / 78%; Mode A 71% / 66% / 64%. The
+   Judge 235b does not earn its ~4x token cost in top-line
+   correctness. It does buy +81% grounded evidence trail, which
+   matters for audit but not for the oracle's correct/wrong
+   judgment.
+
+2. **Prompt engineering is a double-edged lever.** Adding 6
+   targeted rules ("rag_specific": aggregation, recency,
+   abstention, citation, verbatim, concise) **regressed by 20pp**
+   vs the 3-rule RAG baseline. The minimal prompt survives on
+   llama3.1-8b better than a precise prompt. Surgical, not
+   additive.
+
+3. **Temperature 0.3 was introducing cross-run variance.** Same
+   seed, same question, flipped verdict 16-18% of the time
+   between runs. Temperature 0.0 is necessary before any
+   A/B claim survives scrutiny.
+
+## The production shape that actually matters
+
+Mode A (what we evaluated) is **retrieve-between-two-generations**.
+Mode C is **retrieve-during-one-generation** via KV-splice. That
+is the architectural difference that makes the cost collapse
+viable.
+
+### Biological analogy (useful intuition, NOT a thesis claim)
+
+Jay framed the experiment informally as "asi como funciona la
+memoria humana" -- the interleaving of retrieval and generation
+feels analogous to how people fetch memories while speaking.
+Treat this as an **intuition pump** for why continuous
+interception is an interesting shape to test, not as a
+cognitive-science claim about the architecture. We are not
+modeling human memory; we are using the metaphor to motivate
+a mid-stream retrieval loop that is worth measuring against
+RAG and Mode A on real tasks.
+
+Where the analogy is handy:
+- Frequency of retrieval correlates with complexity of
+  utterance -- "hi" consults nothing, "remember when we talked
+  about X in 2019..." consults multiple times.
+- Retrievals interleave with generation rather than preceding
+  it.
+
+Where it is only metaphor, not mechanism:
+- K/V splice is an LLM-cache operation, not reconstruction-from-
+  engram. Do not build on the human-memory framing as if it
+  explained the attention math.
+- No claim here about RAG or Mode A being "less like memory" --
+  they are engineering shapes with their own tradeoffs. The
+  analogy describes why Mode C is worth testing, not why the
+  others are wrong.
+
+### Continuous streaming decider -- the refined concept
+
+The gate does NOT fire once at N=10 tokens and then wait. It is
+a continuous monitor that runs across the generation stream at a
+configurable cadence:
+
+- Decide every N tokens where N in {10, 20, 100, variable} --
+  the cadence is a hyperparameter, not a fixed cut.
+- Windows may OVERLAP (sliding, e.g. evaluate the last 20 tokens
+  every 10 tokens generated) or be DISJOINT (evaluate fresh
+  chunks of 20 tokens as they arrive). Both are valid.
+- Each firing may or may not trigger a vstash call. Simple
+  responses may not hit the decider's threshold at all.
+  Complex multi-claim responses trigger several retrievals +
+  splices across one generation.
+- Each retrieval is a potential K/V splice into the ongoing
+  generation's cache. The Builder keeps running after each
+  splice with the enriched context.
+
+Concretely:
+
+```
+Builder streams tokens
+  decider(window_1) -> maybe splice
+  Builder continues
+  decider(window_2) -> maybe splice
+  Builder continues
+  decider(window_3) -> no splice, just pass
+  ...
+  Builder emits EOS
+```
+
+### Implications for the claim_detector
+
+Training data is **per-window**, not per-question:
+- Features = `(question, partial_output_prefix, window_content)`
+- Label = `needs_retrieval` (bool) plus `retrieval_query_hint`
+  (what to search)
+
+This is a classic streaming classifier problem, not a one-shot
+gate. The audit rows we are already accumulating are close but
+not directly usable -- they carry whole-question outcomes, not
+per-window decisions. We need a per-window labeler (could be
+derived from the claims[] array the Judge already emits, by
+mapping sub-claims to the spans in the output where they first
+appear).
+
+### Cost profile (revised)
+
+Average question (mix of simple and complex):
+- 0-3 decider firings per question (simple: 0; complex: 2-3)
+- Each firing: ~10ms for the decider + ~100ms vstash +
+  ~100ms K/V splice
+- One Builder generation end-to-end (no second LLM call)
+- Total: ~500-800 LLM tokens, ~1-2s wall, $0 if local mlx
+
+vs Mode A 8759 tok / ~5s / $0.008. An order of magnitude
+cheaper once the decider works.
+
+## RAG ceiling calibration (2026-04-21 grid)
+
+Temperature + top_k sweep on RAG baseline, N=50 seed 42
+longmemeval_s, same corpus the Mode A runs used
+(`grids/rag_baseline_sweep.yml`):
+
+**Temperature (top_k=5 fixed):**
+- t=0.0: 72.0% correct, 2288 tok/q
+- t=0.1: 74.0% correct, 2290 tok/q
+- t=0.3: 74.0% correct, 2294 tok/q
+
+**top_k (t=0.0 fixed):**
+- k=1: 54.0%, 531 tok
+- k=3: **70.0%, 1394 tok** (cost/correctness knee)
+- k=5: 72.0%, 2288 tok
+- k=10: 72.0%, 4436 tok
+
+**Calibrated baseline: RAG-k3 at temp 0.0-0.3 = ~70-74%
+correct at ~1400 tok/q.**
+
+Important correction to the earlier "temperature noise"
+hypothesis: the Run 1 vs Run 2 vs Run 3 flips (71% / 70% / 78%
+for RAG) were NOT dominated by Cerebras sampling temperature.
+The t=0.0 run on the same seed landed 72% -- in the middle of
+that range. The variance was mostly **oracle (Gemini Flash)
+noise** across runs. A real stability study would need
+multiple oracle samples per answer; single-draw oracle scoring
+is noisier than we were assuming.
+
+Comparison anchor for Mode C:
+
+| shape | correct | tok/q | API $/q |
+|---|---|---|---|
+| control (no context) | 8% | 290 | 0 |
+| RAG-k3 (new calibrated baseline) | 70% | 1394 | ~$0.0006 |
+| RAG-k5 (earlier baseline) | 72-74% | 2288 | ~$0.001 |
+| Mode A v4 | 64-71% (avg ~67%) | 9048 | ~$0.008 |
+
+**Mode A loses ~3pp to RAG-k3 at ~6.5x the cost.** Mode A is
+not a production candidate on this corpus, at this scale,
+with this Builder (llama3.1-8b). It remains useful as the
+training-time labeler that will eventually distill a
+claim_detector.
+
+Mode C's target: match RAG-k3 on correctness while moving the
+per-query retrieval call from "always" to "content-conditional"
+via the continuous decider. If the decider correctly abstains
+on ~30% of questions (the ones Builder answers correctly
+without memory), Mode C expected cost ~70% of RAG-k3 = ~1000
+tok. Running mlx-locally drops API cost to zero; Cerebras cost
+remains below RAG.
+
+## What stays open
+
+- **Long-splice probe**: Phase 0b proved 14-token splice produces
+  coherent continuation. Needs 500-token probe with real vstash
+  excerpts before the architecture is validated at production
+  scale.
+- **Chat-template interaction**: POC used raw continuation, not
+  Gemma/Llama role markers. Splicing into an assistant turn
+  mid-stream may or may not preserve the template boundaries.
+- **claim_detector as streaming classifier**: current scaffolding
+  (`merken/policies/claim_detector.py`) is one-shot. Needs a
+  windowed wrapper.
+- **vstash call budget policy**: how many splices per generation
+  is too many? Is there a soft-cap? A cooldown?
+
+## What is NOT the production shape
+
+- Mode A with Judge 235b rewriting: validated as training-time
+  teacher only. Kept in the stack for distillation labels.
+- One-shot gate at N=10: superseded by continuous streaming
+  decider per Jay 2026-04-21.
+- Retrieve-everything RAG: the baseline we have to beat, not
+  the shipping shape. Mode C's promise is "cheaper than RAG
+  because the decider often says no".


### PR DESCRIPTION
## Summary

First N>=50 answer-quality eval of Mode A on LongMemEval, following Jay's \"honest review\" ask. Extends the existing R@k harness to measure whether the final user-facing answer is correct, not just whether retrieval surfaced the right chunk.

**Headline: Mode A does NOT beat naive RAG on top-line correctness at N=49.** Same 71.4% correct rate, 4x token cost, 4x wall.

What Mode A buys for the premium: 81.6% grounded (verbatim source quote in the answer footer), claim-level warnings on 10.2% of cases, +14pp on knowledge-update questions. What it loses: -9pp on temporal-reasoning (over-refusal + arithmetic errors).

## Conditions

- **control**: Builder (Cerebras llama3.1-8b) alone, confident prompt, no retrieval.
- **rag**: Builder + top-5 dual-3 chunks inlined in the user prompt. No Judge.
- **mode_a**: full Mode A v4 (draft + dual-3 + claim-level Judge + annotator).

Oracle: Gemini 2.5 Flash. Different model family from Cerebras on purpose, to avoid intra-family bias.

## Headline (N=49, seed 42, longmemeval_s)

| condition | correct | supports | partial | contradicts | neutral | avg_tok | avg_s |
|---|---|---|---|---|---|---|---|
| control | 8.2% (4/49) | 1 | 3 | 3 | 42 | 288 | 0.7 |
| rag | **71.4%** (35/49) | 30 | 5 | 9 | 5 | 2210 | 1.4 |
| mode_a | **71.4%** (35/49) | 33 | 2 | 7 | 7 | 8759 | 5.3 |

Mode A telemetry: 40/49 grounded (81.6%), 5/49 with claim-level leak (10.2%), 125 sub-claims total of which 14 unsupported (11.2%).

## Per question_type

| type | n | rag | mode_a | delta |
|---|---|---|---|---|
| knowledge-update | 7 | 57% | **71%** | **+14pp** |
| multi-session | 17 | 65% | 65% | 0 |
| temporal-reasoning | 11 | 64% | 55% | **-9pp** |
| single-session-* | 14 | 100% | 100% | 0 |

Mode A wins the cases that need aggregation across multiple chunks (summing \$3,750 charity, 10 rollercoasters, two engineer counts). Mode A loses when it over-refuses (\"how many projects\": refused vs RAG \"at least one\") or when Builder arithmetic is wrong and the Judge passes it through (\"total \$ from markets\" GT \$495, Mode A returned \$595).

## What's in the PR

- `experiments/retrieval/longmemeval/mode_a_eval.py` -- 3-condition eval harness. Per-question try/except so one 5xx does not abort the run; audit JSONL streamed with flush for resumability.
- `experiments/retrieval/longmemeval/analyze_mode_a_eval.py` -- post-hoc analyser (headline / per-type / mode_a telemetry / cost / disagreement cases).
- `experiments/retrieval/longmemeval/RESULTS.md` -- full writeup with caveats and next moves.

## Bundled fixes (surfaced during the run)

- **`cerebras_midloop.retrieve` dedup silent data loss.** The `text[:120]` prefix dedup aliased conversational turns sharing prefixes (\"user: hi, how are you\" vs the same + more detail). Replaced with `vstash.chunk_id` when available, full `(source_id, text)` tuple otherwise. Unit tests cover the collision. Affected both RAG and Mode A equally in Run 1, so the A/B comparison is still valid -- absolute ceilings would lift on a rerun.
- **`conv.answer` sometimes int** (e.g. \"3\" graduation ceremonies). Dataset loader doesn't enforce the `answer: str` annotation. Coerce with `str()` at eval-script entry.
- **Shared `runner._format_turn`** so ingestion strips tiktoken special tokens consistently with the R@k benchmark. Flagged by the code-review pass.

## Pre-run code review

The `code-reviewer` subagent pass before the run identified 3 real issues (format-turn divergence, missing per-question try/except, 4 methodology caveats). All three fixed before running, per the CLAUDE.md empirical-first rule.

## Test plan

- [ ] `python -m experiments.retrieval.longmemeval.mode_a_eval --subset longmemeval_s --n 3 --seed 42` reproduces the preview (3/3 for RAG and Mode A, 0/3 for control).
- [ ] `python -m experiments.retrieval.longmemeval.analyze_mode_a_eval experiments/retrieval/longmemeval/mode_a_eval_runs/n50_seed42.jsonl` prints the full breakdown.
- [ ] Ruff clean on all three new/edited files.

## Next moves (not in this PR)

- Rerun with dedup fix (seed 42, N=49) to see if absolute numbers move; expect both conditions lift together, delta small.
- Tune Judge for temporal-reasoning (lower over-refusal when arithmetic can be inferred from excerpts).
- Cost levers: score-threshold cutoff, full-text hash dedup already landed, mini-rerank pre-Judge.
- Graduate to N=100 or N=500 once cost and Judge tuning stabilise.