### PR TITLE
docs: cron improvement 2026-06-05

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,46 +18,100 @@ session aligned with the state of the repo.
 4. [`notes/silt.md`](notes/silt.md) — working notes on the patterns
    Silt caught that became hard rules.
 
-## Current state (as of 2026-04-17)
+## Current state (as of 2026-06-05)
 
-**Write-filter classifier status:** nanoGPT **v7** is the graduated
-shadow baseline. First version to clear the markdown-tables blind
-spot (FPR 66.7% v6 -> 0% v7) while keeping 100% recall on
-organic_val and jay_vstash. 3/5 graduation criteria pass cleanly,
-1 borderline (94.6% oracle agreement on 205-item subsample), 1 N/A.
-`MERKEN_PRIMARY` flip still deferred; v7 runs as
-`MERKEN_SHADOW=nanogpt`. Full version history and open-frontier
-spec (v9 / v10) in `experiments/nanogpt/RESULTS.md`.
+**Test suite:** 398 passed, 3 pre-existing failures (all torch-import
+failures in shadow classifier env tests — `test_env_primary_overrides_shadow`,
+`test_nanogpt_env_missing_paths_falls_back_cleanly`,
+`test_default_returns_plain_when_shadow_import_fails`), 1 skipped
+(torch classifier), 3 warnings (fastembed/huggingface). Torch is a
+soft dependency — the package is fully usable without it; the failing
+tests only fire when `MERKEN_SHADOW=nanogpt` or `MERKEN_PRIMARY=nanogpt`
+is set without torch installed.
+
+**Write-filter classifier status (merged into develop):**
+
+- **nanoGPT v7** is the graduated shadow baseline. Clears the
+  markdown-tables blind spot (FPR 66.7% v6 → 0% v7) while keeping 100%
+  recall on organic_val and jay_vstash. Runs as `MERKEN_SHADOW=nanogpt`;
+  `MERKEN_PRIMARY` flip still deferred. Full version history in
+  `experiments/nanogpt/RESULTS.md`.
+- **LLM classifier backend** (`MERKEN_SHADOW=llm`, `MERKEN_PRIMARY=llm`)
+  uses any HuggingFace model. Supports calibration via shipped
+  `calibration_v7.json` or custom path. Backend-agnostic `_shadow.py`
+  module handles both nanoGPT and LLM decider roles.
+- **Calibration head** supports both backends: wraps predictions with
+  a post-hoc Platt-calibrated `P_cal` via shipped
+  `merken/classifiers/calibration_v7.json`. Load errors degrade
+  gracefully (warning to stderr, raw P(D) shown).
+
+**Role classifier (merged via PR #43/#48):**
+
+- **`merken/role_classifier.py`** — generic role classifier that
+  leverages a frozen encoder from any merken classifier and assigns
+  events to a user-defined taxonomy of roles.
+- **Production profile** (`role_prototypes_v2.json`) operationalises
+  the #39b STATE_CHANGE_REPORT taxonomy — STRONG gate met with 4-role
+  classification (DECISION, ENTITY, EVENT, FREE).
+- **Decoupled from global ROLES** — supports arbitrary taxonomies.
+- **Role markers** (#39 Phase 1-3): prefix-conditioning found
+  ineffective; `STATE_CHANGE_REPORT` taxonomy (Phase 2) passed STRONG.
+
+**Role geometry / directional residuals (merged via PR #41):**
+
+- **Issue #38/#38b** — NO_GO verdict on EVR_1 (event-role-vector) as a
+  write-gate. Validated on disjoint data; performed worse than plain
+  heuristic gates.
+- **Signal mining post-NO_GO** — partial recovery via directional
+  residual features. #38c deferred.
+- **Paper meta-issue** in `notes/` captures the geometric-methods
+  argument for the merken paper (§7.3/§7.6/§7.7 expansion).
+
+**vstash 0.35.0 drift fix (merged via PR #45):**
+
+- Repaired 18 failing tests caused by upstream vstash API drift.
+- Single commit: `bcc3375 fix(memory): vstash 0.35.0 API drift`.
+
+**Training-data pipeline:** 1026 real oracled labels in
+`data/merken_labels_v7.jsonl` (gitignored), produced by the
+bootstrap scripts under `experiments/`. Pipeline is idempotent.
+
+**Phase 2 distillation (experimental, PR #49 open with changes requested):**
+
+- Steps 1-4 complete end-to-end: gpt-oss-120b teacher on Cerebras,
+  Qwen2.5-7B-Instruct LoRA student.
+- Key result: student v2 (temperature=0.2 + repetition_penalty=1.1)
+  matches zero-shot truncation rate (18%) at **-90% reasoning chars**
+  (1004c vs 9614c median).
+- Step 5 planned: 1K → 50K corpus, 3 epochs, lr 1e-4 → 1e-5.
+
+**Heartbeat daemon (PR #50 open with changes requested):**
+
+- `merken heartbeat` subcommand — periodic background consolidation
+  and forgetting on configurable intervals.
+- Writes `should_heartbeat` audit rows on every tick.
+- Graceful shutdown via SIGINT/SIGTERM.
 
 **Training-data pipeline:** 1026 real oracled labels in
 `data/merken_labels_v7.jsonl` (gitignored), produced by the
 bootstrap scripts under `experiments/` (PR #12). Pipeline is
-idempotent -- re-runs are safe.
+idempotent — re-runs are safe.
 
-**Hook bug fixed (2026-04-17):** `~/.claude/hooks/merken-save.sh`
-used to run `json.load` on JSONL transcripts and silently swallow
-the exception. Result: zero shadow events accumulated. Fixed to
-parse JSONL per-line + extract `message.content[].text`. Future
-accumulation is now passive.
-
-## Decision primitives (as of 2026-04-09)
+## Decision primitives
 
 All four decision primitives from CONSTITUTION §5.1 are implemented:
 
 - **`should_remember`** — `HeuristicWriteDecider` (default) and
-  `AlwaysWrite` (baseline). The heuristic decider now hydrates its
-  dedup set from vstash on first use, so cross-invocation dedup
-  works for CLI and MCP.
+  `AlwaysWrite` (baseline). Optional `ChainedWriteDecider` to compose
+  with a classifier shadow/primary layer. The heuristic decider
+  hydrates its dedup set from vstash on first use.
 - **`should_consolidate`** — `PeriodicConsolidator` (default) and
   `NeverConsolidate`. Uses `cluster_by_embedding` with complete
-  linkage and threshold 0.70 (picked via grid search on three
-  loop_quality scenarios, 2026-04-09).
+  linkage and threshold 0.70.
 - **`should_recall`** — `LayeredRecaller` (default, semantic-first
   with episodic fallback) and `SemanticOnlyRecaller` baseline.
-  `Memory.recall` does round-robin interleave across layers with
-  dedup-by-path. Optional temporal reranking via `temporal_weight`
-  (default 0.0 = off). Grid search across 5 scenarios at 8 weights
-  showed zero regressions.
+  Round-robin interleave across layers with dedup-by-path.
+  Optional temporal reranking via `temporal_weight` (default 0.0).
 - **`should_forget`** — `NeverForget` (default, safe) and
   `ForgetConsolidated`. Tombstone-not-delete: full text preserved
   in `merken_tombstones`, reversible.
@@ -67,13 +121,12 @@ Deployed surfaces:
 - **Python SDK** — `from merken import Memory`. Four primitives
   accessible as `Memory` methods.
 - **CLI** — `merken` on `$PATH` after `pip install -e .`.
-  Eight subcommands map 1:1 to `Memory` methods:
-  `remember | recall | consolidate | forget | audit | tombstones | status | stats`.
+  Nine subcommands: `remember | recall | consolidate | forget |
+  audit | tombstones | status | stats | heartbeat`.
   See `merken --help`.
 - **MCP server** — `merken-mcp` on `$PATH`, `python -m merken.mcp_server`,
   or `claude mcp add merken -- python -m merken.mcp_server`. Eight
-  tools, one per CLI subcommand. Default DB is `~/.merken/<project>.db`,
-  deliberately isolated from `~/.vstash/memory.db`.
+  tools, one per CLI subcommand (heartbeat excluded — daemon, not tool).
 - **Claude Code hooks** — live in `~/.claude/settings.json`.
   Three hooks: `SessionStart` (recall context), `PreCompact`
   (save to memory), `UserPromptSubmit` (search memory).
@@ -81,7 +134,7 @@ Deployed surfaces:
 
 Safety net (`experiments/loop_quality/`):
 
-- Three scenarios, all running under `pytest tests/test_loop_quality.py`
+- Three core scenarios, all running under `pytest tests/test_loop_quality.py`
   via parametrized `test_runner_completes_on_every_scenario`:
     1. `analytics_project` (synthetic control, 100%/100%/100%)
     2. `session_2026_04_09` (synthetic borderline, 100%/100%/33%)
@@ -134,10 +187,10 @@ explicit case in the PR description.
   See `tests/test_mcp_server.py::test_consolidate_force_builds_fact`
   for the pattern.
 
-## Consolidation findings (2026-04-16)
+## Consolidation findings
 
 **Embedding-based consolidation (embedding_v1) is structurally limited.**
-Cosine(q, e(Ti)) >= cosine(q, e(T_consolidated)) for specific queries.
+Cosine(q, e(Ti)) >= Cosine(q, e(T_consolidated)) for specific queries.
 Geometric limit, confirmed across LoCoMo E2E + 3 knowledge_update
 scenarios. LLM synthesis on top of embedding clustering does not help --
 the bottleneck is clustering, not materialization.
@@ -154,23 +207,49 @@ separately from episodic, prepends matched briefs to context.
 
 See `experiments/consolidation/RESULTS.md` for full analysis.
 
+## Tracked concern: Benchmark monoculture (Issue #44)
+
+All recent retrieval/builder decisions (k=8, brief_v1 reject, v5-ft
+Gates, Mode C, gpt-oss-120b unstick) came from the same benchmark
+axis: **LongMemEval + LoCoMo**. Risk of overfit to that signal pair.
+
+**Protocol (from Issue #44):** Before the next round of retrieval/builder
+tuning that would land a new default in production, evaluate on at least
+one disjoint benchmark axis (candidates: MTEB retrieval subset, BEIR
+subset, MS-MARCO). Pre-register the disjoint benchmark before any new
+tuning experiment. Ship iff the change does not regress on the disjoint
+benchmark by more than 1pp.
+
+Reference this issue when planning any new retrieval/builder experiment.
+
 ## What's NOT next
 
 - A fifth decision primitive. Four are enough.
 - Embedding-based consolidation as a retrieval improvement -- proven
   structurally limited (see consolidation findings above).
-- A knowledge graph (CONSTITUTION $6, optional, gated).
+- Knowledge graph (CONSTITUTION §6, optional, gated).
 - Shell completion, colors, a web UI. All noise for the scope.
+- Bespoke compression dialect. See `notes/prior-art.md` for why.
+- Spatial vocabulary (wings/rooms/etc.). Use vstash's existing
+  `project` / `collection` / `layer` / `tags` fields.
 
 ## What IS next (approximately)
 
+- **Phase 2 distillation Step 5:** Scale to 50K corpus, 3 epochs,
+  lr 1e-5. Estimated $200-400 (teacher generation + training + eval).
+- **Heartbeat daemon (PR #50):** Address coderabbitai review comments
+  and merge. Wires periodic maintenance into production usage.
 - **brief_v1 integration into Claude Code hooks.** Generate briefs
   on PreCompact, prepend on SessionStart alongside recall results.
 - **nanoGPT-as-connector.** Small model trained on vstash+merken
   data structure for topic identification and brief selection.
-- Scale brief_v1 to 100+ topics, diverse domains for paper.
-- Additional `loop_quality/` scenarios from Jay's real work.
-- vstash 0.29.0 validation (snapvec integration).
+- **Scale brief_v1 to 100+ topics** for paper, diverse domains.
+- **Additional `loop_quality/` scenarios** from real work (perf
+  migration notes, MedLocal hackathon logs, Kafka meeting threads).
+- **LoCoMo runner** under `experiments/retrieval/locomo/` (Phase B
+  of BENCHMARK_STRATEGY.md).
+- **Disjoint benchmark evaluation** (Issue #44 gate) before next
+  retrieval/builder default change.
 
 ## Branching
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 > [vstash](https://github.com/stffns/vstash).
 
 **Status:** v0.1.0 on [PyPI](https://pypi.org/project/merken/), local-first,
-171 tests green. Four decision primitives, four deployment surfaces
+398+ tests green (3 pre-existing torch-import failures unrelated to
+core logic), four decision primitives, four deployment surfaces
 (SDK, CLI, MCP server, Claude Code hooks), five loop-quality scenarios.
 
 ## In one paragraph
@@ -196,8 +197,10 @@ claude mcp add merken -- merken-mcp
 
 ## Tests and scenarios
 
-- **171 tests** across four decision primitives, three deployment
-  surfaces, and five `loop_quality` scenarios.
+- **398+ tests** across four decision primitives, three deployment
+  surfaces, five `loop_quality` scenarios (+ role classifier,
+  shadow classifier env, and heartbeat tests). 3 pre-existing
+  torch-import failures (require torch installed).
 - **Loop-quality scenarios** live in
   [`experiments/loop_quality/`](experiments/loop_quality/) and enforce
   that every decider change is validated against at least one


### PR DESCRIPTION
Updates CLAUDE.md and README.md to reflect 6 weeks of changes since last doc maintenance (2026-04-17).

### CLAUDE.md
- Current state date: 2026-04-17 → 2026-06-05
- Test count: 171 → 398 (+ 3 pre-existing torch failures)
- Added: role classifier, role geometry/directional residuals, shadow/primary classifier backends (nanoGPT + LLM)
- Added: vstash 0.35.0 drift fix (PR #45)
- Added: open PRs tracking (heartbeat #50, phase2 distillation #49)
- Added: Issue #44 tracked concern (benchmark monoculture)
- Updated: CLI subcommands (9 now), decision primitives section
- Updated: 'What IS next' section with current priorities

### README.md
- Test count: 171 → 398+ (with torch note)
- Scope of tests expanded to cover shadow classifier env, role classifier