### PR TITLE
feat(memory): opt-in role tagging on remember + classify_role helper

### DIFF
--- a/merken/memory.py
+++ b/merken/memory.py
@@ -76,6 +76,7 @@ if TYPE_CHECKING:
         MidloopDecision,
         StepObservation,
     )
+    from merken.role_classifier import RoleClassification, RoleClassifier
 
 DEFAULT_LAYER = "episodic"
 DEFAULT_COLLECTION = "default"
@@ -230,6 +231,7 @@ class Memory:
         consolidate_decider: ConsolidateDecider | None = None,
         recall_decider: RecallDecider | None = None,
         forget_decider: ForgetDecider | None = None,
+        role_classifier: "RoleClassifier | None" = None,
         midloop_decider: MidloopDecider | None = None,
         temporal_weight: float = 0.0,
         trajectory_window: int = 20,
@@ -249,6 +251,11 @@ class Memory:
         )
         self._recall_decider: RecallDecider = recall_decider or LayeredRecaller()
         self._forget_decider: ForgetDecider = forget_decider or NeverForget()
+        # Opt-in role tagging at write time. Default off because the
+        # bundled V2 SCR taxonomy is specific (system events, ops
+        # context) and not all callers want it. Pass an explicit
+        # RoleClassifier instance to enable.
+        self._role_classifier: "RoleClassifier | None" = role_classifier
 
         # Midloop default is Noop (never intervenes). The trajectory
         # is per-Memory instance state, intentionally NOT persisted
@@ -318,12 +325,23 @@ class Memory:
         if not decision.write:
             return RememberResult(written=False, decision=decision, ingest=None)
 
+        # Opt-in: when a role_classifier is configured, attach a
+        # ``role:<role>`` tag so downstream consolidate / recall paths
+        # can read it without re-classifying. Classification happens
+        # only on writes (skipped events stay untagged) so the cost
+        # tracks the write rate, not the call rate.
+        final_tags = tags
+        if self._role_classifier is not None:
+            classification = self._role_classifier.classify(text)
+            role_tag = f"role:{classification.role}"
+            final_tags = f"{tags},{role_tag}" if tags else role_tag
+
         ingest = self._vstash.remember(
             text,
             title=title,
             collection=self.collection,
             layer=layer,
-            tags=tags,
+            tags=final_tags,
         )
 
         # vstash has its own guardrails (e.g. it rejects text shorter
@@ -343,6 +361,23 @@ class Memory:
             return RememberResult(written=False, decision=override, ingest=ingest)
 
         return RememberResult(written=True, decision=decision, ingest=ingest)
+
+    def classify_role(self, text: str) -> "RoleClassification":
+        """Classify an event's role without writing it.
+
+        Convenience wrapper around the configured ``role_classifier``.
+        Useful for callers that want to inspect a role label before
+        deciding whether to ``remember`` (e.g. routing, gating, UI
+        previews). Raises ``RuntimeError`` when no classifier was
+        passed at construction.
+        """
+        if self._role_classifier is None:
+            raise RuntimeError(
+                "Memory was constructed without a role_classifier. Pass "
+                "`role_classifier=RoleClassifier.default()` (or a custom "
+                "instance) to Memory(...) to enable role classification."
+            )
+        return self._role_classifier.classify(text)
 
     # ------------------------------------------------------------------- read
 

