### PR TITLE
fix(memory): vstash 0.35.0 API drift -- restore green test suite

### DIFF
--- a/merken/memory.py
+++ b/merken/memory.py
@@ -931,7 +931,7 @@ class Memory:
             top_k=top_k,
             collection=AUDIT_COLLECTION,
             layer=AUDIT_LAYER,
-            fts_only=fts_only,
+            retrieval_mode="fts_only" if fts_only else None,
         )
 
     # --------------------------------------------------------------- midloop

--- a/tests/test_embed_model_resolution.py
+++ b/tests/test_embed_model_resolution.py
@@ -22,35 +22,22 @@ from merken import Memory
 from merken.memory import _resolve_vstash_embed_model
 
 
-def test_resolver_falls_back_to_config_on_fresh_store(tmp_path: Path) -> None:
-    """A fresh store has no store_meta row for embedding_model because
-    no ingest has happened yet. The resolver must return the vstash
-    config default in that case."""
-    from vstash.config import EmbeddingsConfig
-
-    with Memory(project="fresh", db=tmp_path / "e.db") as mem:
-        resolved = _resolve_vstash_embed_model(mem._vstash)
-
-    assert resolved == EmbeddingsConfig().model
-
-
-def test_resolver_falls_back_when_store_meta_lacks_embedding_model(
+def test_resolver_returns_value_written_by_vstash_on_fresh_store(
     tmp_path: Path,
 ) -> None:
-    """As of vstash 0.27.0, a fresh store does not auto-write
-    ``store_meta.embedding_model`` even after the first ingest —
-    only ``schema_version`` and ``vstash_version`` land there. The
-    resolver must treat a missing row the same as a fresh store
-    and fall back to the config default. (Jay's legacy store has
-    the row because it was created by an older vstash that used
-    to write it — worth tracking as a vstash upstream regression
-    in observability, not something merken should paper over.)
+    """As of vstash 0.35.0, a fresh store has ``store_meta.embedding_model``
+    populated automatically (previously vstash 0.27.0 did not write it).
+    The resolver must return that authoritative value so merken's
+    clustering and vstash's retrieval stay in the same vector space.
+
+    Earlier behavior (vstash 0.27.0): no row -> fall back to config.
+    Current behavior (vstash 0.35.0+): row present -> use it.
+
+    Regression guard: if vstash ever stops writing this row again the
+    precondition assertion below points to fixing the upstream
+    observability rather than papering over it in merken.
     """
-    from vstash.config import EmbeddingsConfig
-
-    with Memory(project="ingested", db=tmp_path / "e.db") as mem:
-        mem.remember("A real event so vstash populates store_meta.")
-
+    with Memory(project="fresh", db=tmp_path / "e.db") as mem:
         con = sqlite3.connect(str(mem._vstash._store.db_path))
         row = con.execute(
             "SELECT value FROM store_meta WHERE key = ?",
@@ -58,15 +45,44 @@ def test_resolver_falls_back_when_store_meta_lacks_embedding_model(
         ).fetchone()
         con.close()
 
+        assert row is not None, (
+            "vstash did not write store_meta.embedding_model on store "
+            "creation. If vstash regressed on this, the resolver fallback "
+            "path is now load-bearing again -- update this test to assert "
+            "the fallback rather than papering over a vstash regression."
+        )
+        stored_model = row[0]
+
         resolved = _resolve_vstash_embed_model(mem._vstash)
 
-    # Confirm the precondition: vstash did not write embedding_model
-    assert row is None, (
-        "vstash unexpectedly wrote store_meta.embedding_model on ingest. "
-        "If vstash regained this behavior upstream, update this test to "
-        "assert the resolver reads the row instead of falling back."
-    )
-    # Resolver falls back cleanly to config default
+    assert resolved == stored_model
+
+
+def test_resolver_falls_back_when_store_meta_row_missing(
+    tmp_path: Path,
+) -> None:
+    """Legacy stores (created by older vstash versions) and corrupted
+    stores may lack the ``embedding_model`` row. The resolver must
+    still resolve cleanly by falling back to the vstash config default
+    rather than returning ``None`` or crashing.
+
+    The "missing row" state is not currently reachable through the
+    vstash public API on a new store (vstash 0.35.0 always writes it),
+    so we simulate it by deleting the row after store init.
+    """
+    from vstash.config import EmbeddingsConfig
+
+    with Memory(project="legacy", db=tmp_path / "e.db") as mem:
+        con = sqlite3.connect(str(mem._vstash._store.db_path))
+        con.execute(
+            "DELETE FROM store_meta WHERE key = ?",
+            ("embedding_model",),
+        )
+        con.commit()
+        con.close()
+
+        resolved = _resolve_vstash_embed_model(mem._vstash)
+
     assert resolved == EmbeddingsConfig().model
 
 


### PR DESCRIPTION
## Summary

Restores the test suite to green (401 passed, was 18 failing) after two independent vstash drifts that accumulated since the last full run.

## What drifted

**1. `Memory.search()` kwarg renamed: `fts_only=True` -> `retrieval_mode="fts_only"`**

Single call site in `merken/memory.py` (the `audit()` method) was passing `fts_only=fts_only` to `self._vstash.search(...)`. vstash 0.35.0's `Memory.search` no longer accepts that kwarg and instead exposes `retrieval_mode: Literal['hybrid', 'vec_only', 'fts_only']`.

Fix translates internally; merken's own `audit(fts_only=...)` public API surface stays unchanged so `labeling.py` and tests that consume it are untouched.

This single line caused 16 failures across `test_cli`, `test_should_remember`, `test_should_recall`, `test_should_consolidate`, `test_should_forget`, `test_midloop_integration`, `test_labeling`, and `test_mcp_server`.

**2. vstash now writes `store_meta.embedding_model` on store init**

vstash 0.27.0 did NOT write this row even after the first ingest -- only after a separate explicit operation. vstash 0.35.0 writes it on store creation. Two `test_embed_model_resolution.py` tests encoded the old "row missing on fresh store" assumption and failed.

The resolver itself (`_resolve_vstash_embed_model`) is unchanged and was always correct end-to-end. Just two tests needed updating:

- `test_resolver_falls_back_to_config_on_fresh_store` -> `test_resolver_returns_value_written_by_vstash_on_fresh_store`. Reads what vstash actually wrote and asserts the resolver returns that authoritative value. Includes a regression-guard precondition pointing back at vstash if the row ever stops being written upstream.
- `test_resolver_falls_back_when_store_meta_lacks_embedding_model` -> `test_resolver_falls_back_when_store_meta_row_missing`. Simulates the missing-row state by `DELETE`-ing the row vstash wrote, since the natural fresh-store path no longer reaches it. Documents that this fallback is only for legacy / corrupted stores.

The override and bare-stub resolver tests pass unchanged.

## Test plan

- [x] `pytest tests/` -> **401 passed** (was 18 failed / 383 passed before)
- [x] No production behavior change beyond the kwarg translation in `audit()`. The `audit()` API surface is unchanged.
- [x] `role_classifier` tests still pass (19/19). Unrelated path but verified to confirm no collateral.
- [x] Manual probe confirmed vstash 0.35.0 writes `store_meta.embedding_model` on `Memory.__init__` (not on first `remember`).