### PR TITLE
docs: cron improvement 2026-06-08 (supersedes PR #51)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,36 +18,89 @@ session aligned with the state of the repo.
 4. [`notes/silt.md`](notes/silt.md) — working notes on the patterns
    Silt caught that became hard rules.
 
-## Current state (as of 2026-04-17)
+## Current state (as of 2026-06-08)
 
-**Write-filter classifier status:** nanoGPT **v7** is the graduated
-shadow baseline. First version to clear the markdown-tables blind
-spot (FPR 66.7% v6 -> 0% v7) while keeping 100% recall on
-organic_val and jay_vstash. 3/5 graduation criteria pass cleanly,
-1 borderline (94.6% oracle agreement on 205-item subsample), 1 N/A.
-`MERKEN_PRIMARY` flip still deferred; v7 runs as
-`MERKEN_SHADOW=nanogpt`. Full version history and open-frontier
-spec (v9 / v10) in `experiments/nanogpt/RESULTS.md`.
+**Test suite:** 398 passed, 3 pre-existing failures (all torch-import
+failures in shadow classifier env tests -- `test_env_primary_overrides_shadow`,
+`test_nanogpt_env_missing_paths_falls_back_cleanly`,
+`test_default_returns_plain_when_shadow_import_fails`), 1 skipped
+(torch classifier). Torch is a soft dependency -- the package is fully
+usable without it; the failing tests only fire when `MERKEN_SHADOW=nanogpt`
+or `MERKEN_PRIMARY=nanogpt` is set without torch installed.
+
+**Write-filter classifier (merged into develop):**
+
+- **nanoGPT v7** is the graduated shadow baseline. Clears the
+  markdown-tables blind spot (FPR 66.7% v6 → 0% v7) while keeping 100%
+  recall on organic_val and jay_vstash. Runs as `MERKEN_SHADOW=nanogpt`;
+  `MERKEN_PRIMARY` flip still deferred. Full version history in
+  `experiments/nanogpt/RESULTS.md`.
+- **LLM classifier backend** (`MERKEN_SHADOW=llm`, `MERKEN_PRIMARY=llm`)
+  uses any HuggingFace model. Supports calibration via shipped
+  `calibration_v7.json` or custom path. Backend-agnostic `_shadow.py`
+  module handles both nanoGPT and LLM decider roles.
+- **Calibration head** supports both backends: wraps predictions with
+  a post-hoc Platt-calibrated `P_cal` via shipped
+  `merken/classifiers/calibration_v7.json`. Load errors degrade
+  gracefully (warning to stderr, raw P(D) shown).
+
+**Role classifier (merged via PR #43/#48):**
+
+- **`merken/role_classifier.py`** -- generic role classifier that
+  leverages a frozen encoder from any merken classifier and assigns
+  events to a user-defined taxonomy of roles.
+- **Production profile** (`role_prototypes_v2.json`) operationalises
+  the #39b STATE_CHANGE_REPORT taxonomy -- STRONG gate met with 4-role
+  classification (DECISION, ENTITY, EVENT, FREE).
+- **Decoupled from global ROLES** -- supports arbitrary taxonomies.
+- **Role markers** (#39 Phase 1-3): prefix-conditioning found
+  ineffective; `STATE_CHANGE_REPORT` taxonomy (Phase 2) passed STRONG.
+
+**Role geometry / directional residuals (merged via PR #41):**
+
+- **Issue #38/#38b** -- NO_GO verdict on EVR_1 (event-role-vector) as a
+  write-gate. Validated on disjoint data; performed worse than plain
+  heuristic gates.
+- **Signal mining post-NO_GO** -- partial recovery via directional
+  residual features. #38c deferred.
+- **Paper meta-issue** in `notes/` captures the geometric-methods
+  argument for the merken paper.
+
+**vstash 0.35.0 drift fix (merged via PR #45):**
+
+- Repaired 18 failing tests caused by upstream vstash API drift.
+- Single commit: `bcc3375 fix(memory): vstash 0.35.0 API drift`.
 
 **Training-data pipeline:** 1026 real oracled labels in
 `data/merken_labels_v7.jsonl` (gitignored), produced by the
-bootstrap scripts under `experiments/` (PR #12). Pipeline is
-idempotent -- re-runs are safe.
+bootstrap scripts under `experiments/`. Pipeline is idempotent.
 
-**Hook bug fixed (2026-04-17):** `~/.claude/hooks/merken-save.sh`
-used to run `json.load` on JSONL transcripts and silently swallow
-the exception. Result: zero shadow events accumulated. Fixed to
-parse JSONL per-line + extract `message.content[].text`. Future
-accumulation is now passive.
+**Issue #44 (benchmark monoculture):** OPEN, no work scheduled.
+Protocol pre-registered: before next retrieval/builder tuning that
+would change a production default, evaluate on at least one disjoint
+benchmark axis (candidates: MTEB retrieval subset, BEIR subset,
+MS-MARCO). Pre-register before tuning. Ship iff no regression >1pp.
+See issue for full reasoning.
 
-## Decision primitives (as of 2026-04-09)
+**Open PRs (not yet on develop):**
+
+- **#50 (heartbeat):** `merken heartbeat` subcommand -- periodic
+  background consolidation/forgetting. Graceful shutdown. Open,
+  mergeable.
+- **#49 (Phase 2 distillation):** Steps 1-4 complete end-to-end
+  (1K SFT smoke). Key result: student v2 matches zero-shot truncation
+  rate (18%) at -90% reasoning chars. Step 5 planned: 1K → 50K corpus.
+  Open, mergeable.
+
+## Decision primitives
 
 All four decision primitives from CONSTITUTION §5.1 are implemented:
 
 - **`should_remember`** — `HeuristicWriteDecider` (default) and
-  `AlwaysWrite` (baseline). The heuristic decider now hydrates its
-  dedup set from vstash on first use, so cross-invocation dedup
-  works for CLI and MCP.
+  `AlwaysWrite` (baseline). Optional `ChainedWriteDecider` to compose
+  with a classifier shadow/primary layer (`_shadow.py`). The heuristic
+  decider hydrates its dedup set from vstash on first use, so
+  cross-invocation dedup works for CLI and MCP.
 - **`should_consolidate`** — `PeriodicConsolidator` (default) and
   `NeverConsolidate`. Uses `cluster_by_embedding` with complete
   linkage and threshold 0.70 (picked via grid search on three
@@ -170,7 +223,11 @@ See `experiments/consolidation/RESULTS.md` for full analysis.
   data structure for topic identification and brief selection.
 - Scale brief_v1 to 100+ topics, diverse domains for paper.
 - Additional `loop_quality/` scenarios from Jay's real work.
-- vstash 0.29.0 validation (snapvec integration).
+- vstash snapshot validation (ongoing — 0.35.0 drift already fixed).
+- **Merge PR #50 (heartbeat + PR #49 (distillation Phase 2).**
+  Both open, mergeable, with review feedback pending.
+- **Add cross-benchmark evaluation per Issue #44 protocol.** Pre-register
+  a disjoint benchmark before the next retrieval/builder tuning.
 
 ## Branching
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 > [vstash](https://github.com/stffns/vstash).
 
 **Status:** v0.1.0 on [PyPI](https://pypi.org/project/merken/), local-first,
-171 tests green. Four decision primitives, four deployment surfaces
-(SDK, CLI, MCP server, Claude Code hooks), five loop-quality scenarios.
+398 tests green (3 pre-existing torch-import failures, 1 skipped). Four decision
+primitives, four deployment surfaces (SDK, CLI, MCP server, Claude Code hooks),
+five loop-quality scenarios.
 
 ## In one paragraph
 
@@ -196,8 +197,9 @@ claude mcp add merken -- merken-mcp
 
 ## Tests and scenarios
 
-- **171 tests** across four decision primitives, three deployment
-  surfaces, and five `loop_quality` scenarios.
+- **398 tests** across four decision primitives, three deployment
+  surfaces, and five `loop_quality` scenarios (3 pre-existing torch
+  import failures documented in CLAUDE.md).
 - **Loop-quality scenarios** live in
   [`experiments/loop_quality/`](experiments/loop_quality/) and enforce
   that every decider change is validated against at least one


### PR DESCRIPTION
Updates CLAUDE.md and README.md to reflect project state as of 2026-06-08.

### Changes

**CLAUDE.md** — 2026-04-17 → 2026-06-08:
- Test count: 171 → 398 passed (+3 pre-existing torch failures, +1 skipped)
- Added: shadow/primary classifier backends (nanoGPT + LLM), calibration head
- Added: role classifier (#43/#48), role geometry/directional residuals (#41)
- Added: vstash 0.35.0 drift fix (#45)
- Updated: decision primitives (ChainedWriteDecider, _shadow.py)
- Added: Issue #44 benchmark monoculture protocol summary
- Added: open PRs tracking (#50 heartbeat, #49 distillation)
- Updated: What IS next with current priorities
- **Fixed: duplicated Training-data pipeline section** that existed in PR #51

**README.md**
- Test count: 171 → 398 (with torch note)
- Test count in scenarios section also updated

### Supersedes
Closes the previous PR #51 which had a duplicated section in CLAUDE.md.