--- a/tests/test_memory_role_classifier_integration.py
+++ b/tests/test_memory_role_classifier_integration.py
@@ -1,0 +1,194 @@
+"""Integration tests for ``Memory(role_classifier=...)``.
+
+The unit tests in ``test_role_classifier.py`` exercise the classifier
+itself with a fake embedder. These tests exercise the wiring point
+between ``Memory.remember()`` and ``RoleClassifier``: that the role
+tag is attached at write time when a classifier is configured, that
+it is not attached when no classifier is configured (default), and
+that it composes cleanly with caller-supplied tags.
+
+Uses a real ``Memory`` (real vstash, real SQLite) but stubs the
+classifier with a fake to keep the tests fast and deterministic. The
+classifier API contract is what we care about here, not the embedder
+math (already covered upstream).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from merken import Memory
+from merken.role_classifier import RoleClassification, RoleClassifier
+
+
+class _StubClassifier:
+    """Fake classifier that returns a fixed role for any input.
+
+    Quacks like ``RoleClassifier`` for the one method ``Memory`` calls.
+    The real classifier is a heavy object (loads bundled prototypes,
+    embeds via vstash); this stub is enough to verify the wiring.
+    """
+
+    def __init__(self, role: str = "state_change_report", confidence: float = 0.5) -> None:
+        self._role = role
+        self._confidence = confidence
+        self.calls: list[str] = []
+
+    def classify(self, text: str) -> RoleClassification:
+        self.calls.append(text)
+        return RoleClassification(
+            role=self._role,
+            confidence=self._confidence,
+            role_similarities={self._role: self._confidence + 0.5},
+        )
+
+
+def _read_back_tags(mem: Memory, ingest_path: str) -> str | None:
+    """Pull the tags string vstash recorded for the given path."""
+    docs = mem._vstash.list(collection=mem.collection)
+    for doc in docs:
+        if doc.path == ingest_path:
+            return getattr(doc, "tags", None)
+    return None
+
+
+def test_no_role_tag_when_classifier_not_configured(tmp_path: Path) -> None:
+    """Default Memory (no classifier) must not attach a role tag."""
+    with Memory(project="default_no_tag", db=tmp_path / "e.db") as mem:
+        result = mem.remember(
+            "Production now runs on Vespa as of 2026-04-15."
+        )
+        assert result.written
+        assert result.ingest is not None
+
+        tags = _read_back_tags(mem, result.ingest.source)
+        # Either None or a string that does not contain a role tag.
+        assert tags is None or "role:" not in tags
+
+
+def test_role_tag_attached_when_classifier_configured(tmp_path: Path) -> None:
+    """With a classifier, ``Memory.remember`` must tag the ingest with
+    ``role:<predicted_role>``."""
+    stub = _StubClassifier(role="state_change_report")
+    with Memory(
+        project="with_clf",
+        db=tmp_path / "e.db",
+        role_classifier=stub,
+    ) as mem:
+        result = mem.remember("Vespa replaced Elasticsearch in production.")
+        assert result.written
+        assert result.ingest is not None
+
+        tags = _read_back_tags(mem, result.ingest.source)
+        assert tags is not None
+        assert "role:state_change_report" in tags
+        assert stub.calls == ["Vespa replaced Elasticsearch in production."]
+
+
+def test_role_tag_appended_to_caller_tags(tmp_path: Path) -> None:
+    """When the caller passes tags, the role tag must be appended,
+    not replace them."""
+    stub = _StubClassifier(role="preference")
+    with Memory(
+        project="composed_tags",
+        db=tmp_path / "e.db",
+        role_classifier=stub,
+    ) as mem:
+        result = mem.remember(
+            "We would prefer Bazel over Make for the polyglot stack.",
+            tags="source:notes,domain:build_system",
+        )
+        assert result.written
+        assert result.ingest is not None
+
+        tags = _read_back_tags(mem, result.ingest.source)
+        assert tags is not None
+        # Caller tags survived
+        assert "source:notes" in tags
+        assert "domain:build_system" in tags
+        # Role tag landed
+        assert "role:preference" in tags
+
+
+def test_role_tag_skipped_when_write_skipped(tmp_path: Path) -> None:
+    """If the write_decider rejects the event, classification should
+    not happen (we don't pay the cost on skipped writes)."""
+    from merken.policies.types import Decision, Event, WriteContext, WriteDecider
+
+    class AlwaysSkip:
+        name = "always_skip"
+
+        def decide(self, event: Event, ctx: WriteContext) -> Decision:
+            return Decision(
+                write=False,
+                reason="test_skip",
+                confidence=1.0,
+                policy="always_skip",
+            )
+
+    stub = _StubClassifier()
+    with Memory(
+        project="skip_no_classify",
+        db=tmp_path / "e.db",
+        write_decider=AlwaysSkip(),
+        role_classifier=stub,
+    ) as mem:
+        result = mem.remember("This will be skipped.")
+        assert not result.written
+
+    # Classifier was never asked.
+    assert stub.calls == []
+
+
+def test_classify_role_returns_classification(tmp_path: Path) -> None:
+    """``Memory.classify_role`` should return the classifier's result
+    without writing anything to vstash."""
+    stub = _StubClassifier(role="investigation", confidence=0.42)
+    with Memory(
+        project="classify_only",
+        db=tmp_path / "e.db",
+        role_classifier=stub,
+    ) as mem:
+        result = mem.classify_role("Investigating the consumer lag.")
+        assert isinstance(result, RoleClassification)
+        assert result.role == "investigation"
+        assert result.confidence == pytest.approx(0.42)
+
+        # Verify nothing was written.
+        docs = list(mem._vstash.list(collection=mem.collection))
+        assert docs == []
+
+
+def test_classify_role_raises_when_unconfigured(tmp_path: Path) -> None:
+    """``Memory.classify_role`` without a classifier must fail loudly,
+    not silently return a default."""
+    with Memory(project="no_classifier", db=tmp_path / "e.db") as mem:
+        with pytest.raises(RuntimeError, match="role_classifier"):
+            mem.classify_role("any text")
+
+
+def test_role_classifier_default_real_embedder_smoke(tmp_path: Path) -> None:
+    """End-to-end smoke with the real ``RoleClassifier.default()``.
+
+    Confirms the integration works against a real BGE-small embedder,
+    not just stubs. Uses one canonical SCR example so the test is
+    deterministic enough not to flake; classifier validation lives in
+    PR #43 (3-seed canonical eval, macro-F1 0.929).
+    """
+    clf = RoleClassifier.default()
+    with Memory(
+        project="real_clf_smoke",
+        db=tmp_path / "e.db",
+        role_classifier=clf,
+    ) as mem:
+        result = mem.remember(
+            "Production logging has been running on OTLP since 2026-03-12."
+        )
+        assert result.written
+        assert result.ingest is not None
+
+        tags = _read_back_tags(mem, result.ingest.source)
+        assert tags is not None
+        assert "role:state_change_report" in tags


### PR DESCRIPTION
## Summary

Wires the V2 SCR ``RoleClassifier`` (shipped in PR #43, merged 661ae9b) into ``Memory``'s write path. First half of the role-classifier integration originally scoped in #43; consolidation-side wiring (role-aware supersession) is deferred to a separate design pass.

## API

### Constructor

```python
from merken import Memory
from merken.role_classifier import RoleClassifier

mem = Memory(
    project=\"my_project\",
    role_classifier=RoleClassifier.default(),  # opt-in, default None
)
```

When ``role_classifier`` is omitted (the default), ``Memory.remember()`` behaves exactly as before -- no extra embedding cost, no tag mutation, no API surface change. When set, every write the ``write_decider`` approves gets a ``role:<predicted_role>`` tag appended (composes cleanly with caller-supplied tags using the existing comma-separated convention).

### ``classify_role(text)`` convenience method

```python
result = mem.classify_role(\"Production now runs Vespa as of 2026-04-15.\")
# result.role -> 'state_change_report'
# result.confidence -> 0.114
# Nothing written.
```

Useful for routing, gating, or UI previews where you want the role label without committing the event. Raises ``RuntimeError`` when no classifier is configured -- no silent magic.

## Cost

Classification happens **only after** the ``write_decider`` approves, so the cost tracks the write rate, not the call rate. Skipped writes pay zero classifier cost. Within a written event the classifier adds one ``embed_fn`` call (prototypes cached after first classify) on top of vstash's existing embed -- roughly 2x embed cost on writes when enabled. Acceptable for an explicit opt-in.

## What's NOT in this PR

- **Role-aware supersession in ``consolidate()``**. SCR forms supersession chains (newest takes precedence), PREFERENCE non-superseding, OBSERVATION additive, INVESTIGATION open. Needs a design pass on the ordering primitive before code lands.
- **First-class ``recall(role=...)`` filter**. Tags exist now, so callers can filter manually via vstash search; a first-class API is a follow-up.

## Test plan

7 new tests in ``tests/test_memory_role_classifier_integration.py``, all pass. The classifier itself is unit-tested in ``test_role_classifier.py`` -- this file only exercises the wiring boundary, using a stub classifier for speed plus one end-to-end smoke with the real ``RoleClassifier.default()`` + BGE-small.

- [x] No role tag when ``classifier=None`` (default behavior preserved)
- [x] ``role:<role>`` tag attached when classifier configured
- [x] Role tag **appended** to caller tags, not replacing them
- [x] Classifier NOT called when ``write_decider`` rejects the event
- [x] ``classify_role`` returns ``RoleClassification``, writes nothing
- [x] ``classify_role`` raises ``RuntimeError`` when classifier=None
- [x] End-to-end smoke: real ``RoleClassifier.default()`` + BGE-small classifies the canonical SCR example as ``state_change_report``

Full suite: 408 passed (was 401 before).